### PR TITLE
Fix safety issues, deprecated APIs, and code quality

### DIFF
--- a/MacTorn/MacTorn/MacTornApp.swift
+++ b/MacTorn/MacTorn/MacTornApp.swift
@@ -14,7 +14,7 @@ struct MacTornApp: App {
                 .onAppear {
                     updateAppearance()
                 }
-                .onChange(of: appearanceModeRaw) { _ in
+                .onChange(of: appearanceModeRaw) {
                     updateAppearance()
                 }
         } label: {

--- a/MacTorn/MacTorn/Models/TornModels.swift
+++ b/MacTorn/MacTorn/Models/TornModels.swift
@@ -1,6 +1,11 @@
 import Foundation
 import SwiftUI
 
+// MARK: - Constants
+enum TornConstants {
+    static let developerID = 2362436
+}
+
 // MARK: - Root Response
 struct TornResponse: Codable {
     let name: String?

--- a/MacTorn/MacTorn/Utilities/NotificationManager.swift
+++ b/MacTorn/MacTorn/Utilities/NotificationManager.swift
@@ -103,14 +103,8 @@ class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
 
     /// Cancel all travel-related notifications
     func cancelTravelNotifications() {
-        let identifiers = [
-            "travel_2min_alert",
-            "travel_1min_alert",
-            "travel_30sec_alert",
-            "travel_10sec_alert"
-        ]
+        let identifiers = TravelNotificationSetting.defaults.map { "\($0.id)_alert" }
         UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: identifiers)
-        print("Cancelled travel notifications")
     }
 
     /// Cancel a specific notification by identifier

--- a/MacTorn/MacTorn/ViewModels/AppState.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState.swift
@@ -584,9 +584,7 @@ class AppState: ObservableObject {
             // Check if feedback prompt should be shown
             self.checkFeedbackPrompt()
 
-            // Force UI update by triggering objectWillChange
-            self.objectWillChange.send()
-            logger.info("UI update triggered, lastUpdated: \(self.lastUpdated?.description ?? "nil")")
+            logger.info("Data updated, lastUpdated: \(self.lastUpdated?.description ?? "nil")")
         }
     }
     

--- a/MacTorn/MacTorn/Views/ContentView.swift
+++ b/MacTorn/MacTorn/Views/ContentView.swift
@@ -91,7 +91,7 @@ struct ContentView: View {
     private var headerView: some View {
         HStack {
             if let lastUpdated = appState.lastUpdated {
-                Text("Updated: \(lastUpdated, formatter: timeFormatter)")
+                Text("Updated: \(lastUpdated, formatter: Self.timeFormatter)")
                     .font(.caption2)
                     .foregroundColor(.secondary)
             }
@@ -177,9 +177,9 @@ struct ContentView: View {
         .padding(.bottom, 8)
     }
     
-    private var timeFormatter: DateFormatter {
+    private static let timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.timeStyle = .short
         return formatter
-    }
+    }()
 }

--- a/MacTorn/MacTorn/Views/CreditsView.swift
+++ b/MacTorn/MacTorn/Views/CreditsView.swift
@@ -5,7 +5,7 @@ struct CreditsView: View {
     @Binding var showCredits: Bool
 
     // MARK: - Developer
-    private let developer = TornContributor(name: "bombel", tornID: 2362436)
+    private let developer = TornContributor(name: "bombel", tornID: TornConstants.developerID)
 
     // MARK: - Special Thanks
     private let specialThanks: [TornContributor] = [
@@ -92,7 +92,9 @@ struct CreditsView: View {
             }
 
             Button {
-                openTornProfile(developer.tornID!)
+                if let tornID = developer.tornID {
+                    openTornProfile(tornID)
+                }
             } label: {
                 HStack {
                     Text(developer.name)

--- a/MacTorn/MacTorn/Views/SettingsView.swift
+++ b/MacTorn/MacTorn/Views/SettingsView.swift
@@ -9,8 +9,7 @@ struct SettingsView: View {
     @State private var showCredits: Bool = false
     @State private var availableBrowsers: [PreferredBrowser] = PreferredBrowser.availableBrowsers()
 
-    // Developer ID for tip feature (bombel)
-    private let developerID = 2362436
+    private let developerID = TornConstants.developerID
 
     var body: some View {
         if showCredits {
@@ -74,7 +73,7 @@ struct SettingsView: View {
                         Text("2m").tag(120)
                     }
                     .pickerStyle(.segmented)
-                    .onChange(of: appState.refreshInterval) { _ in
+                    .onChange(of: appState.refreshInterval) {
                         Task { @MainActor in
                             appState.startPolling()
                         }


### PR DESCRIPTION
## Summary
- **Safe optional binding** — replaced `developer.tornID!` force unwrap in `CreditsView` with `if let` to prevent potential crash
- **Dynamic travel notification cancellation** — `cancelTravelNotifications()` now derives identifiers from `TravelNotificationSetting.defaults` instead of hardcoded strings, so adding new settings won't leave orphaned notifications
- **Centralized developer ID** — extracted duplicated `2362436` from `SettingsView` and `CreditsView` into `TornConstants.developerID`
- **Static DateFormatter** — changed `ContentView.timeFormatter` from computed property (recreated every render) to `static let` (created once)
- **Removed redundant objectWillChange.send()** — `@Published` properties already trigger this automatically
- **Migrated deprecated onChange** — updated `onChange(of:) { _ in }` to parameterless closure form in `MacTornApp` and `SettingsView`

## Test plan
- [ ] Open Credits view and tap developer profile link — verify it opens correctly
- [ ] Enable travel notifications, travel in-game, and verify notifications fire and cancel properly
- [ ] Verify "Updated: HH:MM" timestamp renders correctly in header
- [ ] Change appearance mode and refresh interval — verify onChange handlers still trigger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized configuration constants for improved code maintainability.
  * Refactored internal notification handling to be more dynamic and flexible.
  * Optimized internal code structure and formatting.

* **Bug Fixes**
  * Enhanced stability in developer profile handling through safer error prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->