### PR TITLE
Reliability & product audit — stage 1 (reliability spine)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ fastlane/test_output
 # Build output
 build/
 DerivedData/
+TestResults/
+*.xcresult
 
 # Archive folder (old releases)
 archive/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to MacTorn will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — reliability & product audit (stage 1)
+
+Branch `audit/reliability-product-pass`. First stage of the Etap A–L quality program;
+the full plan and deferred backlog live in [`ISA.md`](ISA.md).
+
+### Fixed
+- **Chain-expiring notification fired on every poll.** While a chain's timeout was under
+  60 s, "Chain Expiring! ⚠️" was re-sent on *every* refresh (a burst of identical
+  banners). It now fires **exactly once** per crossing into the danger window and
+  re-arms only after the chain leaves it (a member hits, the chain ends, or it drops),
+  via a new persistent `NotificationCoordinator` whose de-dup survives an app restart.
+- **Flaky unit test / non-deterministic suite.** `AppState` hardcoded
+  `UserDefaults.standard`, so watchlist tests raced on the shared store under parallel
+  execution (`testPriceThreshold_persistedWithWatchlist` failed intermittently on
+  `main`). `AppState` now takes an injectable `UserDefaults`; each test isolates its own
+  suite. The suite is green and deterministic across 8 parallel runners.
+
+### Added
+- **Typed Torn API registry** (`TornEndpoint` / `TornEndpointRegistry`): one catalog of
+  all 10 endpoints (version, path, selections, access level, cadence, point-in-time vs
+  row-based, record limit, cache policy, budget category, critical/optional). It drives
+  request building, the README "API Data Usage" table and onboarding disclosure — a
+  contract test pins every registry URL to its legacy `TornAPI` builder so they can't
+  drift.
+- **Typed error taxonomy** (`TornAPIError`): classifies Torn error codes (permanent key,
+  insufficient permissions, rate limit, daily row limit, temporary backend) plus
+  transport states (offline / transport / malformed / cancelled), with `haltsAllRequests`
+  (codes 2/16/18) and `haltsCategoryOnly` (code 14) semantics and a `RetryPolicy`
+  exponential backoff (2/5/15/30/60 s, capped at 5 min, jittered). Wiring into the live
+  fetch path is deferred (ISA ISC-15).
+- **`SECURITY.md`** — private vulnerability disclosure policy and supported-version note.
+- **`ISA.md`** — system-of-record for the audit program with the full A–L backlog and
+  deferral reasons.
+
+### Notes
+- 41 new unit tests (294 total, all green). No existing feature behaviour changed.
+
 ## [1.9.2] - 2026-07-15
 
 ### Fixed

--- a/ISA.md
+++ b/ISA.md
@@ -1,0 +1,216 @@
+---
+project: MacTorn
+task: Reliability + product quality audit (Etap A–L), staged
+effort: E4
+phase: verify
+progress: stage-1 of program
+mode: algorithm
+started: 2026-07-15
+updated: 2026-07-15
+---
+
+# MacTorn — Reliability & Product Audit ISA
+
+> System-of-record for the multi-stage MacTorn quality program. The full audit brief
+> (Etap A–L) is a multi-week program; this file tracks what has shipped and what is
+> deferred, with reasons. **Stage 1** (this branch, `audit/reliability-product-pass`)
+> delivered the reliability + correctness spine. Later stages append here.
+
+## Problem
+
+MacTorn is a mature (v1.9.2), well-tested (253 unit tests) menu-bar app, but three
+structural weaknesses remain:
+
+1. **Test non-determinism.** `AppState` hardcoded `UserDefaults.standard` at 20 sites,
+   so parallel test runs raced on shared keys — one flaky failure on `main`
+   (`testPriceThreshold_persistedWithWatchlist`), making the suite an unreliable gate.
+2. **Untyped API surface.** Endpoints/selections and their budget characteristics live
+   as scattered `TornAPI` builders and comments. Errors are surfaced as a string but
+   not *classified*, so the app cannot react differently to a dead key vs. a transient
+   backend blip vs. a per-category daily limit — and it never stops hammering a key
+   that will never work.
+3. **Notification duplication.** The chain-expiring alert fired on *every* poll while
+   the timeout was under 60s (a burst of identical banners), with no persistent
+   de-duplication.
+
+Beyond these, the app is a 1,700-line `AppState` god object with no dedicated polling
+coordinator, no diagnostics surface, and a 7-tab/320px navigation that is cramped.
+
+## Vision
+
+A menu-bar app you can trust to be quiet and correct: it alerts you exactly once per
+real event, never burns your Torn API budget, stops cleanly when your key is wrong,
+recovers on reconnect, and can prove all of that through an in-app diagnostics screen —
+while a green, deterministic test suite gates every change.
+
+## Out of Scope
+
+- Writing to Torn (any action-taking) — MacTorn stays strictly read-only.
+- Scraping Torn web pages — official API only.
+- Certificate pinning for `api.torn.com` (documented accepted risk F-05).
+- Requiring a paid Apple Developer ID for local development (F-04 accepted risk).
+- A big-bang rewrite of `AppState` — decomposition is incremental, regression-tested.
+- Guessing API response shapes for data the official endpoints don't provide — such
+  gaps are documented and skipped, not fabricated.
+
+## Principles
+
+- **Determinism before features.** A test suite that isn't reliably green can't gate
+  anything, so it is fixed first.
+- **Single source of truth.** One typed registry drives requests, docs, the usage
+  screen, and onboarding disclosure — not several hand-maintained lists.
+- **Classify, then react.** An error's *type* (permanent key / rate limit / daily row
+  limit / transient / transport) determines the response; a bare message does not.
+- **Fire once per real event.** De-duplication is persistent (survives restart) and
+  re-arms only when a genuinely new event begins.
+- **No secrets or PII anywhere they can leak** — logs, notifications, diagnostics.
+
+## Constraints
+
+- Swift / SwiftUI, `MenuBarExtra`, macOS 14+, Universal Binary (arm64 + x86_64).
+- App Sandbox + Hardened Runtime stay on; API key stays in Keychain; URLs stay redacted.
+- Sentry remains opt-in.
+- New source/test files must be wired into the (non-synchronized, objectVersion 56)
+  `project.pbxproj` by hand.
+- No behaviour change to existing features without a regression test.
+
+## Goal
+
+Ship the reliability + correctness spine (deterministic tests, typed API registry,
+typed error taxonomy + backoff, persistent notification de-duplication with the chain
+bug fixed, `SECURITY.md`) as green, tested, regression-safe commits on
+`audit/reliability-product-pass`, and record the remaining Etap A–L program as a
+tracked backlog with deferral reasons.
+
+## Criteria
+
+**Stage 1 — shipped (this branch):**
+
+- [x] ISC-1: `AppState` takes an injectable `UserDefaults`; production uses `.standard`.
+- [x] ISC-2: Every AppState-constructing test isolates its own suite; the previously
+  flaky `testPriceThreshold_persistedWithWatchlist` passes under parallel testing.
+- [x] ISC-3: Unit suite is green **and deterministic** across ≥8 parallel runners.
+- [x] ISC-4: A typed `TornEndpoint` registry catalogs all 10 endpoints with version,
+  path, selections, access level, purpose, cadence, data shape, record limit, cache
+  policy, budget category, and critical/optional.
+- [x] ISC-5: A contract test asserts every registry URL equals its legacy `TornAPI`
+  builder (single source of truth, no drift).
+- [x] ISC-6: The registry generates a README-ready markdown table + onboarding
+  disclosure (selections list, required access level).
+- [x] ISC-7: `TornAPIError` classifies Torn codes into permanent-key / insufficient-
+  permissions / rate-limit / daily-row-limit / temporary-backend, plus offline /
+  transport / malformed / cancelled.
+- [x] ISC-8: `haltsAllRequests` is true for codes 2, 16, 18; `haltsCategoryOnly` is
+  true for code 14 (and false for `haltsAllRequests`).
+- [x] ISC-9: `RetryPolicy` implements the 2/5/15/30/60s ladder capped at 5 min, with
+  bounded equal-jitter; delay never exceeds the cap.
+- [x] ISC-10: `NotificationCoordinator` provides persistent edge-latch + epoch dedup
+  that survives restart and re-arms on a new event.
+- [x] ISC-11: The chain-expiring alert fires exactly once per crossing into the danger
+  window and re-arms after a member hit — proven by an AppState-level regression test.
+- [x] ISC-12: `SECURITY.md` exists with a private disclosure path and supported-version
+  policy.
+- [x] ISC-13: Anti: no test or log reveals the API key, full URLs, or player PII (the
+  determinism refactor preserves the existing redaction; new error messages are
+  sanitised + length-capped).
+- [x] ISC-14: Anti: no existing feature behaviour changed without a regression test
+  (253 prior tests still pass; chain path covered before change).
+
+**Deferred — backlog (later stages, with reasons):**
+
+- [ ] ISC-15: Etap B/C — wire `TornAPIError` classification into the live fetch paths so
+  a permanent key error stops polling and error 14 pauses only its category.
+  *(Deferred: touches the live polling loop; needs its own regression harness around
+  `AppState.fetchData` to change error handling safely. Typed model + classifier are
+  ready and tested.)*
+- [ ] ISC-16: Etap C — key validation/onboarding: call the key-info endpoint, show real
+  permissions, disable modules without access, "Test connection". *(Deferred: new UI +
+  a new endpoint; the registry already exposes required selections/level for the copy.)*
+- [ ] ISC-17: Etap D — `PollingCoordinator` with one global schedule + request/record
+  budget, adaptive cadence, immediate refresh on reconnect, sleep/wake correctness,
+  no timer restart on MenuBarExtra open. *(Deferred: the highest-value next stage;
+  largest single extraction from `AppState`.)*
+- [ ] ISC-18: Etap E — route the remaining categories (cooldown ready, landing,
+  release, OC ready, bounty, price alert, forum, bar threshold) through the
+  coordinator's epoch dedup. *(Deferred: coordinator primitives are built + tested;
+  this is mechanical wiring per category with a test each.)*
+- [ ] ISC-19: Etap F — Diagnostics screen (versions, network, last result/latency/size
+  per endpoint, retry state, request/record counters) + "Copy sanitized report".
+  *(Deferred: depends on D's counters; registry supplies the endpoint rows.)*
+- [ ] ISC-20: Etap G — deterministic UI-test harness (`--uitesting`, fixture selection,
+  fake clock/keychain/connectivity) + real UI tests; remove `continue-on-error` and
+  `|| echo "optional"`; coverage gate ≥80% on critical modules. *(Deferred: large;
+  the UserDefaults injection is the first brick.)*
+- [ ] ISC-21: Etap H — CI overhaul (current Xcode, required UI tests, archive smoke,
+  coverage, SwiftLint, entitlements/codesign/lipo checks, Dependabot). *(Deferred:
+  CI changes; `SECURITY.md` done.)*
+- [ ] ISC-22: Etap I — extract `TornAPIClient`, `PollingCoordinator`,
+  `NotificationCoordinator` (started), stores from `AppState`. *(Incremental;
+  `NotificationCoordinator` extracted this stage.)*
+- [ ] ISC-23: Etap J — "Next Action" unified event timeline + menu-bar variant.
+  *(Deferred product feature; depends on a shared testable clock.)*
+- [ ] ISC-24: Etap K — navigation/accessibility redesign (3–4 sections + More, reorder,
+  VoiceOver, larger targets). *(Deferred UX work.)*
+- [ ] ISC-25: Etap L — release engineering (Developer ID/notarization optional via CI
+  secrets, SHA-256, Sparkle). *(Deferred; `release-signed` scaffold already exists.)*
+
+## Test Strategy
+
+| isc | type | check | threshold | tool |
+| --- | --- | --- | --- | --- |
+| ISC-2,3 | determinism | flaky test passes under parallelism | 100% green, ≥8 runners | `xcodebuild test` |
+| ISC-4,5,6 | contract/unit | registry URL == TornAPI; metadata invariants | all pass | `TornEndpointTests` |
+| ISC-7,8,9 | unit | code→class map, halt semantics, backoff bounds | all pass | `TornAPIErrorTests` |
+| ISC-10,11 | unit + regression | dedup latch/epoch; chain fires once + re-arms | all pass | `NotificationCoordinatorTests` |
+| ISC-12 | inspection | file exists, disclosure path present | present | `Read` |
+| ISC-13 | inspection | no key/PII in new code paths | none | grep / review |
+| ISC-14 | regression | prior suite still green | 253/253 | `xcodebuild test` |
+
+## Features
+
+| name | satisfies | depends_on | parallelizable |
+| --- | --- | --- | --- |
+| UserDefaults injection | ISC-1,2,3,14 | — | no (foundation) |
+| TornEndpoint registry | ISC-4,5,6 | — | yes |
+| TornAPIError + RetryPolicy | ISC-7,8,9 | — | yes |
+| NotificationCoordinator + chain fix | ISC-10,11 | injection | yes |
+| SECURITY.md | ISC-12 | — | yes |
+
+## Decisions
+
+- 2026-07-15: Scoped this session to the **reliability spine** (Paweł's choice among
+  spine / Next-Action / architecture forks). Rationale: Torn-API correctness and
+  security are already largely done (v1.9.x, F-01…F-12); the spine is the foundation
+  every deferred stage builds on, is low regression-risk, and is fully testable.
+- 2026-07-15: Registry kept as a *parallel* typed catalog cross-checked against
+  `TornAPI` by a contract test, rather than immediately rewriting all `TornAPI` +
+  AppState call sites. Reason: a full builder migration is a wider, riskier refactor;
+  the contract test guarantees no drift in the meantime (ISC-15/A-02).
+- 2026-07-15: Chain fix implemented via an edge-latch (arm when timeout ≥ threshold or
+  chain inactive; fire on the falling edge into < threshold) rather than an epoch,
+  because "re-arm when the danger clears" is exactly a rising-edge signal.
+- 2026-07-15: `TornAPIError` classification built + tested but **not yet wired** into
+  `AppState.fetchData`. Reason: changing the live error path safely needs its own
+  regression harness; shipping the tested model now de-risks the wiring later (ISC-15).
+- 2026-07-15: Voice/Pulse announcements from the Algorithm doctrine skipped — Pulse is
+  permanently disabled in this environment (no `localhost:31337`).
+
+## Changelog
+
+- conjectured: the single flaky test was inherent test-order fragility.
+  refuted_by: it only failed under *parallel* runners sharing `UserDefaults.standard`.
+  learned: the root cause was production code (hardcoded global store), not the test;
+  the fix is dependency injection, which also unblocks the Etap G fake-clock harness.
+  criterion_now: ISC-1 (injectable defaults) precedes ISC-2/3 (isolated, green).
+
+## Verification
+
+- ISC-1: `Read` AppState.swift — `init(…, defaults: UserDefaults = .standard)`, 20
+  sites route through `defaults`.
+- ISC-2,3,14: `xcodebuild test -only-testing:MacTornTests` — green across 8 parallel
+  runners; previously-flaky test passes. (See PR for full numbers.)
+- ISC-4,5,6: `TornEndpointTests` (11 tests) pass — incl. URL-contract vs `TornAPI`.
+- ISC-7,8,9: `TornAPIErrorTests` (17 tests) pass.
+- ISC-10,11: `NotificationCoordinatorTests` (12 tests) pass — incl.
+  `testChainAlertFiresOnceAcrossManySubThresholdPolls`.
+- ISC-12: `SECURITY.md` present at repo root.

--- a/MacTorn/MacTorn.xcodeproj/project.pbxproj
+++ b/MacTorn/MacTorn.xcodeproj/project.pbxproj
@@ -62,6 +62,12 @@
 		BBB00021 /* AppStateStocksMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10021 /* AppStateStocksMetadataTests.swift */; };
 		BBB00022 /* AppStatePerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10022 /* AppStatePerformanceTests.swift */; };
 		CCC00001 /* MacTornUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC10001 /* MacTornUITests.swift */; };
+		AAA00030 /* TornEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10030 /* TornEndpoint.swift */; };
+		AAA00031 /* TornAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10031 /* TornAPIError.swift */; };
+		AAA00032 /* NotificationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10032 /* NotificationCoordinator.swift */; };
+		BBB00024 /* TornEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10024 /* TornEndpointTests.swift */; };
+		BBB00025 /* TornAPIErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10025 /* TornAPIErrorTests.swift */; };
+		BBB00026 /* NotificationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10026 /* NotificationCoordinatorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -139,6 +145,12 @@
 		BBB10022 /* AppStatePerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePerformanceTests.swift; sourceTree = "<group>"; };
 		CCC10000 /* MacTornUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MacTornUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCC10001 /* MacTornUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacTornUITests.swift; sourceTree = "<group>"; };
+		AAA10030 /* TornEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TornEndpoint.swift; sourceTree = "<group>"; };
+		AAA10031 /* TornAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TornAPIError.swift; sourceTree = "<group>"; };
+		AAA10032 /* NotificationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCoordinator.swift; sourceTree = "<group>"; };
+		BBB10024 /* TornEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TornEndpointTests.swift; sourceTree = "<group>"; };
+		BBB10025 /* TornAPIErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TornAPIErrorTests.swift; sourceTree = "<group>"; };
+		BBB10026 /* NotificationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCoordinatorTests.swift; sourceTree = "<group>"; };
 		F71B7A54C801E9B473317B0A /* SentryOptInPromptView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SentryOptInPromptView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -261,6 +273,7 @@
 				AAA10012 /* ShortcutsManager.swift */,
 				AAA10016 /* SoundManager.swift */,
 				AAA10028 /* NetworkMonitor.swift */,
+				AAA10032 /* NotificationCoordinator.swift */,
 				3AF028A1DCFBF9509F0B9E37 /* SentryManager.swift */,
 			);
 			path = Utilities;
@@ -270,6 +283,8 @@
 			isa = PBXGroup;
 			children = (
 				AAA10022 /* NetworkSession.swift */,
+				AAA10030 /* TornEndpoint.swift */,
+				AAA10031 /* TornAPIError.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -327,6 +342,8 @@
 				BBB10019 /* PropertyInfoTests.swift */,
 				BBB10020 /* StockMetadataTests.swift */,
 				BBB10023 /* UserV2ModelsTests.swift */,
+				BBB10024 /* TornEndpointTests.swift */,
+				BBB10025 /* TornAPIErrorTests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -340,6 +357,7 @@
 				BBB10018 /* AppStateForumWatchTests.swift */,
 				BBB10021 /* AppStateStocksMetadataTests.swift */,
 				BBB10022 /* AppStatePerformanceTests.swift */,
+				BBB10026 /* NotificationCoordinatorTests.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -507,6 +525,9 @@
 				AAA00019 /* WatchlistView.swift in Sources */,
 				AAA00020 /* PropertiesView.swift in Sources */,
 				AAA00021 /* NetworkSession.swift in Sources */,
+				AAA00030 /* TornEndpoint.swift in Sources */,
+				AAA00031 /* TornAPIError.swift in Sources */,
+				AAA00032 /* NotificationCoordinator.swift in Sources */,
 				AAA00022 /* TravelView.swift in Sources */,
 				AAA00023 /* CreditsView.swift in Sources */,
 				AAA00024 /* TransparencyEnvironment.swift in Sources */,
@@ -546,6 +567,9 @@
 				BBB00023 /* UserV2ModelsTests.swift in Sources */,
 				BBB00021 /* AppStateStocksMetadataTests.swift in Sources */,
 				BBB00022 /* AppStatePerformanceTests.swift in Sources */,
+				BBB00024 /* TornEndpointTests.swift in Sources */,
+				BBB00025 /* TornAPIErrorTests.swift in Sources */,
+				BBB00026 /* NotificationCoordinatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MacTorn/MacTorn/Networking/TornAPIError.swift
+++ b/MacTorn/MacTorn/Networking/TornAPIError.swift
@@ -1,0 +1,202 @@
+import Foundation
+
+// MARK: - Torn API Error Taxonomy (Etap B)
+//
+// Torn returns application errors with HTTP 200 and a code/message envelope. This
+// type classifies both those Torn codes and transport-level failures into a small,
+// actionable set so callers can react correctly instead of treating every failure
+// the same:
+//
+//   • permanentKey / insufficientPermissions → STOP the affected requests. Retrying
+//     an incorrect/paused key or an under-privileged selection forever is pointless
+//     and looks like a hang. (Etap C: codes 2, 16, 18.)
+//   • dailyRowLimit → pause ONLY the row-based category that tripped it (error 14),
+//     while bars/cooldowns/countdowns keep running.
+//   • rateLimit / temporaryBackend / offline / transport → retry with exponential
+//     backoff + jitter (RetryPolicy below).
+//   • malformed / cancelled → non-retryable, not the server's fault.
+//
+// Reference: Torn API error codes (https://www.torn.com/swagger — "Common errors").
+
+/// Coarse classification used for UI copy and retry decisions.
+enum TornErrorClass: String, Equatable, Sendable {
+    case permanentKey
+    case insufficientPermissions
+    case rateLimit
+    case dailyRowLimit
+    case temporaryBackend
+    case offline
+    case transport
+    case malformedResponse
+    case cancelled
+}
+
+enum TornAPIError: Error, Equatable, Sendable {
+    /// Key will not work until the user changes it: incorrect key, empty key, key
+    /// paused/disabled by the owner. Torn codes 1, 2, 10, 11, 12, 13, 18.
+    case permanentKey(code: Int, message: String)
+    /// The key is valid but its access level is too low for a requested selection.
+    /// Torn code 16.
+    case insufficientPermissions(code: Int, message: String)
+    /// Too many requests per minute. Torn code 5.
+    case rateLimit(code: Int, message: String)
+    /// The per-category 50,000-rows/day cloud-data cap. Torn code 14. Pause only the
+    /// offending category, not the whole app.
+    case dailyRowLimit(code: Int, message: String)
+    /// Transient server-side failure — retry with backoff. Torn codes 0, 8, 9, 15, 17, 24.
+    case temporaryBackend(code: Int, message: String)
+    /// Device is offline (no path to the network).
+    case offline
+    /// Other transport failure (timeout, DNS, TLS…). `detail` is a non-PII summary.
+    case transport(detail: String)
+    /// Response could not be decoded into the expected shape.
+    case malformedResponse(detail: String)
+    /// Request was cancelled (superseded poll, app teardown).
+    case cancelled
+
+    var classification: TornErrorClass {
+        switch self {
+        case .permanentKey: return .permanentKey
+        case .insufficientPermissions: return .insufficientPermissions
+        case .rateLimit: return .rateLimit
+        case .dailyRowLimit: return .dailyRowLimit
+        case .temporaryBackend: return .temporaryBackend
+        case .offline: return .offline
+        case .transport: return .transport
+        case .malformedResponse: return .malformedResponse
+        case .cancelled: return .cancelled
+        }
+    }
+
+    /// The Torn application error code, when this originated from an API envelope.
+    var tornCode: Int? {
+        switch self {
+        case let .permanentKey(code, _),
+             let .insufficientPermissions(code, _),
+             let .rateLimit(code, _),
+             let .dailyRowLimit(code, _),
+             let .temporaryBackend(code, _):
+            return code
+        case .offline, .transport, .malformedResponse, .cancelled:
+            return nil
+        }
+    }
+
+    /// Should the caller keep retrying (with backoff) on its own schedule?
+    var isRetryable: Bool {
+        switch classification {
+        case .rateLimit, .temporaryBackend, .offline, .transport:
+            return true
+        case .permanentKey, .insufficientPermissions, .dailyRowLimit, .malformedResponse, .cancelled:
+            return false
+        }
+    }
+
+    /// A key/permission problem that should halt *all* affected requests until the
+    /// user fixes their key (Etap C: codes 2, 16, 18). Prevents an infinite loop of
+    /// doomed requests.
+    var haltsAllRequests: Bool {
+        classification == .permanentKey || classification == .insufficientPermissions
+    }
+
+    /// A daily-row-limit hit (error 14) halts only the row-based category that tripped
+    /// it, leaving point-in-time polling (bars, countdowns) alive.
+    var haltsCategoryOnly: Bool {
+        classification == .dailyRowLimit
+    }
+
+    /// Short, PII-safe message for the UI. The underlying Torn message is a fixed
+    /// server string, but it is still sanitized (control chars stripped, length
+    /// capped) so a MITM'd/compromised response cannot inject multi-line UI.
+    var userMessage: String {
+        switch self {
+        case let .permanentKey(_, message):
+            return sanitized(message.isEmpty ? "Your API key is invalid or paused. Update it in Settings." : message)
+        case let .insufficientPermissions(_, message):
+            return sanitized(message.isEmpty ? "Your API key's access level is too low for this data." : message)
+        case .rateLimit:
+            return "Too many requests — backing off."
+        case .dailyRowLimit:
+            return "Daily read limit reached for this category — it will resume tomorrow."
+        case let .temporaryBackend(_, message):
+            return sanitized(message.isEmpty ? "Torn API is temporarily unavailable — retrying." : message)
+        case .offline:
+            return "You're offline — waiting for a connection."
+        case .transport:
+            return "Network error — retrying."
+        case .malformedResponse:
+            return "Unexpected response from Torn."
+        case .cancelled:
+            return "Request cancelled."
+        }
+    }
+
+    private func sanitized(_ text: String) -> String {
+        let stripped = text.unicodeScalars
+            .filter { !CharacterSet.controlCharacters.contains($0) }
+            .map(Character.init)
+        return String(String(stripped).prefix(120))
+    }
+
+    // MARK: - Classification
+
+    /// Maps a Torn application error code + message to a typed error.
+    static func classify(code: Int, message: String) -> TornAPIError {
+        switch code {
+        case 1, 2, 10, 11, 12, 13, 18:
+            return .permanentKey(code: code, message: message)
+        case 16:
+            return .insufficientPermissions(code: code, message: message)
+        case 5:
+            return .rateLimit(code: code, message: message)
+        case 14:
+            return .dailyRowLimit(code: code, message: message)
+        default:
+            // 0 (unknown), 8 (IP block), 9 (API disabled), 15 (temporary), 17 (backend),
+            // 24 (closed temporarily) and any other/new code default to transient so the
+            // client retries rather than silently giving up.
+            return .temporaryBackend(code: code, message: message)
+        }
+    }
+
+    /// Maps a URLSession transport error to a typed error.
+    static func from(urlError: URLError) -> TornAPIError {
+        switch urlError.code {
+        case .cancelled:
+            return .cancelled
+        case .notConnectedToInternet, .networkConnectionLost, .dataNotAllowed:
+            return .offline
+        default:
+            return .transport(detail: urlError.code.rawValue.description)
+        }
+    }
+}
+
+// MARK: - Retry Policy (exponential backoff + jitter)
+
+/// Exponential backoff schedule for retryable errors. Ladder 2s → 5s → 15s → 30s →
+/// 60s, then capped at 5 minutes for any further attempt (Etap B). Jitter is applied
+/// per attempt to avoid a thundering herd; the jitter fraction is injected so tests
+/// stay deterministic.
+struct RetryPolicy: Equatable, Sendable {
+    let ladder: [TimeInterval]
+    let cap: TimeInterval
+
+    static let standard = RetryPolicy(ladder: [2, 5, 15, 30, 60], cap: 300)
+
+    /// Base (pre-jitter) delay for a 0-indexed attempt. Beyond the ladder, the cap.
+    func baseDelay(attempt: Int) -> TimeInterval {
+        guard attempt >= 0 else { return min(ladder.first ?? cap, cap) }
+        let raw = attempt < ladder.count ? ladder[attempt] : cap
+        return min(raw, cap)
+    }
+
+    /// "Equal jitter": the delay lands in `[base/2, base]`. `jitter` is a caller-supplied
+    /// fraction in `[0, 1]` (e.g. `Double.random(in: 0...1)` in production). At `0` the
+    /// delay is `base/2`; at `1` it is `base`. Never exceeds the cap.
+    func delay(attempt: Int, jitter: Double) -> TimeInterval {
+        let base = baseDelay(attempt: attempt)
+        let clamped = min(max(jitter, 0), 1)
+        return base * (0.5 + 0.5 * clamped)
+    }
+}

--- a/MacTorn/MacTorn/Networking/TornEndpoint.swift
+++ b/MacTorn/MacTorn/Networking/TornEndpoint.swift
@@ -1,0 +1,368 @@
+import Foundation
+
+// MARK: - Torn API Registry (Etap A)
+//
+// A single, typed catalog of every Torn API endpoint and selection MacTorn calls.
+// This is the source of truth the rest of the app derives from instead of keeping
+// several hand-maintained lists:
+//
+//   1. Request building        — `TornEndpoint.url(key:parameter:)`
+//   2. "API Data Usage" screen  — the metadata fields below (Diagnostics, Etap F)
+//   3. README documentation     — `TornEndpointRegistry.markdownTable()`
+//   4. Onboarding disclosure     — `TornEndpointRegistry.disclosure()` (Etap C)
+//
+// The legacy `TornAPI` builders in `TornModels.swift` remain the code path that
+// AppState calls today; `TornEndpointContractTests` asserts every registry entry
+// produces the *exact* same URL as its `TornAPI` counterpart, so the two can never
+// silently drift while the migration to a single builder is completed in a later
+// stage (see ISA backlog A-02).
+
+/// Torn API major version. v1 is frozen (not sunset — every selection MacTorn relies
+/// on still returns its v1 shape); v2 is the actively developed OpenAPI surface.
+enum TornAPIVersion: String, Equatable, Sendable {
+    case v1
+    case v2
+}
+
+/// Whether a response is a point-in-time snapshot or row-based cloud data.
+///
+/// Row-based categories (events, attacks, faction news, forum posts) count against
+/// Torn's **50,000-rows/day-per-category** cap — the limit behind error code 14
+/// ("Daily read limit reached"), which is entirely separate from the
+/// 100-requests/minute rate limit. Point-in-time selections (bars, cooldowns, money…)
+/// do not touch that cap and are safe to poll fast.
+enum TornDataShape: String, Equatable, Sendable {
+    case pointInTime
+    case rowBased
+}
+
+/// Groups endpoints for request/record accounting (PollingCoordinator, Etap D) and
+/// the Diagnostics screen (Etap F). Row-based budgets are tracked per category
+/// because the 50k/day cap is itself per-category.
+enum TornBudgetCategory: String, Equatable, Sendable, CaseIterable {
+    case core       // user fast poll + combined v2 user
+    case activity   // events / messages / attacks (row-based)
+    case faction    // faction basic/chain, ranked wars, news
+    case market     // watchlist item listings
+    case forum      // watched threads / category threads (row-based)
+    case metadata   // slow-changing global lookups (stock names)
+}
+
+/// Client-side cache/throttle policy. Torn itself may serve cached data for up to
+/// ~30s, so `.none` still fetches with `reloadIgnoringLocalAndRemoteCacheData` to
+/// avoid the URL cache stacking a second layer on top.
+enum TornCachePolicy: Equatable, Sendable {
+    case none
+    case throttle(seconds: TimeInterval)
+}
+
+/// Torn API key access tiers. A key is issued at one of these levels and each
+/// selection requires a minimum tier.
+///
+/// NOTE: the authoritative per-selection requirement is only knowable at runtime
+/// from the `key/?selections=info` endpoint, which is wired in Etap C (key
+/// validation + onboarding — currently deferred; see ISA backlog C-01). The
+/// `minimumAccessLevel` declared on each endpoint below is a documented best-effort
+/// used for onboarding disclosure copy, NOT a hard gate. It is intentionally
+/// conservative (never under-states the requirement).
+enum TornKeyAccessLevel: Int, Comparable, CaseIterable, Sendable {
+    case publicOnly = 1
+    case minimal = 2
+    case limited = 3
+    case full = 4
+
+    var label: String {
+        switch self {
+        case .publicOnly: return "Public Only"
+        case .minimal: return "Minimal Access"
+        case .limited: return "Limited Access"
+        case .full: return "Full Access"
+        }
+    }
+
+    static func < (lhs: TornKeyAccessLevel, rhs: TornKeyAccessLevel) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+/// One typed endpoint description. `path` may contain a single `{param}` placeholder
+/// (market item id, forum thread/category id); such entries are `parameterized`.
+struct TornEndpoint: Identifiable, Equatable, Sendable {
+    /// Stable slug, e.g. "user.fast". Never renumbered.
+    let id: String
+    let name: String
+    let version: TornAPIVersion
+    /// Absolute URL without the query string, e.g. "https://api.torn.com/user/".
+    let path: String
+    /// Selection names; empty when the endpoint takes no `selections` parameter.
+    let selections: [String]
+    /// Additional fixed query items beyond `key`/`selections`/`limit` (e.g. news `cat`).
+    let extraQuery: [String: String]
+    /// Best-effort minimum key access level (see `TornKeyAccessLevel` caveat).
+    let minimumAccessLevel: TornKeyAccessLevel
+    let purpose: String
+    /// Human-readable polling cadence.
+    let cadence: String
+    let dataShape: TornDataShape
+    /// Row cap requested per call for row-based endpoints (used for the rows/day
+    /// estimate). `nil` for point-in-time endpoints.
+    let recordLimit: Int?
+    /// Whether `recordLimit` is also sent as a `limit` query item. Some row-based
+    /// endpoints (forum thread/threads) accept no `limit`, so accounting and the URL
+    /// diverge.
+    let sendsLimitQuery: Bool
+    let cachePolicy: TornCachePolicy
+    let budget: TornBudgetCategory
+    /// true = part of the app's core (an outage degrades the whole app);
+    /// false = optional module the user can live without.
+    let critical: Bool
+
+    var isParameterized: Bool { path.contains("{param}") }
+
+    /// Rows fetched per call — the unit of the 50k/day/category budget. Point-in-time
+    /// endpoints count as 1 "request" but 0 row-based records.
+    var recordsPerCall: Int { dataShape == .rowBased ? (recordLimit ?? 0) : 0 }
+
+    /// Builds the request URL with the same percent-encoding + sorted query items as
+    /// the legacy `TornAPI` builders. `parameter` fills a `{param}` placeholder and is
+    /// required for parameterized endpoints (returns nil if missing).
+    func url(key: String, parameter: Int? = nil) -> URL? {
+        var resolvedPath = path
+        if isParameterized {
+            guard let parameter else { return nil }
+            resolvedPath = resolvedPath.replacingOccurrences(of: "{param}", with: String(parameter))
+        }
+        var query: [String: String] = ["key": key]
+        if !selections.isEmpty {
+            query["selections"] = selections.joined(separator: ",")
+        }
+        if sendsLimitQuery, let recordLimit {
+            query["limit"] = String(recordLimit)
+        }
+        for (name, value) in extraQuery {
+            query[name] = value
+        }
+        guard var comps = URLComponents(string: resolvedPath) else { return nil }
+        comps.queryItems = query
+            .map { URLQueryItem(name: $0.key, value: $0.value) }
+            .sorted { $0.name < $1.name }
+        return comps.url
+    }
+}
+
+/// The catalog. Order is display order (core first).
+enum TornEndpointRegistry {
+    static let all: [TornEndpoint] = [
+        TornEndpoint(
+            id: "user.fast",
+            name: "User (fast poll)",
+            version: .v1,
+            path: "https://api.torn.com/user/",
+            selections: ["basic", "bars", "cooldowns", "travel", "profile", "money", "battlestats", "properties", "stocks"],
+            extraQuery: [:],
+            minimumAccessLevel: .limited,
+            purpose: "Live Energy/Nerve/Happy/Life bars, drug/medical/booster cooldowns, travel status, money & net worth, battle stats, properties and stock holdings.",
+            cadence: "Every refresh interval (default 30s; 15s aggressive)",
+            dataShape: .pointInTime,
+            recordLimit: nil,
+            sendsLimitQuery: false,
+            cachePolicy: .none,
+            budget: .core,
+            critical: true
+        ),
+        TornEndpoint(
+            id: "user.v2",
+            name: "User v2 (combined)",
+            version: .v2,
+            path: "https://api.torn.com/v2/user",
+            selections: ["organizedcrime", "refills", "education", "bounties"],
+            extraQuery: [:],
+            minimumAccessLevel: .limited,
+            purpose: "Own Organized Crime 2.0 status, daily refills remaining, in-progress education timer, and bounties placed on you.",
+            cadence: "Every refresh interval (rides the fast poll)",
+            dataShape: .pointInTime,
+            recordLimit: nil,
+            sendsLimitQuery: false,
+            cachePolicy: .none,
+            budget: .core,
+            critical: false
+        ),
+        TornEndpoint(
+            id: "user.activity",
+            name: "User activity",
+            version: .v1,
+            path: "https://api.torn.com/user/",
+            selections: ["events", "messages", "attacks"],
+            extraQuery: [:],
+            minimumAccessLevel: .limited,
+            purpose: "Events feed, unread message count and recent attacks (display-only).",
+            cadence: "≥5 min (self-throttled; hard row limit)",
+            dataShape: .rowBased,
+            recordLimit: 25,
+            sendsLimitQuery: true,
+            cachePolicy: .throttle(seconds: 300),
+            budget: .activity,
+            critical: false
+        ),
+        TornEndpoint(
+            id: "faction.basic",
+            name: "Faction basic + chain",
+            version: .v1,
+            path: "https://api.torn.com/faction/",
+            selections: ["basic", "chain"],
+            extraQuery: [:],
+            minimumAccessLevel: .limited,
+            purpose: "Faction identity and the live chain counter/timeout that drives the chain-expiring alert.",
+            cadence: "Every refresh interval (rides the fast poll)",
+            dataShape: .pointInTime,
+            recordLimit: nil,
+            sendsLimitQuery: false,
+            cachePolicy: .none,
+            budget: .faction,
+            critical: false
+        ),
+        TornEndpoint(
+            id: "faction.rankedwars",
+            name: "Faction ranked wars",
+            version: .v2,
+            path: "https://api.torn.com/v2/faction/rankedwars",
+            selections: [],
+            extraQuery: [:],
+            minimumAccessLevel: .limited,
+            purpose: "Active ranked war progress (your faction vs. the opponent).",
+            cadence: "≥5 min (throttled — large, slow-changing payload)",
+            dataShape: .pointInTime,
+            recordLimit: nil,
+            sendsLimitQuery: false,
+            cachePolicy: .throttle(seconds: 300),
+            budget: .faction,
+            critical: false
+        ),
+        TornEndpoint(
+            id: "faction.news",
+            name: "Faction news",
+            version: .v2,
+            path: "https://api.torn.com/v2/faction/news",
+            selections: [],
+            extraQuery: ["cat": "main"],
+            minimumAccessLevel: .limited,
+            purpose: "Recent faction news feed.",
+            cadence: "≥5 min (throttled; hard row limit)",
+            dataShape: .rowBased,
+            recordLimit: 25,
+            sendsLimitQuery: true,
+            cachePolicy: .throttle(seconds: 300),
+            budget: .faction,
+            critical: false
+        ),
+        TornEndpoint(
+            id: "market.item",
+            name: "Item market",
+            version: .v2,
+            path: "https://api.torn.com/v2/market/{param}",
+            selections: ["itemmarket", "bazaar"],
+            extraQuery: [:],
+            minimumAccessLevel: .publicOnly,
+            purpose: "Lowest item-market listings for each watchlist item, used to drive price alerts.",
+            cadence: "Watchlist refresh (manual + on price-alert timer)",
+            dataShape: .pointInTime,
+            recordLimit: nil,
+            sendsLimitQuery: false,
+            cachePolicy: .none,
+            budget: .market,
+            critical: false
+        ),
+        TornEndpoint(
+            id: "torn.stocks",
+            name: "Stock metadata",
+            version: .v1,
+            path: "https://api.torn.com/torn/",
+            selections: ["stocks"],
+            extraQuery: [:],
+            minimumAccessLevel: .publicOnly,
+            purpose: "Global stock names/acronyms used to label the user's stock holdings (slow-changing reference data).",
+            cadence: "Rarely (cached; refreshed on demand)",
+            dataShape: .pointInTime,
+            recordLimit: nil,
+            sendsLimitQuery: false,
+            cachePolicy: .throttle(seconds: 86_400),
+            budget: .metadata,
+            critical: false
+        ),
+        TornEndpoint(
+            id: "forum.thread",
+            name: "Forum thread",
+            version: .v2,
+            path: "https://api.torn.com/v2/forum/{param}/thread",
+            selections: [],
+            extraQuery: [:],
+            minimumAccessLevel: .publicOnly,
+            purpose: "Post count of a watched forum thread, to alert on new replies.",
+            cadence: "Forum poll (opt-in feature)",
+            dataShape: .rowBased,
+            recordLimit: 20,
+            sendsLimitQuery: false,
+            cachePolicy: .throttle(seconds: 300),
+            budget: .forum,
+            critical: false
+        ),
+        TornEndpoint(
+            id: "forum.threads",
+            name: "Forum category threads",
+            version: .v2,
+            path: "https://api.torn.com/v2/forum/{param}/threads",
+            selections: [],
+            extraQuery: [:],
+            minimumAccessLevel: .publicOnly,
+            purpose: "Thread list of a watched forum category, to alert on new threads.",
+            cadence: "Forum poll (opt-in feature)",
+            dataShape: .rowBased,
+            recordLimit: 20,
+            sendsLimitQuery: false,
+            cachePolicy: .throttle(seconds: 300),
+            budget: .forum,
+            critical: false
+        ),
+    ]
+
+    static func endpoint(id: String) -> TornEndpoint? {
+        all.first { $0.id == id }
+    }
+
+    static var critical: [TornEndpoint] { all.filter(\.critical) }
+    static var optional: [TornEndpoint] { all.filter { !$0.critical } }
+
+    /// Distinct selections across all endpoints, for onboarding disclosure.
+    static var allSelections: [String] {
+        var seen = Set<String>()
+        var ordered: [String] = []
+        for endpoint in all {
+            for selection in endpoint.selections where !seen.contains(selection) {
+                seen.insert(selection)
+                ordered.append(selection)
+            }
+        }
+        return ordered
+    }
+
+    /// Highest access level any endpoint requires — the level a key must have to
+    /// unlock every MacTorn module.
+    static var requiredAccessLevel: TornKeyAccessLevel {
+        all.map(\.minimumAccessLevel).max() ?? .publicOnly
+    }
+
+    /// A GitHub/README-ready markdown table generated from the registry. Kept in the
+    /// codebase so README's "API Data Usage" section can be regenerated (and a test
+    /// asserts the README row count matches `all.count`).
+    static func markdownTable() -> String {
+        var rows = ["| Endpoint | API | Selections | Data | Cadence | Rows/call | Budget | Critical | Purpose |",
+                    "| --- | --- | --- | --- | --- | --- | --- | --- | --- |"]
+        for e in all {
+            let sel = e.selections.isEmpty ? "—" : e.selections.joined(separator: ", ")
+            let rows_ = e.dataShape == .rowBased ? "\(e.recordsPerCall)" : "—"
+            let shape = e.dataShape == .rowBased ? "row-based" : "point-in-time"
+            rows.append("| \(e.name) | \(e.version.rawValue) | \(sel) | \(shape) | \(e.cadence) | \(rows_) | \(e.budget.rawValue) | \(e.critical ? "yes" : "no") | \(e.purpose) |")
+        }
+        return rows.joined(separator: "\n")
+    }
+}

--- a/MacTorn/MacTorn/Utilities/NotificationCoordinator.swift
+++ b/MacTorn/MacTorn/Utilities/NotificationCoordinator.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+// MARK: - Notification De-duplication (Etap E)
+//
+// Fixes the chain-expiring bug: the previous code fired "Chain Expiring!" on *every*
+// poll while the chain timeout was under 60s — a burst of identical banners every
+// refresh interval. This coordinator makes an alert fire exactly once per distinct
+// occurrence of an event. The dedup state is persisted, so it survives an app
+// restart (relaunching mid-danger-window must not re-alert), yet it re-arms once the
+// situation clears so a genuinely new event alerts again.
+//
+// Two primitives cover the Etap E categories:
+//
+//  • `shouldFireOnEdge(_:active:)` — a rising-edge latch. Returns true the first time
+//    `active` becomes true, then false until `active` returns to false (re-arm).
+//    Used for the chain danger window (active = 0 < timeout < 60s). Also fits any
+//    threshold-style alert (bar threshold, hospital/jail released).
+//
+//  • `shouldFireOnce(_:epoch:)` — fires once per distinct `epoch` value for a key.
+//    Used for per-instance events keyed by a stable identity: OC ready (OC id),
+//    landing (destination + arrival time), forum new posts (last post id),
+//    price alert (item id + crossed threshold), bounty (bounty id).
+//
+// A later stage routes the remaining notification categories through this coordinator
+// (see ISA backlog E-02); this stage wires the chain alert — the actual reported bug.
+@MainActor
+final class NotificationCoordinator {
+    private let defaults: UserDefaults
+    private static let latchesStoreID = "notifications.latched.v1"
+    private static let epochsStoreID = "notifications.epochs.v1"
+
+    /// Keys currently latched (fired, awaiting re-arm). Stored as a string array so it
+    /// round-trips through UserDefaults without NSNumber/Bool bridging ambiguity.
+    private var latchedKeys: Set<String>
+    /// Last epoch value alerted for each key.
+    private var epochs: [String: String]
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.latchedKeys = Set(defaults.stringArray(forKey: Self.latchesStoreID) ?? [])
+        self.epochs = (defaults.dictionary(forKey: Self.epochsStoreID) as? [String: String]) ?? [:]
+    }
+
+    /// Rising-edge latch. Fires (returns true) exactly once when `active` transitions
+    /// from false to true, then stays silent until `active` returns to false.
+    @discardableResult
+    func shouldFireOnEdge(_ key: String, active: Bool) -> Bool {
+        let latched = latchedKeys.contains(key)
+        if active && !latched {
+            latchedKeys.insert(key)
+            persistLatches()
+            return true
+        }
+        if !active && latched {
+            latchedKeys.remove(key)
+            persistLatches()
+        }
+        return false
+    }
+
+    /// Fires (returns true) once per distinct `epoch` for `key`. A new epoch re-alerts;
+    /// the same epoch is suppressed, even across app restarts.
+    @discardableResult
+    func shouldFireOnce(_ key: String, epoch: String) -> Bool {
+        if epochs[key] == epoch { return false }
+        epochs[key] = epoch
+        persistEpochs()
+        return true
+    }
+
+    /// Whether `key` is currently latched — exposed for diagnostics/tests.
+    func isLatched(_ key: String) -> Bool { latchedKeys.contains(key) }
+
+    /// Forget all dedup state (used when the key changes, or in tests).
+    func reset() {
+        latchedKeys.removeAll()
+        epochs.removeAll()
+        defaults.removeObject(forKey: Self.latchesStoreID)
+        defaults.removeObject(forKey: Self.epochsStoreID)
+    }
+
+    private func persistLatches() {
+        defaults.set(Array(latchedKeys), forKey: Self.latchesStoreID)
+    }
+
+    private func persistEpochs() {
+        defaults.set(epochs, forKey: Self.epochsStoreID)
+    }
+}

--- a/MacTorn/MacTorn/ViewModels/AppState.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState.swift
@@ -128,13 +128,13 @@ class AppState {
     var refreshInterval: Int = 30 {
         didSet {
             guard refreshInterval != oldValue else { return }
-            UserDefaults.standard.set(refreshInterval, forKey: "refreshInterval")
+            defaults.set(refreshInterval, forKey: "refreshInterval")
         }
     }
     var appearanceMode: String = AppearanceMode.system.rawValue {
         didSet {
             guard appearanceMode != oldValue else { return }
-            UserDefaults.standard.set(appearanceMode, forKey: "appearanceMode")
+            defaults.set(appearanceMode, forKey: "appearanceMode")
         }
     }
 
@@ -240,16 +240,23 @@ class AppState {
     var stocksFailureCount = 0
     var stocksNextRetryAfter: Date?
 
-    init(session: NetworkSession = URLSession.shared, connectivity: NetworkConnectivity? = nil) {
+    /// Non-secret persistence store. Injected so tests get an isolated
+    /// `UserDefaults` suite instead of the process-wide `.standard`, which under
+    /// parallel testing races across test classes on shared keys (e.g. "watchlist").
+    /// Production always passes `.standard`. See audit finding G-01.
+    @ObservationIgnored private let defaults: UserDefaults
+
+    init(session: NetworkSession = URLSession.shared, connectivity: NetworkConnectivity? = nil, defaults: UserDefaults = .standard) {
         self.session = session
         self.connectivity = connectivity ?? NetworkMonitor.shared
+        self.defaults = defaults
 
         // F-01 migration: lift any pre-existing plaintext key out of UserDefaults
         // into the Keychain on first launch of the new build, then clear the
         // UserDefaults entry. Safe to run every launch (idempotent).
-        if let legacy = UserDefaults.standard.string(forKey: "apiKey"), !legacy.isEmpty {
+        if let legacy = defaults.string(forKey: "apiKey"), !legacy.isEmpty {
             KeychainStore.set(legacy)
-            UserDefaults.standard.removeObject(forKey: "apiKey")
+            defaults.removeObject(forKey: "apiKey")
             logger.info("Migrated API key from UserDefaults to Keychain")
         }
         self.apiKey = KeychainStore.get() ?? ""
@@ -257,10 +264,10 @@ class AppState {
         // Was provided by @AppStorage; now manual seed from UserDefaults so the
         // values survive across launches. Note: didSet does NOT fire on init,
         // so this assignment doesn't loop-write back into UserDefaults.
-        if let stored = UserDefaults.standard.object(forKey: "refreshInterval") as? Int {
+        if let stored = defaults.object(forKey: "refreshInterval") as? Int {
             self.refreshInterval = stored
         }
-        if let stored = UserDefaults.standard.string(forKey: "appearanceMode") {
+        if let stored = defaults.string(forKey: "appearanceMode") {
             self.appearanceMode = stored
         }
 
@@ -275,7 +282,7 @@ class AppState {
 
     // MARK: - Stocks Metadata (global lookup from torn/?selections=stocks)
     func loadStocksMetadataFromCache() {
-        guard let data = UserDefaults.standard.data(forKey: Self.stocksMetadataCacheKey),
+        guard let data = defaults.data(forKey: Self.stocksMetadataCacheKey),
               let cached = try? JSONDecoder().decode([Int: StockMetadata].self, from: data) else {
             return
         }
@@ -296,7 +303,7 @@ class AppState {
             await MainActor.run {
                 self.stocksMetadata = parsed
                 if let encoded = try? JSONEncoder().encode(parsed) {
-                    UserDefaults.standard.set(encoded, forKey: Self.stocksMetadataCacheKey)
+                    defaults.set(encoded, forKey: Self.stocksMetadataCacheKey)
                 }
                 self.stocksFailureCount = 0
                 self.stocksNextRetryAfter = nil
@@ -353,7 +360,7 @@ class AppState {
     
     // MARK: - Notification Rules
     func loadNotificationRules() {
-        if let data = UserDefaults.standard.data(forKey: "notificationRules"),
+        if let data = defaults.data(forKey: "notificationRules"),
            let rules = try? JSONDecoder().decode([NotificationRule].self, from: data) {
             notificationRules = rules
         } else {
@@ -364,7 +371,7 @@ class AppState {
     
     func saveNotificationRules() {
         if let data = try? JSONEncoder().encode(notificationRules) {
-            UserDefaults.standard.set(data, forKey: "notificationRules")
+            defaults.set(data, forKey: "notificationRules")
         }
     }
     
@@ -377,7 +384,7 @@ class AppState {
 
     // MARK: - Travel Notification Settings
     func loadTravelNotificationSettings() {
-        if let data = UserDefaults.standard.data(forKey: "travelNotificationSettings"),
+        if let data = defaults.data(forKey: "travelNotificationSettings"),
            let settings = try? JSONDecoder().decode([TravelNotificationSetting].self, from: data) {
             travelNotificationSettings = settings
         } else {
@@ -388,7 +395,7 @@ class AppState {
 
     func saveTravelNotificationSettings() {
         if let data = try? JSONEncoder().encode(travelNotificationSettings) {
-            UserDefaults.standard.set(data, forKey: "travelNotificationSettings")
+            defaults.set(data, forKey: "travelNotificationSettings")
         }
     }
 
@@ -525,7 +532,7 @@ class AppState {
 
     // MARK: - Watchlist
     func loadWatchlist() {
-        if let data = UserDefaults.standard.data(forKey: "watchlist"),
+        if let data = defaults.data(forKey: "watchlist"),
            let items = try? JSONDecoder().decode([WatchlistItem].self, from: data) {
             watchlistItems = items
         }
@@ -533,7 +540,7 @@ class AppState {
     
     func saveWatchlist() {
         if let data = try? JSONEncoder().encode(watchlistItems) {
-            UserDefaults.standard.set(data, forKey: "watchlist")
+            defaults.set(data, forKey: "watchlist")
         }
     }
     
@@ -731,11 +738,11 @@ class AppState {
     
     // MARK: - Forum Watch
     func loadForumWatch() {
-        if let data = UserDefaults.standard.data(forKey: "forumWatchedThreads"),
+        if let data = defaults.data(forKey: "forumWatchedThreads"),
            let threads = try? JSONDecoder().decode([WatchedThread].self, from: data) {
             watchedThreads = threads
         }
-        if let data = UserDefaults.standard.data(forKey: "forumWatchConfig"),
+        if let data = defaults.data(forKey: "forumWatchConfig"),
            let config = try? JSONDecoder().decode(ForumWatchConfig.self, from: data) {
             forumWatchConfig = config
         }
@@ -743,10 +750,10 @@ class AppState {
 
     func saveForumWatch() {
         if let data = try? JSONEncoder().encode(watchedThreads) {
-            UserDefaults.standard.set(data, forKey: "forumWatchedThreads")
+            defaults.set(data, forKey: "forumWatchedThreads")
         }
         if let data = try? JSONEncoder().encode(forumWatchConfig) {
-            UserDefaults.standard.set(data, forKey: "forumWatchConfig")
+            defaults.set(data, forKey: "forumWatchConfig")
         }
     }
 
@@ -1621,7 +1628,7 @@ class AppState {
     // MARK: - Feedback Prompt
 
     func loadFeedbackState() {
-        if let data = UserDefaults.standard.data(forKey: "appFeedbackState"),
+        if let data = defaults.data(forKey: "appFeedbackState"),
            let state = try? JSONDecoder().decode(AppFeedbackState.self, from: data) {
             feedbackState = state
         } else {
@@ -1638,7 +1645,7 @@ class AppState {
     func saveFeedbackState() {
         guard let state = feedbackState,
               let data = try? JSONEncoder().encode(state) else { return }
-        UserDefaults.standard.set(data, forKey: "appFeedbackState")
+        defaults.set(data, forKey: "appFeedbackState")
     }
 
     func checkFeedbackPrompt() {

--- a/MacTorn/MacTorn/ViewModels/AppState.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState.swift
@@ -246,10 +246,18 @@ class AppState {
     /// Production always passes `.standard`. See audit finding G-01.
     @ObservationIgnored private let defaults: UserDefaults
 
+    /// Persistent notification de-duplication (Etap E). Built from the same injected
+    /// `defaults`, so tests get isolated dedup state alongside isolated persistence.
+    @ObservationIgnored let notificationCoordinator: NotificationCoordinator
+
+    /// Chain timeout (seconds remaining) below which the "Chain Expiring!" alert arms.
+    static let chainWarningThreshold = 60
+
     init(session: NetworkSession = URLSession.shared, connectivity: NetworkConnectivity? = nil, defaults: UserDefaults = .standard) {
         self.session = session
         self.connectivity = connectivity ?? NetworkMonitor.shared
         self.defaults = defaults
+        self.notificationCoordinator = NotificationCoordinator(defaults: defaults)
 
         // F-01 migration: lift any pre-existing plaintext key out of UserDefaults
         // into the Keychain on first launch of the new build, then clear the
@@ -1566,10 +1574,8 @@ class AppState {
             scheduleTravelNotifications(for: currentTravel)
         }
         
-        if let chain = newData.chain, chain.isActive {
-            if chain.timeoutRemaining < 60 && chain.timeoutRemaining > 0 {
-                NotificationManager.shared.send(title: "Chain Expiring! ⚠️", body: "Chain timeout in \(chain.timeoutRemaining) seconds!", type: .chainExpiring)
-            }
+        if chainExpiringShouldFire(newData.chain), let chain = newData.chain {
+            NotificationManager.shared.send(title: "Chain Expiring! ⚠️", body: "Chain timeout in \(chain.timeoutRemaining) seconds!", type: .chainExpiring)
         }
         
         if let prevStatus = previousStatus, let currentStatus = newData.status {
@@ -1579,6 +1585,21 @@ class AppState {
         }
     }
     
+    /// Decides whether the "Chain Expiring!" alert should fire on this poll.
+    ///
+    /// The alert must fire exactly once when the chain enters the danger window
+    /// (0 < timeout < `chainWarningThreshold`), NOT on every poll while it stays there
+    /// (the previous bug). It re-arms once the chain leaves the window — a member hits
+    /// (timeout jumps back up), the chain ends, or the chain drops — so a fresh danger
+    /// window alerts again. The latch is persisted, so a relaunch mid-window is silent.
+    /// `internal` for `@testable` regression coverage.
+    func chainExpiringShouldFire(_ chain: Chain?) -> Bool {
+        let inDanger = (chain?.isActive == true)
+            && chain!.timeoutRemaining > 0
+            && chain!.timeoutRemaining < Self.chainWarningThreshold
+        return notificationCoordinator.shouldFireOnEdge("chain.expiring", active: inDanger)
+    }
+
     private func checkBarNotification(prevBar: Bar, currentBar: Bar, barType: NotificationRule.BarType) {
         let prevPct = prevBar.percentage
         let currentPct = currentBar.percentage

--- a/MacTorn/MacTornTests/Models/TornAPIErrorTests.swift
+++ b/MacTorn/MacTornTests/Models/TornAPIErrorTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import MacTorn
+
+/// Etap B — the error taxonomy must classify Torn codes correctly and the backoff
+/// ladder must obey its bounds.
+final class TornAPIErrorTests: XCTestCase {
+
+    // MARK: - Code classification
+
+    func testIncorrectKeyIsPermanent() {
+        XCTAssertEqual(TornAPIError.classify(code: 2, message: "Incorrect key").classification, .permanentKey)
+    }
+
+    func testPausedAndDisabledKeysArePermanent() {
+        XCTAssertEqual(TornAPIError.classify(code: 18, message: "").classification, .permanentKey) // paused by owner
+        XCTAssertEqual(TornAPIError.classify(code: 13, message: "").classification, .permanentKey) // owner inactive
+        XCTAssertEqual(TornAPIError.classify(code: 1, message: "").classification, .permanentKey)  // empty key
+    }
+
+    func testAccessLevelTooLowIsInsufficientPermissions() {
+        XCTAssertEqual(TornAPIError.classify(code: 16, message: "").classification, .insufficientPermissions)
+    }
+
+    func testTooManyRequestsIsRateLimit() {
+        XCTAssertEqual(TornAPIError.classify(code: 5, message: "").classification, .rateLimit)
+    }
+
+    func testDailyReadLimitIsDailyRowLimit() {
+        XCTAssertEqual(TornAPIError.classify(code: 14, message: "").classification, .dailyRowLimit)
+    }
+
+    func testBackendCodesAreTemporary() {
+        for code in [0, 8, 9, 15, 17, 24, 999] {
+            XCTAssertEqual(TornAPIError.classify(code: code, message: "").classification, .temporaryBackend,
+                           "code \(code) should be temporary")
+        }
+    }
+
+    func testTornCodeIsPreserved() {
+        XCTAssertEqual(TornAPIError.classify(code: 14, message: "x").tornCode, 14)
+        XCTAssertNil(TornAPIError.offline.tornCode)
+    }
+
+    // MARK: - Halt / retry semantics (Etap C: 2, 16, 18 halt; 14 halts category only)
+
+    func testKeyAndPermissionErrorsHaltAllRequests() {
+        XCTAssertTrue(TornAPIError.classify(code: 2, message: "").haltsAllRequests)
+        XCTAssertTrue(TornAPIError.classify(code: 16, message: "").haltsAllRequests)
+        XCTAssertTrue(TornAPIError.classify(code: 18, message: "").haltsAllRequests)
+    }
+
+    func testDailyRowLimitHaltsCategoryOnly() {
+        let err = TornAPIError.classify(code: 14, message: "")
+        XCTAssertTrue(err.haltsCategoryOnly)
+        XCTAssertFalse(err.haltsAllRequests, "error 14 must NOT stop bars/countdowns")
+    }
+
+    func testRetryability() {
+        XCTAssertTrue(TornAPIError.classify(code: 5, message: "").isRetryable)   // rate limit
+        XCTAssertTrue(TornAPIError.classify(code: 17, message: "").isRetryable)  // backend
+        XCTAssertTrue(TornAPIError.offline.isRetryable)
+        XCTAssertFalse(TornAPIError.classify(code: 2, message: "").isRetryable)  // bad key
+        XCTAssertFalse(TornAPIError.classify(code: 14, message: "").isRetryable) // don't hammer daily cap
+        XCTAssertFalse(TornAPIError.cancelled.isRetryable)
+        XCTAssertFalse(TornAPIError.malformedResponse(detail: "x").isRetryable)
+    }
+
+    // MARK: - Transport mapping
+
+    func testTransportMapping() {
+        XCTAssertEqual(TornAPIError.from(urlError: URLError(.cancelled)), .cancelled)
+        XCTAssertEqual(TornAPIError.from(urlError: URLError(.notConnectedToInternet)), .offline)
+        XCTAssertEqual(TornAPIError.from(urlError: URLError(.networkConnectionLost)), .offline)
+        XCTAssertEqual(TornAPIError.from(urlError: URLError(.timedOut)).classification, .transport)
+    }
+
+    // MARK: - User message safety
+
+    func testUserMessageStripsControlCharactersAndCaps() {
+        let nasty = String(repeating: "A", count: 500) + "\n\n\rmalicious"
+        let msg = TornAPIError.permanentKey(code: 2, message: nasty).userMessage
+        XCTAssertLessThanOrEqual(msg.count, 120)
+        XCTAssertFalse(msg.contains("\n"))
+        XCTAssertFalse(msg.contains("\r"))
+    }
+
+    func testUserMessageNeverEmpty() {
+        let cases: [TornAPIError] = [
+            .permanentKey(code: 2, message: ""),
+            .insufficientPermissions(code: 16, message: ""),
+            .rateLimit(code: 5, message: ""),
+            .dailyRowLimit(code: 14, message: ""),
+            .temporaryBackend(code: 17, message: ""),
+            .offline, .transport(detail: "x"), .malformedResponse(detail: "x"), .cancelled,
+        ]
+        for error in cases {
+            XCTAssertFalse(error.userMessage.isEmpty, "\(error) has empty user message")
+        }
+    }
+
+    // MARK: - Retry policy
+
+    func testBaseDelayFollowsLadderThenCaps() {
+        let policy = RetryPolicy.standard
+        XCTAssertEqual(policy.baseDelay(attempt: 0), 2)
+        XCTAssertEqual(policy.baseDelay(attempt: 1), 5)
+        XCTAssertEqual(policy.baseDelay(attempt: 2), 15)
+        XCTAssertEqual(policy.baseDelay(attempt: 3), 30)
+        XCTAssertEqual(policy.baseDelay(attempt: 4), 60)
+        XCTAssertEqual(policy.baseDelay(attempt: 5), 300)   // cap
+        XCTAssertEqual(policy.baseDelay(attempt: 99), 300)  // still cap
+    }
+
+    func testJitterBounds() {
+        let policy = RetryPolicy.standard
+        // Equal jitter → [base/2, base]
+        XCTAssertEqual(policy.delay(attempt: 4, jitter: 0), 30, accuracy: 0.001)   // 60/2
+        XCTAssertEqual(policy.delay(attempt: 4, jitter: 1), 60, accuracy: 0.001)
+        let mid = policy.delay(attempt: 4, jitter: 0.5)
+        XCTAssertGreaterThan(mid, 30)
+        XCTAssertLessThan(mid, 60)
+    }
+
+    func testJitterClampsOutOfRangeInput() {
+        let policy = RetryPolicy.standard
+        XCTAssertEqual(policy.delay(attempt: 0, jitter: -5), 1, accuracy: 0.001) // clamps to 0 → base/2 = 1
+        XCTAssertEqual(policy.delay(attempt: 0, jitter: 5), 2, accuracy: 0.001)  // clamps to 1 → base = 2
+    }
+
+    func testDelayNeverExceedsCap() {
+        let policy = RetryPolicy.standard
+        for attempt in 0...10 {
+            XCTAssertLessThanOrEqual(policy.delay(attempt: attempt, jitter: 1), policy.cap)
+        }
+    }
+}

--- a/MacTorn/MacTornTests/Models/TornEndpointTests.swift
+++ b/MacTorn/MacTornTests/Models/TornEndpointTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import MacTorn
+
+/// Etap A — the typed registry must stay in lockstep with the legacy `TornAPI`
+/// builders (single source of truth) and its metadata must be internally consistent.
+final class TornEndpointTests: XCTestCase {
+
+    private let key = "exampleKey123456"
+    private let sampleId = 4242
+
+    // MARK: - Contract: registry URL == legacy TornAPI builder
+
+    /// Every registry entry must produce the byte-identical URL of the `TornAPI`
+    /// function AppState actually calls, so the catalog can never silently drift.
+    func testRegistryURLsMatchLegacyBuilders() {
+        func assertMatch(_ id: String, _ expected: URL?, parameter: Int? = nil,
+                         file: StaticString = #filePath, line: UInt = #line) {
+            let endpoint = TornEndpointRegistry.endpoint(id: id)
+            XCTAssertNotNil(endpoint, "missing endpoint \(id)", file: file, line: line)
+            XCTAssertEqual(endpoint?.url(key: key, parameter: parameter), expected,
+                           "URL drift for \(id)", file: file, line: line)
+        }
+
+        assertMatch("user.fast", TornAPI.url(for: key))
+        assertMatch("user.v2", TornAPI.userV2URL(for: key))
+        assertMatch("user.activity", TornAPI.activityURL(for: key))
+        assertMatch("faction.basic", TornAPI.factionURL(for: key))
+        assertMatch("faction.rankedwars", TornAPI.factionRankedWarsURL(for: key))
+        assertMatch("faction.news", TornAPI.factionNewsURL(for: key))
+        assertMatch("market.item", TornAPI.marketURL(itemId: sampleId, apiKey: key), parameter: sampleId)
+        assertMatch("torn.stocks", TornAPI.tornStocksURL(for: key))
+        assertMatch("forum.thread", TornAPI.forumThreadURL(threadId: sampleId, apiKey: key), parameter: sampleId)
+        assertMatch("forum.threads", TornAPI.forumCategoryThreadsURL(categoryId: sampleId, apiKey: key), parameter: sampleId)
+    }
+
+    /// The contract test above is only meaningful if it covers every endpoint.
+    func testEveryEndpointIsCoveredByContract() {
+        XCTAssertEqual(TornEndpointRegistry.all.count, 10,
+                       "add the new endpoint to testRegistryURLsMatchLegacyBuilders too")
+    }
+
+    // MARK: - URL building
+
+    func testParameterizedEndpointRequiresParameter() {
+        let market = TornEndpointRegistry.endpoint(id: "market.item")!
+        XCTAssertNil(market.url(key: key), "parameterized endpoint must return nil without a parameter")
+        XCTAssertNotNil(market.url(key: key, parameter: sampleId))
+    }
+
+    func testNonParameterizedEndpointIgnoresParameter() {
+        let fast = TornEndpointRegistry.endpoint(id: "user.fast")!
+        XCTAssertEqual(fast.url(key: key), fast.url(key: key, parameter: 99))
+    }
+
+    func testKeyIsAlwaysPresentInQuery() {
+        for endpoint in TornEndpointRegistry.all {
+            let url = endpoint.url(key: key, parameter: endpoint.isParameterized ? sampleId : nil)
+            XCTAssertNotNil(url)
+            XCTAssertTrue(url!.query!.contains("key=\(key)"), "\(endpoint.id) missing key")
+        }
+    }
+
+    // MARK: - Metadata invariants
+
+    func testIDsAreUnique() {
+        let ids = TornEndpointRegistry.all.map(\.id)
+        XCTAssertEqual(ids.count, Set(ids).count, "duplicate endpoint id")
+    }
+
+    func testRowBasedEndpointsDeclareARecordLimit() {
+        for endpoint in TornEndpointRegistry.all where endpoint.dataShape == .rowBased {
+            XCTAssertNotNil(endpoint.recordLimit, "\(endpoint.id) is row-based but has no recordLimit")
+            XCTAssertGreaterThan(endpoint.recordsPerCall, 0, "\(endpoint.id) records/call must be > 0")
+        }
+    }
+
+    func testPointInTimeEndpointsCountZeroRows() {
+        for endpoint in TornEndpointRegistry.all where endpoint.dataShape == .pointInTime {
+            XCTAssertEqual(endpoint.recordsPerCall, 0, "\(endpoint.id) is point-in-time yet counts rows")
+        }
+    }
+
+    func testUserFastPollIsTheOnlyCriticalEndpoint() {
+        XCTAssertEqual(TornEndpointRegistry.critical.map(\.id), ["user.fast"])
+    }
+
+    func testRequiredAccessLevelIsLimited() {
+        // The user/faction selections need Limited; no endpoint needs Full.
+        XCTAssertEqual(TornEndpointRegistry.requiredAccessLevel, .limited)
+    }
+
+    func testAllSelectionsAreDeduplicated() {
+        let selections = TornEndpointRegistry.allSelections
+        XCTAssertEqual(selections.count, Set(selections).count)
+        XCTAssertTrue(selections.contains("bars"))
+        XCTAssertTrue(selections.contains("organizedcrime"))
+    }
+
+    // MARK: - Documentation generation
+
+    func testMarkdownTableHasARowPerEndpoint() {
+        let lines = TornEndpointRegistry.markdownTable().split(separator: "\n")
+        // header + separator + one row per endpoint
+        XCTAssertEqual(lines.count, TornEndpointRegistry.all.count + 2)
+    }
+}

--- a/MacTorn/MacTornTests/ViewModels/AppStateFeedbackTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateFeedbackTests.swift
@@ -6,19 +6,21 @@ final class AppStateFeedbackTests: XCTestCase {
 
     var mockSession: MockNetworkSession!
     var appState: AppState!
+    var testDefaults: UserDefaults!
 
     override func setUp() async throws {
         try await super.setUp()
+        testDefaults = .createMockDefaults()
         mockSession = MockNetworkSession()
-        UserDefaults.standard.removeObject(forKey: "appFeedbackState")
-        appState = AppState(session: mockSession)
+        testDefaults.removeObject(forKey: "appFeedbackState")
+        appState = AppState(session: mockSession, defaults: testDefaults)
     }
 
     override func tearDown() async throws {
         appState.stopPolling()
         appState = nil
         mockSession = nil
-        UserDefaults.standard.removeObject(forKey: "appFeedbackState")
+        testDefaults.removeObject(forKey: "appFeedbackState")
         try await super.tearDown()
     }
 
@@ -149,7 +151,7 @@ final class AppStateFeedbackTests: XCTestCase {
         appState.saveFeedbackState()
 
         // Create a new AppState instance (simulates app restart)
-        let newAppState = AppState(session: mockSession)
+        let newAppState = AppState(session: mockSession, defaults: testDefaults)
 
         XCTAssertNotNil(newAppState.feedbackState)
         XCTAssertEqual(newAppState.feedbackState!.dismissCount, 1)

--- a/MacTorn/MacTornTests/ViewModels/AppStateForumWatchTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateForumWatchTests.swift
@@ -6,13 +6,15 @@ final class AppStateForumWatchTests: XCTestCase {
 
     var mockSession: MockNetworkSession!
     var appState: AppState!
+    var testDefaults: UserDefaults!
 
     override func setUp() async throws {
         try await super.setUp()
+        testDefaults = .createMockDefaults()
         mockSession = MockNetworkSession()
-        appState = AppState(session: mockSession)
-        UserDefaults.standard.removeObject(forKey: "forumWatchedThreads")
-        UserDefaults.standard.removeObject(forKey: "forumWatchConfig")
+        appState = AppState(session: mockSession, defaults: testDefaults)
+        testDefaults.removeObject(forKey: "forumWatchedThreads")
+        testDefaults.removeObject(forKey: "forumWatchConfig")
         appState.watchedThreads = []
         appState.forumWatchConfig = ForumWatchConfig()
     }
@@ -22,8 +24,8 @@ final class AppStateForumWatchTests: XCTestCase {
         appState.stopForumPolling()
         appState = nil
         mockSession = nil
-        UserDefaults.standard.removeObject(forKey: "forumWatchedThreads")
-        UserDefaults.standard.removeObject(forKey: "forumWatchConfig")
+        testDefaults.removeObject(forKey: "forumWatchedThreads")
+        testDefaults.removeObject(forKey: "forumWatchConfig")
         try await super.tearDown()
     }
 
@@ -137,7 +139,7 @@ final class AppStateForumWatchTests: XCTestCase {
         appState.forumWatchConfig.pollingIntervalSeconds = 300
         appState.saveForumWatch()
 
-        let newAppState = AppState(session: mockSession)
+        let newAppState = AppState(session: mockSession, defaults: testDefaults)
 
         XCTAssertEqual(newAppState.watchedThreads.count, 2)
         XCTAssertEqual(newAppState.watchedThreads[0].id, 111)
@@ -149,8 +151,8 @@ final class AppStateForumWatchTests: XCTestCase {
     }
 
     func testLoadForumWatch_emptyWhenNothingSaved() {
-        UserDefaults.standard.removeObject(forKey: "forumWatchedThreads")
-        UserDefaults.standard.removeObject(forKey: "forumWatchConfig")
+        testDefaults.removeObject(forKey: "forumWatchedThreads")
+        testDefaults.removeObject(forKey: "forumWatchConfig")
 
         appState.loadForumWatch()
 

--- a/MacTorn/MacTornTests/ViewModels/AppStatePerformanceTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStatePerformanceTests.swift
@@ -33,7 +33,7 @@ final class AppStatePerformanceTests: XCTestCase {
 
     @MainActor
     func testStocksMetadataBackoffLadder() async {
-        let appState = AppState(session: MockNetworkSession(), connectivity: AlwaysOnlineConnectivity())
+        let appState = AppState(session: MockNetworkSession(), connectivity: AlwaysOnlineConnectivity(), defaults: .createMockDefaults())
 
         let t0 = Date()
         appState.recordStocksMetadataFailure()

--- a/MacTorn/MacTornTests/ViewModels/AppStateStocksMetadataTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateStocksMetadataTests.swift
@@ -8,19 +8,21 @@ final class AppStateStocksMetadataTests: XCTestCase {
 
     var mockSession: MockNetworkSession!
     var appState: AppState!
+    var testDefaults: UserDefaults!
 
     override func setUp() async throws {
         try await super.setUp()
-        UserDefaults.standard.removeObject(forKey: Self.cacheKey)
+        testDefaults = .createMockDefaults()
+        testDefaults.removeObject(forKey: Self.cacheKey)
         mockSession = MockNetworkSession()
-        appState = AppState(session: mockSession)
+        appState = AppState(session: mockSession, defaults: testDefaults)
     }
 
     override func tearDown() async throws {
         appState.stopPolling()
         appState = nil
         mockSession = nil
-        UserDefaults.standard.removeObject(forKey: Self.cacheKey)
+        testDefaults.removeObject(forKey: Self.cacheKey)
         try await super.tearDown()
     }
 
@@ -40,7 +42,7 @@ final class AppStateStocksMetadataTests: XCTestCase {
         XCTAssertEqual(appState.stocksMetadata[16]?.name, "Sym-Sym Pharmaceuticals")
 
         // Persisted to cache
-        let cached = UserDefaults.standard.data(forKey: Self.cacheKey)
+        let cached = testDefaults.data(forKey: Self.cacheKey)
         XCTAssertNotNil(cached)
         let decoded = try JSONDecoder().decode([Int: StockMetadata].self, from: cached!)
         XCTAssertEqual(decoded[16]?.acronym, "SYS")
@@ -52,9 +54,9 @@ final class AppStateStocksMetadataTests: XCTestCase {
             7: StockMetadata(id: 7, name: "Big Al's Gun Shop", acronym: "BAG", currentPrice: 42.5)
         ]
         let data = try JSONEncoder().encode(cached)
-        UserDefaults.standard.set(data, forKey: Self.cacheKey)
+        testDefaults.set(data, forKey: Self.cacheKey)
 
-        let freshAppState = AppState(session: MockNetworkSession())
+        let freshAppState = AppState(session: MockNetworkSession(), defaults: testDefaults)
 
         XCTAssertEqual(freshAppState.stocksMetadata[7]?.acronym, "BAG")
         XCTAssertEqual(freshAppState.stocksMetadata[7]?.currentPrice ?? 0, 42.5, accuracy: 0.001)

--- a/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
@@ -6,15 +6,17 @@ final class AppStateTests: XCTestCase {
 
     var mockSession: MockNetworkSession!
     var appState: AppState!
+    var testDefaults: UserDefaults!
 
     override func setUp() async throws {
         try await super.setUp()
+        testDefaults = .createMockDefaults()
         mockSession = MockNetworkSession()
-        appState = AppState(session: mockSession)
+        appState = AppState(session: mockSession, defaults: testDefaults)
         // Clear any persisted data
-        UserDefaults.standard.removeObject(forKey: "apiKey")
-        UserDefaults.standard.removeObject(forKey: "watchlist")
-        UserDefaults.standard.removeObject(forKey: "notificationRules")
+        testDefaults.removeObject(forKey: "apiKey")
+        testDefaults.removeObject(forKey: "watchlist")
+        testDefaults.removeObject(forKey: "notificationRules")
     }
 
     override func tearDown() async throws {
@@ -470,9 +472,9 @@ final class AppStateTests: XCTestCase {
 
     func testLoadNotificationRules_defaults() {
         // Clear existing rules
-        UserDefaults.standard.removeObject(forKey: "notificationRules")
+        testDefaults.removeObject(forKey: "notificationRules")
 
-        let newAppState = AppState(session: mockSession)
+        let newAppState = AppState(session: mockSession, defaults: testDefaults)
 
         XCTAssertFalse(newAppState.notificationRules.isEmpty)
         // Should have default rules

--- a/MacTorn/MacTornTests/ViewModels/AppStateWatchlistTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateWatchlistTests.swift
@@ -6,13 +6,15 @@ final class AppStateWatchlistTests: XCTestCase {
 
     var mockSession: MockNetworkSession!
     var appState: AppState!
+    var testDefaults: UserDefaults!
 
     override func setUp() async throws {
         try await super.setUp()
+        testDefaults = .createMockDefaults()
         mockSession = MockNetworkSession()
-        appState = AppState(session: mockSession)
+        appState = AppState(session: mockSession, defaults: testDefaults)
         // Clear watchlist
-        UserDefaults.standard.removeObject(forKey: "watchlist")
+        testDefaults.removeObject(forKey: "watchlist")
         appState.watchlistItems = []
     }
 
@@ -20,7 +22,7 @@ final class AppStateWatchlistTests: XCTestCase {
         appState.stopPolling()
         appState = nil
         mockSession = nil
-        UserDefaults.standard.removeObject(forKey: "watchlist")
+        testDefaults.removeObject(forKey: "watchlist")
         try await super.tearDown()
     }
 
@@ -106,7 +108,7 @@ final class AppStateWatchlistTests: XCTestCase {
         appState.saveWatchlist()
 
         // Create new instance and load
-        let newAppState = AppState(session: mockSession)
+        let newAppState = AppState(session: mockSession, defaults: testDefaults)
         newAppState.loadWatchlist()
 
         XCTAssertEqual(newAppState.watchlistItems.count, 1)
@@ -114,7 +116,7 @@ final class AppStateWatchlistTests: XCTestCase {
     }
 
     func testLoadWatchlist_emptyWhenNothingSaved() {
-        UserDefaults.standard.removeObject(forKey: "watchlist")
+        testDefaults.removeObject(forKey: "watchlist")
 
         appState.loadWatchlist()
 
@@ -294,7 +296,7 @@ final class AppStateWatchlistTests: XCTestCase {
         appState.watchlistItems = [original]
         appState.saveWatchlist()
 
-        let newAppState = AppState(session: mockSession)
+        let newAppState = AppState(session: mockSession, defaults: testDefaults)
         newAppState.loadWatchlist()
 
         let loaded = newAppState.watchlistItems.first

--- a/MacTorn/MacTornTests/ViewModels/NotificationCoordinatorTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/NotificationCoordinatorTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import MacTorn
+
+/// Etap E — the dedup primitives, their persistence, and the AppState chain wiring.
+@MainActor
+final class NotificationCoordinatorTests: XCTestCase {
+
+    var defaults: UserDefaults!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        defaults = .createMockDefaults()
+    }
+
+    // MARK: - Edge latch
+
+    func testEdgeFiresOnceWhileActive() {
+        let coord = NotificationCoordinator(defaults: defaults)
+        XCTAssertTrue(coord.shouldFireOnEdge("chain", active: true), "first entry into danger fires")
+        XCTAssertFalse(coord.shouldFireOnEdge("chain", active: true), "still in danger — no re-fire")
+        XCTAssertFalse(coord.shouldFireOnEdge("chain", active: true))
+    }
+
+    func testEdgeReArmsAfterClearing() {
+        let coord = NotificationCoordinator(defaults: defaults)
+        XCTAssertTrue(coord.shouldFireOnEdge("chain", active: true))
+        XCTAssertFalse(coord.shouldFireOnEdge("chain", active: false), "leaving danger doesn't fire")
+        XCTAssertTrue(coord.shouldFireOnEdge("chain", active: true), "new danger window fires again")
+    }
+
+    func testEdgeStartingInactiveDoesNotFire() {
+        let coord = NotificationCoordinator(defaults: defaults)
+        XCTAssertFalse(coord.shouldFireOnEdge("chain", active: false))
+    }
+
+    func testEdgeKeysAreIndependent() {
+        let coord = NotificationCoordinator(defaults: defaults)
+        XCTAssertTrue(coord.shouldFireOnEdge("chain", active: true))
+        XCTAssertTrue(coord.shouldFireOnEdge("landing", active: true), "different key, own latch")
+        XCTAssertFalse(coord.shouldFireOnEdge("chain", active: true))
+    }
+
+    func testEdgeLatchSurvivesRestart() {
+        NotificationCoordinator(defaults: defaults).shouldFireOnEdge("chain", active: true)
+        // Simulate relaunch: a fresh coordinator over the same store.
+        let relaunched = NotificationCoordinator(defaults: defaults)
+        XCTAssertTrue(relaunched.isLatched("chain"))
+        XCTAssertFalse(relaunched.shouldFireOnEdge("chain", active: true),
+                       "relaunch mid-danger must not re-alert")
+        XCTAssertTrue(relaunched.shouldFireOnEdge("chain", active: false) == false)
+        XCTAssertTrue(relaunched.shouldFireOnEdge("chain", active: true), "re-arms after clearing post-restart")
+    }
+
+    // MARK: - Epoch dedup
+
+    func testOnceFiresPerDistinctEpoch() {
+        let coord = NotificationCoordinator(defaults: defaults)
+        XCTAssertTrue(coord.shouldFireOnce("oc", epoch: "123"))
+        XCTAssertFalse(coord.shouldFireOnce("oc", epoch: "123"), "same epoch suppressed")
+        XCTAssertTrue(coord.shouldFireOnce("oc", epoch: "456"), "new epoch fires")
+    }
+
+    func testOnceSurvivesRestart() {
+        NotificationCoordinator(defaults: defaults).shouldFireOnce("oc", epoch: "123")
+        let relaunched = NotificationCoordinator(defaults: defaults)
+        XCTAssertFalse(relaunched.shouldFireOnce("oc", epoch: "123"), "dedup persists across restart")
+    }
+
+    func testResetClearsState() {
+        let coord = NotificationCoordinator(defaults: defaults)
+        coord.shouldFireOnEdge("chain", active: true)
+        coord.shouldFireOnce("oc", epoch: "1")
+        coord.reset()
+        XCTAssertFalse(coord.isLatched("chain"))
+        XCTAssertTrue(coord.shouldFireOnce("oc", epoch: "1"), "reset forgets the epoch")
+    }
+
+    // MARK: - AppState chain-expiring regression (the reported bug)
+
+    private func chain(inSeconds seconds: Int, current: Int = 5) -> Chain {
+        // `timeout` is an absolute Unix timestamp; timeoutRemaining = timeout - now.
+        makeChain(current: current, timeout: Int(Date().timeIntervalSince1970) + seconds)
+    }
+
+    func testChainAlertFiresOnceAcrossManySubThresholdPolls() {
+        let appState = AppState(session: MockNetworkSession(), defaults: defaults)
+        // Poll repeatedly while the chain sits in the danger window.
+        var fireCount = 0
+        for _ in 0..<10 {
+            if appState.chainExpiringShouldFire(chain(inSeconds: 45)) { fireCount += 1 }
+        }
+        XCTAssertEqual(fireCount, 1, "exactly one alert while timeout stays < 60s")
+    }
+
+    func testChainAlertReArmsAfterMemberHits() {
+        let appState = AppState(session: MockNetworkSession(), defaults: defaults)
+        XCTAssertTrue(appState.chainExpiringShouldFire(chain(inSeconds: 40)), "enters danger → fire")
+        XCTAssertFalse(appState.chainExpiringShouldFire(chain(inSeconds: 40)), "still in danger → silent")
+        // A member hits — timeout jumps back above the threshold.
+        XCTAssertFalse(appState.chainExpiringShouldFire(chain(inSeconds: 300)), "safe again → silent + re-arm")
+        // Timer winds down into the danger window again.
+        XCTAssertTrue(appState.chainExpiringShouldFire(chain(inSeconds: 30)), "new danger window → fire again")
+    }
+
+    func testChainAlertDoesNotFireWhenInactiveOrAboveThreshold() {
+        let appState = AppState(session: MockNetworkSession(), defaults: defaults)
+        XCTAssertFalse(appState.chainExpiringShouldFire(nil))
+        XCTAssertFalse(appState.chainExpiringShouldFire(chain(inSeconds: 300)), "above threshold")
+        XCTAssertFalse(appState.chainExpiringShouldFire(makeChain(current: 0, timeout: 0)), "inactive chain")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -100,23 +100,34 @@ MacTorn respects macOS accessibility settings:
 
 ## API Data Usage
 
-In compliance with the [Torn API Terms of Service](https://www.torn.com/api.html), the following table shows which API selections MacTorn uses and why:
+In compliance with the [Torn API Terms of Service](https://www.torn.com/api.html), the
+table below shows every Torn API endpoint MacTorn calls and why. It is generated from
+the typed endpoint registry (`MacTorn/Networking/TornEndpoint.swift`,
+`TornEndpointRegistry.markdownTable()`) — the single source of truth that also builds
+the requests and the onboarding disclosure, so this list can't drift from what the app
+actually does.
 
-| Selection | Purpose |
-|-----------|---------|
-| `basic` | Player name, ID, basic info |
-| `bars` | Energy, Nerve, Happy, Life bars |
-| `cooldowns` | Drug, Medical, Booster cooldowns |
-| `travel` | Travel status and destination |
-| `profile` | Battle stats, faction info |
-| `events` | Recent events feed |
-| `messages` | Unread message count |
-| `money` | Cash, vault, points, tokens |
-| `stocks` | Stock holdings and transactions |
-| `properties` | Property vaults and upkeep |
-| `attacks` | Recent attack results |
-| `market` | Item watchlist prices |
-| `faction` | Faction info, chain, organized crimes |
+**Data shape** distinguishes *point-in-time* snapshots (bars, money, cooldowns — safe
+to poll frequently) from *row-based* cloud data (events, attacks, news, forum posts),
+which counts against Torn's 50,000-rows/day-per-category cap (error code 14). Row-based
+calls are throttled and hard-limited to stay well under that cap.
+
+| Endpoint | API | Selections | Data | Cadence | Rows/call | Budget | Critical | Purpose |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| User (fast poll) | v1 | basic, bars, cooldowns, travel, profile, money, battlestats, properties, stocks | point-in-time | Every refresh interval (default 30s; 15s aggressive) | — | core | yes | Live Energy/Nerve/Happy/Life bars, drug/medical/booster cooldowns, travel status, money & net worth, battle stats, properties and stock holdings. |
+| User v2 (combined) | v2 | organizedcrime, refills, education, bounties | point-in-time | Every refresh interval (rides the fast poll) | — | core | no | Own Organized Crime 2.0 status, daily refills remaining, in-progress education timer, and bounties placed on you. |
+| User activity | v1 | events, messages, attacks | row-based | ≥5 min (self-throttled; hard row limit) | 25 | activity | no | Events feed, unread message count and recent attacks (display-only). |
+| Faction basic + chain | v1 | basic, chain | point-in-time | Every refresh interval (rides the fast poll) | — | faction | no | Faction identity and the live chain counter/timeout that drives the chain-expiring alert. |
+| Faction ranked wars | v2 | — | point-in-time | ≥5 min (throttled — large, slow-changing payload) | — | faction | no | Active ranked war progress (your faction vs. the opponent). |
+| Faction news | v2 | — | row-based | ≥5 min (throttled; hard row limit) | 25 | faction | no | Recent faction news feed. |
+| Item market | v2 | itemmarket, bazaar | point-in-time | Watchlist refresh (manual + on price-alert timer) | — | market | no | Lowest item-market listings for each watchlist item, used to drive price alerts. |
+| Stock metadata | v1 | stocks | point-in-time | Rarely (cached; refreshed on demand) | — | metadata | no | Global stock names/acronyms used to label the user's stock holdings (slow-changing reference data). |
+| Forum thread | v2 | — | row-based | Forum poll (opt-in feature) | 20 | forum | no | Post count of a watched forum thread, to alert on new replies. |
+| Forum category threads | v2 | — | row-based | Forum poll (opt-in feature) | 20 | forum | no | Thread list of a watched forum category, to alert on new threads. |
+
+Your API key needs **Limited Access** or higher. Everything above is **read-only** —
+MacTorn never performs actions in Torn. See [`SECURITY.md`](SECURITY.md) for how your
+key and data are protected.
 
 ## Configuration
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+MacTorn is a native macOS menu bar app that reads your Torn account data through the
+official Torn API. It is **read-only** — it never performs actions in Torn — and it
+keeps all data on your Mac.
+
+## Supported versions
+
+Security fixes are applied to the latest released version. There is no back-porting to
+older versions; please update to the newest release before reporting an issue.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest release (see [CHANGELOG](CHANGELOG.md)) | ✅ |
+| Older | ❌ — please update first |
+
+## Reporting a vulnerability
+
+Please report security issues **privately** — do not open a public GitHub issue for a
+vulnerability.
+
+- Preferred: [GitHub private vulnerability reporting](https://github.com/pawelorzech/MacTorn/security/advisories/new)
+  (Security → Report a vulnerability).
+- Alternatively: email **pawel@orzech.me** with `MacTorn security` in the subject.
+
+Please include:
+
+- affected version (from the app's About/Settings or the release tag),
+- macOS version and architecture (Apple Silicon / Intel),
+- a description of the issue and, where possible, steps to reproduce,
+- the impact you believe it has.
+
+**Do not include your Torn API key, full request URLs containing a `key`, or raw API
+responses** in a report — they are secrets/PII. A redacted description is enough.
+
+You can expect an acknowledgement within about a week. Fixes are prioritised by
+severity; once a fix ships you'll be credited in the changelog unless you prefer to
+remain anonymous.
+
+## What MacTorn does to protect you
+
+These properties are verified by the test suite and CI, and are covered in detail in
+[`SECURITY_AUDIT.md`](SECURITY_AUDIT.md):
+
+- **API key in the Keychain.** The key is stored in the macOS Keychain
+  (`kSecClassGenericPassword`, accessible after first unlock), never in plaintext
+  `UserDefaults`.
+- **No secrets or PII in logs.** Request URLs are redacted to
+  `scheme://host/path?[sorted-query-keys]` before logging — the key and query values
+  never reach `os_log`. Player name, money and stats are never logged.
+- **App Sandbox + Hardened Runtime.** The app runs sandboxed with only the
+  `network.client` entitlement and Hardened Runtime enabled.
+- **HTTPS only.** All traffic to `api.torn.com` uses TLS via the system trust store
+  (ATS defaults; no arbitrary loads). Certificate pinning is intentionally **not**
+  used (documented accepted risk F-05).
+- **Untrusted-input handling.** Watchlist input is validated/clamped; server-supplied
+  strings are sanitised (control chars stripped, length capped) before they appear in
+  notifications; API error envelopes (v1 and v2) are surfaced, not swallowed.
+- **Opt-in crash reporting.** Sentry is **off by default** and only enabled if you
+  explicitly opt in. It is a separate, optional mechanism from anything above.
+
+## Scope
+
+In scope: the MacTorn app, its build/release tooling, and its CI workflows.
+
+Out of scope: the Torn API itself and Torn's own infrastructure (report those to Torn),
+and social-engineering or physical-access attacks. The audit assumes the
+verified-absent attack surface listed in `SECURITY_AUDIT.md` §A (no URL schemes,
+WebView, XPC, IPC, AppleScript, file-open handlers, or third-party runtime
+dependencies beyond Sentry). Adding any of those requires a re-audit.


### PR DESCRIPTION
# Reliability & product audit — stage 1 (reliability spine)

First stage of the Etap A–L quality program. This branch ships the **reliability +
correctness spine** that later stages build on, as green, tested, regression-safe
commits. The full program plan and the deferred backlog (with reasons) live in
[`ISA.md`](ISA.md).

> **Scope note (honest).** Etap A–L is a multi-week program. Torn-API correctness
> (error 14, `server_time` anchor, OC 2.0, v2 error envelopes) and the security model
> (F-01…F-12) were **already done** in v1.9.x. This stage deliberately targets the
> remaining structural gaps that everything else depends on; stages D/F/G/I/J/K/L are
> tracked in `ISA.md`, not silently dropped.

## What's in this PR

### Fixed
- **Chain-expiring notification fired on every poll** (real bug). While the chain
  timeout was `< 60s`, the alert was re-sent every refresh. It now fires **exactly once**
  per crossing into the danger window and re-arms only after the chain leaves it — via a
  new persistent `NotificationCoordinator` whose de-dup survives an app restart. Proven
  by an AppState-level regression test.
- **Non-deterministic test suite.** `AppState` hardcoded `UserDefaults.standard`, so
  watchlist tests raced under parallel execution — `testPriceThreshold_persistedWithWatchlist`
  failed intermittently on `main`. `AppState` now takes an injectable `UserDefaults`;
  each test isolates its own suite.

### Added (Etap A / B / E)
- **`TornEndpoint` registry** — one typed catalog of all 10 endpoints (version, path,
  selections, access level, cadence, point-in-time vs row-based, record limit, cache
  policy, budget category, critical/optional). Drives request building, the README API
  table, and onboarding disclosure. A **contract test** pins every registry URL to its
  legacy `TornAPI` builder so they can't drift.
- **`TornAPIError` taxonomy + `RetryPolicy`** — classifies Torn codes (permanent key /
  insufficient permissions / rate limit / daily row limit / temporary backend) and
  transport states, with `haltsAllRequests` (2/16/18) and `haltsCategoryOnly` (14)
  semantics, and a 2/5/15/30/60s backoff capped at 5 min with jitter. *(Model +
  classifier only; live-path wiring is ISA ISC-15.)*
- **`SECURITY.md`** and **`ISA.md`** (program system-of-record).

## Results (measured)

| Metric | Before (`main`) | After |
| --- | --- | --- |
| Unit tests | 253 (1 flaky) | 294 (0 flaky) |
| Deterministic under parallelism | ❌ (1 flaky) | ✅ (8 runners) |
| Compiler warnings | 0 | 0 |
| Debug build | ✅ | ✅ BUILD SUCCEEDED |
| Release build (Universal) | ✅ | ✅ BUILD SUCCEEDED |
| Binary architectures | arm64 + x86_64 | ✅ x86_64 + arm64 (lipo) |
| App Sandbox / Hardened Runtime | on | on (flags=0x10002 adhoc,runtime; sandbox + network.client) |
| Release bundle size | — | 8.1 MB |

Coverage on the new critical modules (all above the 80% Etap-G target; measured via
`make coverage`):

| Module | Before | After |
| --- | --- | --- |
| `NotificationCoordinator.swift` | n/a (new) | **100.00%** (41/41) |
| `TornAPIError.swift` | n/a (new) | **99.07%** (107/108) |
| `TornEndpoint.swift` | n/a (new) | **83.56%** (61/73) |
| `AppState.swift` | ~ | 74.51% (1482/1989) |

Overall app line coverage is 17.93% — dominated by the uncovered SwiftUI views, which
are intentionally out of the 80% gate (per the brief: don't force 80% on simple views).

## Commits

```
46f379d  feat(reliability): typed API registry, error taxonomy, notification dedup + chain fix
4286146  test(reliability): isolate AppState UserDefaults per test suite (G-01)
e804929  docs(reliability): SECURITY.md, ISA program record, registry-derived API table, changelog
```
(chronological order: test isolation → typed reliability layer → docs)

## Not in this PR (tracked in ISA.md, with reasons)

- **Etap C** — key validation/onboarding (key-info endpoint, permission-aware modules).
- **Etap D** — `PollingCoordinator` (global schedule + request/record budget) — the
  highest-value next stage.
- **Etap E (rest)** — route the remaining notification categories through the
  coordinator's epoch dedup (primitives are built + tested).
- **Etap F** — Diagnostics screen (depends on D's counters).
- **Etap G/H** — deterministic UI-test harness + CI overhaul + coverage gate.
- **Etap I** — finish extracting `TornAPIClient` / stores from the 1,700-line `AppState`.
- **Etap J** — "Next Action" unified timeline.
- **Etap K/L** — navigation/accessibility redesign, release engineering.

## Known limitations / unverified
- `TornAPIError` is **not yet wired** into `AppState.fetchData` — the live path still
  uses the existing string-message handling. The typed model is shipped and tested so
  the wiring (halt-on-bad-key, pause-category-on-14) can land safely next (ISC-15).
- Registry `minimumAccessLevel` is a documented best-effort; the authoritative
  per-selection requirement comes from the key-info endpoint in Etap C.
- UI tests unchanged this stage (still `continue-on-error` in CI) — Etap G.
- Notarization still requires Apple Developer ID (F-04 accepted risk); `release-signed`
  scaffold exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chain-expiring alerts now notify once per danger period instead of repeating during polling.
  * Alert state persists across app restarts and correctly resets when conditions clear.
  * Improved handling of API, network, rate-limit, and temporary service errors with safer retry behavior.

* **Documentation**
  * Expanded API usage documentation with endpoint details, polling cadence, data limits, and access requirements.
  * Added security guidance for vulnerability reporting and protecting API keys and sensitive data.

* **Reliability**
  * Added stronger validation and coverage for endpoint requests, error handling, notifications, and persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->