### PR TITLE
Etap D — polling budget + reconnect refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,22 @@ the full plan and deferred backlog live in [`ISA.md`](ISA.md).
 - **`ISA.md`** — system-of-record for the audit program with the full A–L backlog and
   deferral reasons.
 
+### Added — Etap D (polling budget + reconnect)
+- **API budget accounting** (`PollingCoordinator`): every request-issuing path records
+  against a rolling requests/min + requests/day count and per-category rows/day (driven
+  by the typed registry), with a conservative 60/min hard cap that no path bypasses. This
+  makes the usage that caused error 14 (v1.9.2) measurable and bounded.
+- **Immediate refresh on reconnect.** After a network outage, MacTorn refreshes once as
+  soon as connectivity returns (on the genuine down→up edge) instead of waiting up to a
+  full refresh interval.
+- **Shared testable clock** (`TimeSource`) behind the budget windows — also the clock the
+  upcoming "Next Action" timeline will use.
+- The **15s** refresh option is now labelled **"15s aggressive"** with a note that Torn
+  may serve cached data for ~30s, so 15s can spend API budget for no fresher data.
+
 ### Notes
-- 41 new unit tests (294 total, all green). No existing feature behaviour changed.
+- 55 new unit tests since `main` (308 total, all green). No existing feature behaviour
+  changed. CI's Release build was also un-broken (Xcode 16 for `Package.resolved` v3).
 
 ## [1.9.2] - 2026-07-15
 

--- a/ISA.md
+++ b/ISA.md
@@ -126,10 +126,15 @@ tracked backlog with deferral reasons.
 - [ ] ISC-16: Etap C — key validation/onboarding: call the key-info endpoint, show real
   permissions, disable modules without access, "Test connection". *(Deferred: new UI +
   a new endpoint; the registry already exposes required selections/level for the copy.)*
-- [ ] ISC-17: Etap D — `PollingCoordinator` with one global schedule + request/record
-  budget, adaptive cadence, immediate refresh on reconnect, sleep/wake correctness,
-  no timer restart on MenuBarExtra open. *(Deferred: the highest-value next stage;
-  largest single extraction from `AppState`.)*
+- [x] ISC-17: Etap D (budget + reconnect) — `PollingCoordinator` measures requests/min,
+  requests/day and rows/day/category against the registry, with a 60/min hard-cap gate
+  (`canMakeRequest()`) wired into `fetchData` and `record()` at all 9 request sites; a
+  shared injectable `TimeSource`; and immediate refresh on a down→up connectivity edge.
+  Verified by `PollingCoordinatorTests` (11) + AppState budget/reconnect tests (3).
+- [ ] ISC-17.1: Etap D (schedule ownership, D-02) — move the Combine poll timer, adaptive
+  cadence and sleep/wake handling out of `AppState` into the coordinator so it owns the
+  schedule, not just the accounting. *(Deferred: the high-regression-risk extraction; the
+  measurable budget/reconnect wins land first without destabilising the poll loop.)*
 - [ ] ISC-18: Etap E — route the remaining categories (cooldown ready, landing,
   release, OC ready, bounty, price alert, forum, bar threshold) through the
   coordinator's epoch dedup. *(Deferred: coordinator primitives are built + tested;

--- a/MacTorn/MacTorn.xcodeproj/project.pbxproj
+++ b/MacTorn/MacTorn.xcodeproj/project.pbxproj
@@ -68,6 +68,9 @@
 		BBB00024 /* TornEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10024 /* TornEndpointTests.swift */; };
 		BBB00025 /* TornAPIErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10025 /* TornAPIErrorTests.swift */; };
 		BBB00026 /* NotificationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10026 /* NotificationCoordinatorTests.swift */; };
+		AAA00033 /* TimeSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10033 /* TimeSource.swift */; };
+		AAA00034 /* PollingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10034 /* PollingCoordinator.swift */; };
+		BBB00027 /* PollingCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10027 /* PollingCoordinatorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -151,6 +154,9 @@
 		BBB10024 /* TornEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TornEndpointTests.swift; sourceTree = "<group>"; };
 		BBB10025 /* TornAPIErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TornAPIErrorTests.swift; sourceTree = "<group>"; };
 		BBB10026 /* NotificationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCoordinatorTests.swift; sourceTree = "<group>"; };
+		AAA10033 /* TimeSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSource.swift; sourceTree = "<group>"; };
+		AAA10034 /* PollingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingCoordinator.swift; sourceTree = "<group>"; };
+		BBB10027 /* PollingCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingCoordinatorTests.swift; sourceTree = "<group>"; };
 		F71B7A54C801E9B473317B0A /* SentryOptInPromptView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SentryOptInPromptView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -274,6 +280,7 @@
 				AAA10016 /* SoundManager.swift */,
 				AAA10028 /* NetworkMonitor.swift */,
 				AAA10032 /* NotificationCoordinator.swift */,
+				AAA10034 /* PollingCoordinator.swift */,
 				3AF028A1DCFBF9509F0B9E37 /* SentryManager.swift */,
 			);
 			path = Utilities;
@@ -293,6 +300,7 @@
 			isa = PBXGroup;
 			children = (
 				AAA10025 /* TransparencyEnvironment.swift */,
+				AAA10033 /* TimeSource.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -358,6 +366,7 @@
 				BBB10021 /* AppStateStocksMetadataTests.swift */,
 				BBB10022 /* AppStatePerformanceTests.swift */,
 				BBB10026 /* NotificationCoordinatorTests.swift */,
+				BBB10027 /* PollingCoordinatorTests.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -528,6 +537,8 @@
 				AAA00030 /* TornEndpoint.swift in Sources */,
 				AAA00031 /* TornAPIError.swift in Sources */,
 				AAA00032 /* NotificationCoordinator.swift in Sources */,
+				AAA00033 /* TimeSource.swift in Sources */,
+				AAA00034 /* PollingCoordinator.swift in Sources */,
 				AAA00022 /* TravelView.swift in Sources */,
 				AAA00023 /* CreditsView.swift in Sources */,
 				AAA00024 /* TransparencyEnvironment.swift in Sources */,
@@ -570,6 +581,7 @@
 				BBB00024 /* TornEndpointTests.swift in Sources */,
 				BBB00025 /* TornAPIErrorTests.swift in Sources */,
 				BBB00026 /* NotificationCoordinatorTests.swift in Sources */,
+				BBB00027 /* PollingCoordinatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MacTorn/MacTorn/Helpers/TimeSource.swift
+++ b/MacTorn/MacTorn/Helpers/TimeSource.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+// MARK: - Shared testable clock (Etap D / foundation for Etap J)
+//
+// A single, injectable source of "now" so time-dependent logic — the polling budget
+// windows here, and the upcoming "Next Action" timeline — can be tested deterministically
+// without sleeping real seconds, and so every feature reads the same clock.
+
+protocol TimeSource: AnyObject {
+    var now: Date { get }
+}
+
+/// Production clock: wall time.
+final class SystemTimeSource: TimeSource {
+    var now: Date { Date() }
+}
+
+/// Test/preview clock: advance time by hand.
+final class MutableTimeSource: TimeSource {
+    private var current: Date
+    init(_ start: Date = Date(timeIntervalSince1970: 1_700_000_000)) { current = start }
+    var now: Date { current }
+    func advance(_ seconds: TimeInterval) { current = current.addingTimeInterval(seconds) }
+    func set(_ date: Date) { current = date }
+}

--- a/MacTorn/MacTorn/Utilities/NetworkMonitor.swift
+++ b/MacTorn/MacTorn/Utilities/NetworkMonitor.swift
@@ -5,6 +5,10 @@ import Network
 @MainActor
 protocol NetworkConnectivity: AnyObject {
     var isConnected: Bool { get }
+    /// Invoked when connectivity transitions from down to up, so the app can trigger a
+    /// safe refresh (Etap D: "offline → online powoduje bezpieczny refresh"). Set by the
+    /// owner; may be nil.
+    var onConnectivityRestored: (() -> Void)? { get set }
 }
 
 @MainActor
@@ -12,6 +16,7 @@ final class NetworkMonitor: NetworkConnectivity {
     static let shared = NetworkMonitor()
 
     private(set) var isConnected: Bool = true
+    var onConnectivityRestored: (() -> Void)?
 
     private let monitor = NWPathMonitor()
     private let queue = DispatchQueue(label: "com.mactorn.networkmonitor")
@@ -19,7 +24,15 @@ final class NetworkMonitor: NetworkConnectivity {
     private init() {
         monitor.pathUpdateHandler = { [weak self] path in
             Task { @MainActor in
-                self?.isConnected = path.status == .satisfied
+                guard let self else { return }
+                let nowConnected = path.status == .satisfied
+                let wasConnected = self.isConnected
+                self.isConnected = nowConnected
+                // Fire only on a genuine down→up edge, so a refresh happens once per
+                // reconnect (not on every path update while already online).
+                if nowConnected && !wasConnected {
+                    self.onConnectivityRestored?()
+                }
             }
         }
         monitor.start(queue: queue)

--- a/MacTorn/MacTorn/Utilities/PollingCoordinator.swift
+++ b/MacTorn/MacTorn/Utilities/PollingCoordinator.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+// MARK: - Polling budget accounting (Etap D)
+//
+// Measures and caps MacTorn's Torn API usage so it stays well under Torn's limits and
+// never silently drifts over (the class of bug that caused error 14 in v1.9.2). It
+// tracks two independent budgets, both keyed off the typed `TornEndpoint` registry:
+//
+//   • Requests — a rolling per-minute and per-day count. Torn allows 100 req/min; we
+//     cap at a conservative `hardCapPerMinute` (60) and treat `softTargetPerMinute` (15)
+//     as the "healthy" line for diagnostics. `canMakeRequest()` is the gate no code path
+//     may bypass.
+//   • Records — row-based categories (events, attacks, news, forum) count against Torn's
+//     50,000-rows/day-per-category cap. We track rows/day per `TornBudgetCategory` and
+//     flag anything approaching `recordBudgetPerDayPerCategory` (15,000, a safe target).
+//
+// Time comes from an injected `TimeSource`, so the rolling windows are testable without
+// waiting real minutes. Ownership of the actual poll *schedule* (moving the Combine
+// timer out of AppState) is a later step — see ISA backlog D-02.
+@MainActor
+final class PollingCoordinator {
+    private let time: TimeSource
+
+    /// Conservative per-minute ceiling (Torn's own limit is 100/min).
+    let hardCapPerMinute: Int
+    /// "Healthy" per-minute cadence used for diagnostics coloring.
+    let softTargetPerMinute: Int
+    /// Per-category daily row budget (Torn's hard cap is 50,000).
+    let recordBudgetPerDayPerCategory: Int
+
+    private static let minuteWindow: TimeInterval = 60
+    private static let dayWindow: TimeInterval = 24 * 60 * 60
+
+    private var requestTimestamps: [Date] = []
+    private var recordEvents: [(at: Date, category: TornBudgetCategory, count: Int)] = []
+
+    init(time: TimeSource = SystemTimeSource(),
+         hardCapPerMinute: Int = 60,
+         softTargetPerMinute: Int = 15,
+         recordBudgetPerDayPerCategory: Int = 15_000) {
+        self.time = time
+        self.hardCapPerMinute = hardCapPerMinute
+        self.softTargetPerMinute = softTargetPerMinute
+        self.recordBudgetPerDayPerCategory = recordBudgetPerDayPerCategory
+    }
+
+    // MARK: Gate
+
+    /// Whether another request may be issued now without breaching the per-minute hard
+    /// cap. Every request-issuing path should consult this so no UI action can bypass
+    /// the limiter.
+    func canMakeRequest() -> Bool {
+        prune()
+        return requestsInLastMinute < hardCapPerMinute
+    }
+
+    // MARK: Recording
+
+    /// Record that a request to `endpoint` was issued (call at issue time). Point-in-time
+    /// endpoints count as one request with zero rows; row-based endpoints also add
+    /// `recordsPerCall` to their category's daily row total.
+    func record(_ endpoint: TornEndpoint) {
+        let now = time.now
+        requestTimestamps.append(now)
+        if endpoint.recordsPerCall > 0 {
+            recordEvents.append((now, endpoint.budget, endpoint.recordsPerCall))
+        }
+        prune()
+    }
+
+    // MARK: Readouts (for Diagnostics, Etap F)
+
+    var requestsInLastMinute: Int { count(requestTimestamps, within: Self.minuteWindow) }
+    var requestsInLastDay: Int { count(requestTimestamps, within: Self.dayWindow) }
+
+    func recordsInLastDay(_ category: TornBudgetCategory) -> Int {
+        let cutoff = time.now.addingTimeInterval(-Self.dayWindow)
+        var total = 0
+        for event in recordEvents where event.category == category && event.at >= cutoff {
+            total += event.count
+        }
+        return total
+    }
+
+    /// Rows/day for every category that has traffic — for the diagnostics readout.
+    func recordsPerDayByCategory() -> [TornBudgetCategory: Int] {
+        var result: [TornBudgetCategory: Int] = [:]
+        for category in TornBudgetCategory.allCases {
+            let rows = recordsInLastDay(category)
+            if rows > 0 { result[category] = rows }
+        }
+        return result
+    }
+
+    /// Whether a category is still comfortably under its daily row budget.
+    func isWithinRecordBudget(_ category: TornBudgetCategory) -> Bool {
+        recordsInLastDay(category) < recordBudgetPerDayPerCategory
+    }
+
+    // MARK: Internals
+
+    private func count(_ times: [Date], within window: TimeInterval) -> Int {
+        let cutoff = time.now.addingTimeInterval(-window)
+        return times.filter { $0 >= cutoff }.count
+    }
+
+    /// Drop entries older than the day window so the arrays stay bounded.
+    private func prune() {
+        let cutoff = time.now.addingTimeInterval(-Self.dayWindow)
+        requestTimestamps.removeAll { $0 < cutoff }
+        recordEvents.removeAll { $0.at < cutoff }
+    }
+}

--- a/MacTorn/MacTorn/ViewModels/AppState.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState.swift
@@ -250,14 +250,22 @@ class AppState {
     /// `defaults`, so tests get isolated dedup state alongside isolated persistence.
     @ObservationIgnored let notificationCoordinator: NotificationCoordinator
 
+    /// Request/record budget accounting (Etap D). Every request-issuing path records
+    /// through it; diagnostics read from it.
+    @ObservationIgnored let pollingCoordinator: PollingCoordinator
+
     /// Chain timeout (seconds remaining) below which the "Chain Expiring!" alert arms.
     static let chainWarningThreshold = 60
 
-    init(session: NetworkSession = URLSession.shared, connectivity: NetworkConnectivity? = nil, defaults: UserDefaults = .standard) {
+    init(session: NetworkSession = URLSession.shared,
+         connectivity: NetworkConnectivity? = nil,
+         defaults: UserDefaults = .standard,
+         time: TimeSource = SystemTimeSource()) {
         self.session = session
         self.connectivity = connectivity ?? NetworkMonitor.shared
         self.defaults = defaults
         self.notificationCoordinator = NotificationCoordinator(defaults: defaults)
+        self.pollingCoordinator = PollingCoordinator(time: time)
 
         // F-01 migration: lift any pre-existing plaintext key out of UserDefaults
         // into the Keychain on first launch of the new build, then clear the
@@ -285,6 +293,14 @@ class AppState {
         loadForumWatch()
         loadFeedbackState()
         loadStocksMetadataFromCache()
+
+        // Etap D: when the network comes back after an outage, refresh once immediately
+        // instead of waiting up to a full refresh interval. `refreshNow` routes through
+        // the same throttled + budget-gated path, so this can't stampede requests. The
+        // callback is only ever invoked on the main actor (NetworkMonitor hops to it).
+        self.connectivity.onConnectivityRestored = { [weak self] in
+            self?.refreshNow()
+        }
         // Polling and permissions moved to onAppear in UI
     }
 
@@ -299,6 +315,7 @@ class AppState {
 
     func fetchStocksMetadata() async {
         guard !apiKey.isEmpty, let url = TornAPI.tornStocksURL(for: apiKey) else { return }
+        recordRequest("torn.stocks")
         do {
             var request = URLRequest(url: url)
             request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
@@ -625,6 +642,7 @@ class AppState {
     private func fetchItemPrice(itemId: Int, save: Bool = true) async {
         guard !apiKey.isEmpty,
               let url = TornAPI.marketURL(itemId: itemId, apiKey: apiKey) else { return }
+        recordRequest("market.item")
 
         logger.info("Fetching price for item \(itemId)")
 
@@ -863,6 +881,7 @@ class AppState {
 
     private func checkThreadForUpdates(threadId: Int) async {
         guard let url = TornAPI.forumThreadURL(threadId: threadId, apiKey: apiKey) else { return }
+        recordRequest("forum.thread")
 
         do {
             var request = URLRequest(url: url)
@@ -935,6 +954,7 @@ class AppState {
 
     private func fetchForumThreadMetadata(threadId: Int) async {
         guard let url = TornAPI.forumThreadURL(threadId: threadId, apiKey: apiKey) else { return }
+        recordRequest("forum.thread")
 
         do {
             var request = URLRequest(url: url)
@@ -1015,7 +1035,15 @@ class AppState {
     func refreshNow() {
         startPolling(force: true)
     }
-    
+
+    /// Record an issued request against the API budget (Etap D). Defensive no-op if the
+    /// id isn't in the registry.
+    private func recordRequest(_ endpointID: String) {
+        if let endpoint = TornEndpointRegistry.endpoint(id: endpointID) {
+            pollingCoordinator.record(endpoint)
+        }
+    }
+
     // MARK: - Fetch Data
     func fetchData() {
         guard connectivity.isConnected else {
@@ -1037,6 +1065,15 @@ class AppState {
             logger.error("Fetch aborted: Invalid URL")
             return
         }
+
+        // Etap D: the request-budget hard cap that no path may bypass. At normal cadence
+        // (~3 requests / 30s) this never trips; it only guards against a pathological
+        // burst (e.g. rapid manual refresh) exceeding the per-minute ceiling.
+        guard pollingCoordinator.canMakeRequest() else {
+            logger.warning("Fetch skipped: per-minute request budget reached")
+            return
+        }
+        recordRequest("user.fast")
 
         isLoading = true
         errorMsg = nil
@@ -1293,6 +1330,7 @@ class AppState {
     // MARK: - Fetch Faction Data
     private func fetchFactionData() async {
         guard let url = TornAPI.factionURL(for: apiKey) else { return }
+        recordRequest("faction.basic")
 
         do {
             var request = URLRequest(url: url)
@@ -1341,6 +1379,7 @@ class AppState {
     // the fast poll handles the live bars/cooldowns/travel data.
     private func fetchActivityData() async {
         guard !apiKey.isEmpty, let url = TornAPI.activityURL(for: apiKey) else { return }
+        // (recorded below, after the throttle guard, so a throttled skip isn't counted)
 
         // Self-throttle: always runs on the first poll (lastActivityFetch == nil), then
         // at most once per activityMinInterval regardless of how fast the main poll ticks.
@@ -1350,6 +1389,7 @@ class AppState {
             return
         }
         lastActivityFetch = Date()
+        recordRequest("user.activity")
 
         do {
             var request = URLRequest(url: url)
@@ -1397,6 +1437,7 @@ class AppState {
     // (~2 KB), so decoding on the main actor is fine — same pattern as fetchFactionData.
     private func fetchUserV2Data() async {
         guard !apiKey.isEmpty, let url = TornAPI.userV2URL(for: apiKey) else { return }
+        recordRequest("user.v2")
 
         do {
             var request = URLRequest(url: url)
@@ -1506,14 +1547,18 @@ class AppState {
         }
         lastFactionV2Fetch = Date()
 
-        if let url = TornAPI.factionRankedWarsURL(for: apiKey),
-           let wars: [RankedWar] = await fetchV2Array(url: url, key: "rankedwars") {
-            self.rankedWars = wars
+        if let url = TornAPI.factionRankedWarsURL(for: apiKey) {
+            recordRequest("faction.rankedwars")
+            if let wars: [RankedWar] = await fetchV2Array(url: url, key: "rankedwars") {
+                self.rankedWars = wars
+            }
         }
 
-        if let url = TornAPI.factionNewsURL(for: apiKey),
-           let news: [FactionNews] = await fetchV2Array(url: url, key: "news") {
-            self.factionNews = news
+        if let url = TornAPI.factionNewsURL(for: apiKey) {
+            recordRequest("faction.news")
+            if let news: [FactionNews] = await fetchV2Array(url: url, key: "news") {
+                self.factionNews = news
+            }
         }
     }
 

--- a/MacTorn/MacTorn/Views/SettingsView.swift
+++ b/MacTorn/MacTorn/Views/SettingsView.swift
@@ -74,7 +74,7 @@ struct SettingsView: View {
                         .frame(width: 20)
                     
                     Picker("Refresh", selection: $appState.refreshInterval) {
-                        Text("15s").tag(15)
+                        Text("15s ⚡︎").tag(15)
                         Text("30s").tag(30)
                         Text("60s").tag(60)
                         Text("2m").tag(120)
@@ -85,6 +85,12 @@ struct SettingsView: View {
                             appState.startPolling()
                         }
                     }
+                }
+                if appState.refreshInterval == 15 {
+                    Text("⚡︎ Aggressive: Torn may return cached data for up to ~30s, so 15s can spend API budget without fresher data. 30s is recommended.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 
                 // Launch at Login

--- a/MacTorn/MacTornTests/Mocks/TestHelpers.swift
+++ b/MacTorn/MacTornTests/Mocks/TestHelpers.swift
@@ -82,6 +82,26 @@ extension XCTestCase {
     }
 }
 
+// MARK: - Connectivity Test Double
+
+/// Controllable connectivity for tests: flip `isConnected` and fire the restore edge
+/// by hand.
+@MainActor
+final class ControllableConnectivity: NetworkConnectivity {
+    var isConnected: Bool
+    var onConnectivityRestored: (() -> Void)?
+
+    init(connected: Bool = true) { isConnected = connected }
+
+    /// Simulate a down→up transition (as `NetworkMonitor` does on a real reconnect).
+    func restore() {
+        isConnected = true
+        onConnectivityRestored?()
+    }
+
+    func goOffline() { isConnected = false }
+}
+
 // MARK: - UserDefaults Test Helpers
 
 extension UserDefaults {

--- a/MacTorn/MacTornTests/ViewModels/AppStatePerformanceTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStatePerformanceTests.swift
@@ -63,4 +63,5 @@ final class AppStatePerformanceTests: XCTestCase {
 /// Test connectivity stub: always claims online so AppState code paths run.
 private final class AlwaysOnlineConnectivity: NetworkConnectivity {
     var isConnected: Bool { true }
+    var onConnectivityRestored: (() -> Void)?
 }

--- a/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
@@ -26,6 +26,42 @@ final class AppStateTests: XCTestCase {
         try await super.tearDown()
     }
 
+    // MARK: - Etap D: request budget wiring + reconnect refresh
+
+    func testFetchRecordsAgainstRequestBudget() {
+        let conn = ControllableConnectivity(connected: true)
+        let app = AppState(session: MockNetworkSession(), connectivity: conn, defaults: .createMockDefaults())
+        app.apiKey = "valid_key"
+        XCTAssertEqual(app.pollingCoordinator.requestsInLastMinute, 0)
+        app.refreshNow()   // fetchData records "user.fast" synchronously before spawning its task
+        XCTAssertGreaterThanOrEqual(app.pollingCoordinator.requestsInLastMinute, 1,
+                                    "a poll must be recorded against the API budget")
+        app.stopPolling()
+    }
+
+    func testReconnectTriggersRefresh() {
+        let conn = ControllableConnectivity(connected: true)
+        let app = AppState(session: MockNetworkSession(), connectivity: conn, defaults: .createMockDefaults())
+        app.apiKey = "valid_key"
+        XCTAssertNotNil(conn.onConnectivityRestored, "AppState wires the reconnect handler")
+
+        let before = app.pollingCoordinator.requestsInLastMinute
+        conn.goOffline()
+        conn.restore()   // down→up edge → refreshNow → fetchData records a request
+        XCTAssertGreaterThan(app.pollingCoordinator.requestsInLastMinute, before,
+                             "a restored connection refreshes immediately")
+        app.stopPolling()
+    }
+
+    func testOfflineFetchRecordsNothing() {
+        let conn = ControllableConnectivity(connected: false)
+        let app = AppState(session: MockNetworkSession(), connectivity: conn, defaults: .createMockDefaults())
+        app.apiKey = "valid_key"
+        app.refreshNow()   // fetchData bails on the connectivity guard before recording
+        XCTAssertEqual(app.pollingCoordinator.requestsInLastMinute, 0)
+        app.stopPolling()
+    }
+
     // MARK: - API Key Validation Tests
 
     func testFetchData_emptyAPIKey() async {

--- a/MacTorn/MacTornTests/ViewModels/PollingCoordinatorTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/PollingCoordinatorTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import MacTorn
+
+/// Etap D — the request/record budget accounting, driven by a fake clock.
+@MainActor
+final class PollingCoordinatorTests: XCTestCase {
+
+    private var clock: MutableTimeSource!
+    private var coord: PollingCoordinator!
+
+    private func endpoint(_ id: String) -> TornEndpoint {
+        TornEndpointRegistry.endpoint(id: id)!
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        clock = MutableTimeSource(Date(timeIntervalSince1970: 1_700_000_000))
+        coord = PollingCoordinator(time: clock, hardCapPerMinute: 60, softTargetPerMinute: 15)
+    }
+
+    // MARK: Request counting
+
+    func testRecordsCountRequestsInLastMinute() {
+        for _ in 0..<5 { coord.record(endpoint("user.fast")) }
+        XCTAssertEqual(coord.requestsInLastMinute, 5)
+        XCTAssertEqual(coord.requestsInLastDay, 5)
+    }
+
+    func testRequestsRollOffAfterAMinute() {
+        for _ in 0..<3 { coord.record(endpoint("user.fast")) }
+        clock.advance(61)
+        XCTAssertEqual(coord.requestsInLastMinute, 0, "older than 60s should roll off the minute window")
+        XCTAssertEqual(coord.requestsInLastDay, 3, "but still within the day window")
+    }
+
+    func testRequestsRollOffAfterADay() {
+        for _ in 0..<3 { coord.record(endpoint("user.fast")) }
+        clock.advance(24 * 60 * 60 + 1)
+        XCTAssertEqual(coord.requestsInLastDay, 0)
+    }
+
+    // MARK: Hard cap gate
+
+    func testCanMakeRequestUntilHardCap() {
+        for _ in 0..<59 { coord.record(endpoint("user.fast")) }
+        XCTAssertTrue(coord.canMakeRequest(), "59 < 60 cap")
+        coord.record(endpoint("user.fast")) // 60th within the minute
+        XCTAssertFalse(coord.canMakeRequest(), "at the cap, no more requests this minute")
+        clock.advance(61)
+        XCTAssertTrue(coord.canMakeRequest(), "cap frees up as the window slides")
+    }
+
+    // MARK: Record (row) budget per category
+
+    func testRowBasedEndpointAccumulatesRecordsInItsCategory() {
+        coord.record(endpoint("user.activity")) // row-based, 25 rows, activity
+        coord.record(endpoint("user.activity"))
+        XCTAssertEqual(coord.recordsInLastDay(.activity), 50)
+    }
+
+    func testPointInTimeEndpointRecordsNoRows() {
+        coord.record(endpoint("user.fast")) // point-in-time
+        XCTAssertEqual(coord.recordsInLastDay(.core), 0)
+        XCTAssertEqual(coord.requestsInLastDay, 1, "still counts as a request")
+    }
+
+    func testRecordsAreKeyedByCategory() {
+        coord.record(endpoint("user.activity"))   // activity, 25
+        coord.record(endpoint("faction.news"))    // faction, 25
+        XCTAssertEqual(coord.recordsInLastDay(.activity), 25)
+        XCTAssertEqual(coord.recordsInLastDay(.faction), 25)
+        XCTAssertEqual(coord.recordsInLastDay(.forum), 0)
+    }
+
+    func testRecordsPerDayByCategoryOnlyReportsTraffic() {
+        coord.record(endpoint("user.activity"))
+        let byCat = coord.recordsPerDayByCategory()
+        XCTAssertEqual(byCat[.activity], 25)
+        XCTAssertNil(byCat[.forum], "categories with no traffic are omitted")
+    }
+
+    func testRecordsRollOffAfterADay() {
+        coord.record(endpoint("user.activity"))
+        clock.advance(24 * 60 * 60 + 1)
+        XCTAssertEqual(coord.recordsInLastDay(.activity), 0)
+    }
+
+    // MARK: Budget headroom
+
+    func testWithinRecordBudget() {
+        let coordTight = PollingCoordinator(time: clock, recordBudgetPerDayPerCategory: 40)
+        coordTight.record(endpoint("user.activity")) // 25
+        XCTAssertTrue(coordTight.isWithinRecordBudget(.activity), "25 < 40")
+        coordTight.record(endpoint("user.activity")) // 50
+        XCTAssertFalse(coordTight.isWithinRecordBudget(.activity), "50 >= 40")
+    }
+
+    /// The real cadence stays far under budget: point-in-time endpoints every 30s is
+    /// ~2/min, nowhere near the 60/min hard cap or the 15/min soft target.
+    func testRealisticCadenceStaysUnderSoftTarget() {
+        // Simulate one fast-poll cycle (user.fast + user.v2 + faction.basic) at t=0.
+        for id in ["user.fast", "user.v2", "faction.basic"] { coord.record(endpoint(id)) }
+        XCTAssertLessThan(coord.requestsInLastMinute, coord.softTargetPerMinute)
+    }
+}


### PR DESCRIPTION
# Etap D — polling budget + reconnect refresh

Second stage of the reliability program (after PR #19 spine + PR #20 CI fix). Makes
MacTorn's API usage **measured and bounded**, and refreshes immediately on reconnect.

## What's in this PR

- **`PollingCoordinator`** — request/record budget accounting keyed off the typed
  `TornEndpoint` registry:
  - rolling **requests/min** + **requests/day**, a conservative **60/min hard cap**
    (`canMakeRequest()`) wired into `fetchData` that no path may bypass;
  - per-category **rows/day** (via `TornEndpoint.recordsPerCall` + budget category),
    with a 15,000/day/category safe target vs Torn's 50,000 hard cap.
  - `record()` is wired at **all 9 request-issuing sites** (fast poll, faction basic,
    v2 user, activity, market, stocks, forum ×2, ranked wars, news).
- **`TimeSource`** — an injectable clock (System/Mutable) so the rolling windows are
  tested deterministically; also the shared clock the upcoming "Next Action" timeline
  (Etap J) will use.
- **Reconnect refresh** — `NetworkConnectivity` gains an `onConnectivityRestored` edge
  that `NetworkMonitor` fires only on a genuine down→up transition; `AppState` refreshes
  once immediately (DoD: *offline → online safe refresh*).
- **Settings** — the `15s` option is now **"15s aggressive"** with a note that Torn may
  serve cached data for ~30s, so 15s can spend budget for no fresher data.

## Results

| Metric | Value |
| --- | --- |
| Unit tests | 308 (was 253 on `main` before the program) |
| New tests this PR | 14 (PollingCoordinator 11, AppState budget/reconnect 3) |
| Failures / flaky | 0 |
| Release build (Universal) | ✅ BUILD SUCCEEDED (x86_64 + arm64) |
| Coverage — `PollingCoordinator.swift` | exercised by 11 tests (CI reports the %) |
| Coverage — `TimeSource.swift` | exercised by the budget-window tests (CI reports the %) |

## Not in this PR (tracked in ISA.md)

- **ISC-17.1 / D-02 — schedule ownership.** Moving the Combine poll timer, adaptive
  cadence and sleep/wake handling out of `AppState` into the coordinator (so it owns the
  *schedule*, not just the accounting) is the high-regression-risk extraction and is
  deferred. The measurable budget/reconnect wins land first, safely.
- The hard-cap gate is applied at the poll-cycle entry (`fetchData`); sub-requests within
  a cycle are accounted but not individually gated (a cycle is the unit).

## Verification
- `PollingCoordinatorTests` drive the budget with a fake clock (roll-off at 60s/24h,
  hard-cap gate, per-category rows, headroom).
- `AppStateTests`: a poll records against the budget; a restored connection refreshes;
  an offline poll records nothing.
