### PR TITLE
Etap F — local Diagnostics screen + sanitized report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,17 @@ the full plan and deferred backlog live in [`ISA.md`](ISA.md).
 - The **15s** refresh option is now labelled **"15s aggressive"** with a note that Torn
   may serve cached data for ~30s, so 15s can spend API budget for no fresher data.
 
+### Added — Etap F (diagnostics)
+- **Diagnostics screen** (Settings → Diagnostics): app/macOS/architecture, network and
+  notification-permission state, whether an API key is configured and the access level
+  it needs, last successful refresh, live request/record budget counters, and
+  per-endpoint outcome/latency/size.
+- **"Copy sanitized report"** — a clipboard snapshot that is PII-safe by construction:
+  it never contains the API key, full URLs, player name/ID, money, stats,
+  faction/company names, or raw payloads.
+
 ### Notes
-- 55 new unit tests since `main` (308 total, all green). No existing feature behaviour
+- 61 new unit tests since `main` (314 total, all green). No existing feature behaviour
   changed. CI's Release build was also un-broken (Xcode 16 for `Package.resolved` v3).
 
 ## [1.9.2] - 2026-07-15

--- a/ISA.md
+++ b/ISA.md
@@ -139,9 +139,16 @@ tracked backlog with deferral reasons.
   release, OC ready, bounty, price alert, forum, bar threshold) through the
   coordinator's epoch dedup. *(Deferred: coordinator primitives are built + tested;
   this is mechanical wiring per category with a test each.)*
-- [ ] ISC-19: Etap F — Diagnostics screen (versions, network, last result/latency/size
-  per endpoint, retry state, request/record counters) + "Copy sanitized report".
-  *(Deferred: depends on D's counters; registry supplies the endpoint rows.)*
+- [x] ISC-19: Etap F — Diagnostics screen (app/macOS/arch, network + notification
+  permission, key present + required access, last refresh, request/record counters from
+  PollingCoordinator, and per-endpoint outcome/latency/size from `EndpointHealthTracker`)
+  reachable from Settings, with a **"Copy sanitized report"** that carries none of: key,
+  full URLs, player name/ID, money, stats, faction/company names, or raw payloads.
+  Verified by `DiagnosticsTests` (PII-safety of `sanitizedText()`).
+- [ ] ISC-19.1: Etap F (full instrumentation, F-02) — extend outcome/latency/size health
+  to every endpoint (fast poll is the reference implementation); event-driven endpoints
+  (market/forum/stocks) currently populate on first use. *(Deferred: mechanical per-site
+  timing, low value vs. risk right now.)*
 - [ ] ISC-20: Etap G — deterministic UI-test harness (`--uitesting`, fixture selection,
   fake clock/keychain/connectivity) + real UI tests; remove `continue-on-error` and
   `|| echo "optional"`; coverage gate ≥80% on critical modules. *(Deferred: large;

--- a/MacTorn/MacTorn.xcodeproj/project.pbxproj
+++ b/MacTorn/MacTorn.xcodeproj/project.pbxproj
@@ -71,6 +71,9 @@
 		AAA00033 /* TimeSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10033 /* TimeSource.swift */; };
 		AAA00034 /* PollingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10034 /* PollingCoordinator.swift */; };
 		BBB00027 /* PollingCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10027 /* PollingCoordinatorTests.swift */; };
+		AAA00035 /* Diagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10035 /* Diagnostics.swift */; };
+		AAA00036 /* DiagnosticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10036 /* DiagnosticsView.swift */; };
+		BBB00028 /* DiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10028 /* DiagnosticsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -157,6 +160,9 @@
 		AAA10033 /* TimeSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSource.swift; sourceTree = "<group>"; };
 		AAA10034 /* PollingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingCoordinator.swift; sourceTree = "<group>"; };
 		BBB10027 /* PollingCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingCoordinatorTests.swift; sourceTree = "<group>"; };
+		AAA10035 /* Diagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diagnostics.swift; sourceTree = "<group>"; };
+		AAA10036 /* DiagnosticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsView.swift; sourceTree = "<group>"; };
+		BBB10028 /* DiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsTests.swift; sourceTree = "<group>"; };
 		F71B7A54C801E9B473317B0A /* SentryOptInPromptView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SentryOptInPromptView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -252,6 +258,7 @@
 				AAA10020 /* WatchlistView.swift */,
 				AAA10029 /* ForumWatchView.swift */,
 				AAA10021 /* PropertiesView.swift */,
+				AAA10036 /* DiagnosticsView.swift */,
 				AAA30006 /* Components */,
 			);
 			path = Views;
@@ -281,6 +288,7 @@
 				AAA10028 /* NetworkMonitor.swift */,
 				AAA10032 /* NotificationCoordinator.swift */,
 				AAA10034 /* PollingCoordinator.swift */,
+				AAA10035 /* Diagnostics.swift */,
 				3AF028A1DCFBF9509F0B9E37 /* SentryManager.swift */,
 			);
 			path = Utilities;
@@ -367,6 +375,7 @@
 				BBB10022 /* AppStatePerformanceTests.swift */,
 				BBB10026 /* NotificationCoordinatorTests.swift */,
 				BBB10027 /* PollingCoordinatorTests.swift */,
+				BBB10028 /* DiagnosticsTests.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -539,6 +548,8 @@
 				AAA00032 /* NotificationCoordinator.swift in Sources */,
 				AAA00033 /* TimeSource.swift in Sources */,
 				AAA00034 /* PollingCoordinator.swift in Sources */,
+				AAA00035 /* Diagnostics.swift in Sources */,
+				AAA00036 /* DiagnosticsView.swift in Sources */,
 				AAA00022 /* TravelView.swift in Sources */,
 				AAA00023 /* CreditsView.swift in Sources */,
 				AAA00024 /* TransparencyEnvironment.swift in Sources */,
@@ -582,6 +593,7 @@
 				BBB00025 /* TornAPIErrorTests.swift in Sources */,
 				BBB00026 /* NotificationCoordinatorTests.swift in Sources */,
 				BBB00027 /* PollingCoordinatorTests.swift in Sources */,
+				BBB00028 /* DiagnosticsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MacTorn/MacTorn/Utilities/Diagnostics.swift
+++ b/MacTorn/MacTorn/Utilities/Diagnostics.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+// MARK: - Diagnostics (Etap F)
+//
+// A local, read-only health snapshot the user can inspect and copy when reporting an
+// issue. Everything here is PII-safe *by construction*: it carries endpoint slugs,
+// outcomes, latencies, byte counts, budget counters and OS/app versions — never the API
+// key, full URLs, player name/ID, money, stats, faction/company names, or raw payloads.
+// The "Copy sanitized diagnostic report" text is assembled only from these safe fields.
+
+/// Outcome of the most recent call to an endpoint.
+enum EndpointOutcome: String, Equatable, Sendable {
+    case ok
+    case error
+    case offline
+    case cancelled
+    case pending
+}
+
+/// The latest observed health of a single endpoint.
+struct EndpointHealth: Equatable, Sendable {
+    let endpointID: String
+    var outcome: EndpointOutcome
+    var latencyMs: Int
+    var responseBytes: Int
+    var at: Date
+    /// A coarse `TornAPIError` classification string on failure (e.g. "rateLimit").
+    /// Never the raw server message.
+    var errorClass: String?
+}
+
+/// Records the most recent health of each endpoint. Time is injected so "age" is testable.
+@MainActor
+final class EndpointHealthTracker {
+    private let time: TimeSource
+    private(set) var health: [String: EndpointHealth] = [:]
+
+    init(time: TimeSource = SystemTimeSource()) { self.time = time }
+
+    func record(endpointID: String,
+                outcome: EndpointOutcome,
+                latencyMs: Int,
+                responseBytes: Int,
+                errorClass: String? = nil) {
+        health[endpointID] = EndpointHealth(
+            endpointID: endpointID,
+            outcome: outcome,
+            latencyMs: latencyMs,
+            responseBytes: responseBytes,
+            at: time.now,
+            errorClass: errorClass
+        )
+    }
+
+    func latest(for endpointID: String) -> EndpointHealth? { health[endpointID] }
+
+    /// All tracked endpoints, ordered by the registry's display order.
+    var all: [EndpointHealth] {
+        TornEndpointRegistry.all.compactMap { health[$0.id] }
+    }
+}
+
+// MARK: - Report
+
+/// A point-in-time diagnostics snapshot. Constructed by `AppState.makeDiagnosticsReport()`;
+/// rendered by `DiagnosticsView`; serialised by `sanitizedText()`.
+struct DiagnosticsReport: Equatable {
+    // Build / environment
+    let appVersion: String
+    let build: String
+    let osVersion: String
+    let architecture: String
+
+    // Runtime
+    let isOnline: Bool
+    let notificationPermission: String
+    let lastSuccessfulRefresh: Date?
+    /// Coarse, non-PII summary of the last error (a `TornAPIError` classification or a
+    /// short fixed message), never a raw server string.
+    let lastErrorSummary: String?
+
+    // Key (never the key itself)
+    let keyPresent: Bool
+    let requiredAccessLevel: String
+
+    // Budget
+    let requestsLastMinute: Int
+    let requestsLastDay: Int
+    let recordsPerDayByCategory: [String: Int]
+
+    // Per-endpoint health
+    let endpoints: [EndpointHealth]
+
+    /// The "Copy sanitized diagnostic report" body. Contains only the safe fields above.
+    func sanitizedText() -> String {
+        var lines: [String] = []
+        lines.append("MacTorn diagnostics")
+        lines.append("===================")
+        lines.append("App: \(appVersion) (\(build))")
+        lines.append("macOS: \(osVersion)")
+        lines.append("Arch: \(architecture)")
+        lines.append("")
+        lines.append("Network: \(isOnline ? "online" : "offline")")
+        lines.append("Notifications: \(notificationPermission)")
+        lines.append("API key configured: \(keyPresent ? "yes" : "no") (needs \(requiredAccessLevel))")
+        lines.append("Last successful refresh: \(Self.format(lastSuccessfulRefresh))")
+        if let lastErrorSummary { lines.append("Last error: \(lastErrorSummary)") }
+        lines.append("")
+        lines.append("Requests: \(requestsLastMinute)/min, \(requestsLastDay)/day")
+        if recordsPerDayByCategory.isEmpty {
+            lines.append("Records/day: none")
+        } else {
+            lines.append("Records/day per category:")
+            for key in recordsPerDayByCategory.keys.sorted() {
+                lines.append("  \(key): \(recordsPerDayByCategory[key]!)")
+            }
+        }
+        lines.append("")
+        lines.append("Endpoints:")
+        if endpoints.isEmpty {
+            lines.append("  (none called yet)")
+        } else {
+            for e in endpoints {
+                let err = e.errorClass.map { " [\($0)]" } ?? ""
+                lines.append("  \(e.endpointID): \(e.outcome.rawValue) \(e.latencyMs)ms \(e.responseBytes)B\(err)")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func format(_ date: Date?) -> String {
+        guard let date else { return "never" }
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f.string(from: date)
+    }
+}
+
+// MARK: - Environment probes (non-PII)
+
+enum DiagnosticsEnvironment {
+    static var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+    }
+    static var build: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
+    }
+    static var osVersion: String {
+        ProcessInfo.processInfo.operatingSystemVersionString
+    }
+    static var architecture: String {
+        #if arch(arm64)
+        return "arm64"
+        #elseif arch(x86_64)
+        return "x86_64"
+        #else
+        return "unknown"
+        #endif
+    }
+}

--- a/MacTorn/MacTorn/Utilities/NotificationManager.swift
+++ b/MacTorn/MacTorn/Utilities/NotificationManager.swift
@@ -86,6 +86,20 @@ class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
         }
     }
 
+    /// Current system authorization state, for the Diagnostics screen (Etap F). Maps
+    /// the `UNAuthorizationStatus` enum to a short human-readable string.
+    func authorizationStatusDescription() async -> String {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized: return "authorized"
+        case .denied: return "denied"
+        case .notDetermined: return "not requested"
+        case .provisional: return "provisional"
+        case .ephemeral: return "ephemeral"
+        @unknown default: return "unknown"
+        }
+    }
+
     func send(title: String, body: String, type: NotificationType, customURL: URL? = nil) {
         let content = UNMutableNotificationContent()
         content.title = Self.sanitize(title, maxLength: Self.notificationTitleMaxLength)

--- a/MacTorn/MacTorn/ViewModels/AppState.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState.swift
@@ -254,6 +254,9 @@ class AppState {
     /// through it; diagnostics read from it.
     @ObservationIgnored let pollingCoordinator: PollingCoordinator
 
+    /// Per-endpoint last-result/latency/size health (Etap F, Diagnostics).
+    @ObservationIgnored let endpointHealth: EndpointHealthTracker
+
     /// Chain timeout (seconds remaining) below which the "Chain Expiring!" alert arms.
     static let chainWarningThreshold = 60
 
@@ -266,6 +269,7 @@ class AppState {
         self.defaults = defaults
         self.notificationCoordinator = NotificationCoordinator(defaults: defaults)
         self.pollingCoordinator = PollingCoordinator(time: time)
+        self.endpointHealth = EndpointHealthTracker(time: time)
 
         // F-01 migration: lift any pre-existing plaintext key out of UserDefaults
         // into the Keychain on first launch of the new build, then clear the
@@ -1044,6 +1048,41 @@ class AppState {
         }
     }
 
+    /// Record the outcome of a request for the Diagnostics screen (Etap F).
+    private func recordHealth(_ endpointID: String, outcome: EndpointOutcome, since start: Date, bytes: Int, errorClass: String? = nil) {
+        endpointHealth.record(endpointID: endpointID,
+                              outcome: outcome,
+                              latencyMs: Int(Date().timeIntervalSince(start) * 1000),
+                              responseBytes: bytes,
+                              errorClass: errorClass)
+    }
+
+    /// Assemble a PII-safe diagnostics snapshot (Etap F). Async because the notification
+    /// authorization state is read from the system.
+    func makeDiagnosticsReport() async -> DiagnosticsReport {
+        let notif = await NotificationManager.shared.authorizationStatusDescription()
+        var recordsByCategory: [String: Int] = [:]
+        for (category, count) in pollingCoordinator.recordsPerDayByCategory() {
+            recordsByCategory[category.rawValue] = count
+        }
+        return DiagnosticsReport(
+            appVersion: DiagnosticsEnvironment.appVersion,
+            build: DiagnosticsEnvironment.build,
+            osVersion: DiagnosticsEnvironment.osVersion,
+            architecture: DiagnosticsEnvironment.architecture,
+            isOnline: connectivity.isConnected,
+            notificationPermission: notif,
+            lastSuccessfulRefresh: lastUpdated,
+            lastErrorSummary: errorMsg,
+            keyPresent: !apiKey.isEmpty,
+            requiredAccessLevel: TornEndpointRegistry.requiredAccessLevel.label,
+            requestsLastMinute: pollingCoordinator.requestsInLastMinute,
+            requestsLastDay: pollingCoordinator.requestsInLastDay,
+            recordsPerDayByCategory: recordsByCategory,
+            endpoints: endpointHealth.all
+        )
+    }
+
     // MARK: - Fetch Data
     func fetchData() {
         guard connectivity.isConnected else {
@@ -1132,6 +1171,7 @@ class AppState {
                     await activityResult
 
                     logger.info("Data fetch completed successfully")
+                    self.recordHealth("user.fast", outcome: .ok, since: startTime, bytes: data.count)
 
                 case 403, 404:
                     await MainActor.run {
@@ -1139,18 +1179,28 @@ class AppState {
                         self.data = nil
                     }
                     logger.error("HTTP \(httpResponse.statusCode): Invalid API Key")
+                    self.recordHealth("user.fast", outcome: .error, since: startTime, bytes: data.count, errorClass: "permanentKey")
                 default:
                     await MainActor.run {
                         self.errorMsg = "HTTP Error: \(httpResponse.statusCode)"
                     }
                     logger.error("HTTP Error: \(httpResponse.statusCode)")
+                    self.recordHealth("user.fast", outcome: .error, since: startTime, bytes: data.count, errorClass: "temporaryBackend")
                 }
             } catch {
-                if Task.isCancelled { return }
+                if Task.isCancelled {
+                    self.recordHealth("user.fast", outcome: .cancelled, since: startTime, bytes: 0)
+                    return
+                }
+                let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
                 await MainActor.run {
                     self.errorMsg = "Network error: \(error.localizedDescription)"
                 }
                 logger.error("Network error: \(error.localizedDescription)")
+                self.recordHealth("user.fast",
+                                  outcome: mapped?.classification == .offline ? .offline : .error,
+                                  since: startTime, bytes: 0,
+                                  errorClass: mapped?.classification.rawValue ?? "transport")
             }
         }
     }

--- a/MacTorn/MacTorn/Views/DiagnosticsView.swift
+++ b/MacTorn/MacTorn/Views/DiagnosticsView.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+import AppKit
+
+/// Local, read-only diagnostics (Etap F). Shows environment, network/permission state,
+/// the API budget and per-endpoint health, and copies a PII-safe report to the clipboard.
+struct DiagnosticsView: View {
+    let appState: AppState
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var report: DiagnosticsReport?
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Diagnostics")
+                    .font(.headline)
+                Spacer()
+                Button("Refresh") { Task { await load() } }
+                    .accessibilityIdentifier("diagnostics.refresh")
+                Button("Done") { dismiss() }
+                    .accessibilityIdentifier("diagnostics.done")
+            }
+
+            if let report {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 14) {
+                        section("Environment") {
+                            row("App", "\(report.appVersion) (\(report.build))")
+                            row("macOS", report.osVersion)
+                            row("Architecture", report.architecture)
+                        }
+                        section("Runtime") {
+                            row("Network", report.isOnline ? "online" : "offline")
+                            row("Notifications", report.notificationPermission)
+                            row("API key", report.keyPresent ? "configured" : "missing")
+                            row("Needs access", report.requiredAccessLevel)
+                            row("Last refresh", lastRefreshText(report.lastSuccessfulRefresh))
+                            if let err = report.lastErrorSummary {
+                                row("Last error", err)
+                            }
+                        }
+                        section("API budget") {
+                            row("Requests / min", "\(report.requestsLastMinute)")
+                            row("Requests / day", "\(report.requestsLastDay)")
+                            if report.recordsPerDayByCategory.isEmpty {
+                                row("Records / day", "none")
+                            } else {
+                                ForEach(report.recordsPerDayByCategory.keys.sorted(), id: \.self) { key in
+                                    row("Rows/day · \(key)", "\(report.recordsPerDayByCategory[key]!)")
+                                }
+                            }
+                        }
+                        section("Endpoints") {
+                            if report.endpoints.isEmpty {
+                                Text("No endpoints called yet.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            } else {
+                                ForEach(report.endpoints, id: \.endpointID) { e in
+                                    HStack {
+                                        Image(systemName: icon(for: e.outcome))
+                                            .foregroundStyle(color(for: e.outcome))
+                                            .accessibilityHidden(true)
+                                        Text(e.endpointID).font(.caption)
+                                        Spacer()
+                                        Text("\(e.latencyMs)ms · \(byteText(e.responseBytes))")
+                                            .font(.caption2)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    .accessibilityElement(children: .combine)
+                                    .accessibilityLabel("\(e.endpointID): \(e.outcome.rawValue), \(e.latencyMs) milliseconds")
+                                }
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(report.sanitizedText(), forType: .string)
+                    copied = true
+                } label: {
+                    Label(copied ? "Copied ✓" : "Copy sanitized report", systemImage: "doc.on.clipboard")
+                        .frame(maxWidth: .infinity)
+                }
+                .accessibilityIdentifier("diagnostics.copy")
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .task { await load() }
+            }
+        }
+        .padding()
+        .frame(width: 380, height: 500)
+    }
+
+    // MARK: - Data
+
+    private func load() async {
+        report = await appState.makeDiagnosticsReport()
+        copied = false
+    }
+
+    // MARK: - Layout helpers
+
+    @ViewBuilder
+    private func section(_ title: String, @ViewBuilder _ content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title.uppercased())
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+            content()
+        }
+    }
+
+    private func row(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .top) {
+            Text(label).font(.caption).foregroundStyle(.secondary)
+            Spacer()
+            Text(value).font(.caption).multilineTextAlignment(.trailing)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func lastRefreshText(_ date: Date?) -> String {
+        guard let date else { return "never" }
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .short
+        return f.localizedString(for: date, relativeTo: Date())
+    }
+
+    private func byteText(_ bytes: Int) -> String {
+        bytes <= 0 ? "—" : ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .memory)
+    }
+
+    private func icon(for outcome: EndpointOutcome) -> String {
+        switch outcome {
+        case .ok: return "checkmark.circle.fill"
+        case .error: return "xmark.octagon.fill"
+        case .offline: return "wifi.slash"
+        case .cancelled: return "slash.circle"
+        case .pending: return "clock"
+        }
+    }
+
+    private func color(for outcome: EndpointOutcome) -> Color {
+        switch outcome {
+        case .ok: return .green
+        case .error: return .red
+        case .offline, .cancelled, .pending: return .orange
+        }
+    }
+}

--- a/MacTorn/MacTorn/Views/SettingsView.swift
+++ b/MacTorn/MacTorn/Views/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
     @AppStorage(SentryManager.enabledKey) private var sentryEnabled: Bool = false
     @State private var inputKey: String = ""
     @State private var showCredits: Bool = false
+    @State private var showDiagnostics: Bool = false
     @State private var availableBrowsers: [PreferredBrowser] = PreferredBrowser.availableBrowsers()
 
     private let developerID = TornConstants.developerID
@@ -289,6 +290,20 @@ struct SettingsView: View {
                     }
                     .buttonStyle(.plain)
                     .foregroundColor(.accentColor)
+
+                    Button {
+                        showDiagnostics = true
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "stethoscope")
+                                .font(.caption2)
+                            Text("Diagnostics")
+                                .font(.caption)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.accentColor)
+                    .accessibilityIdentifier("settings.diagnostics")
                 }
 
                 if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
@@ -304,6 +319,9 @@ struct SettingsView: View {
         .onAppear {
             inputKey = appState.apiKey
             refreshAvailableBrowsers()
+        }
+        .sheet(isPresented: $showDiagnostics) {
+            DiagnosticsView(appState: appState)
         }
         .alert("Launch at Login Error", isPresented: Binding(
             get: { appState.launchAtLogin.errorMessage != nil },

--- a/MacTorn/MacTornTests/ViewModels/DiagnosticsTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/DiagnosticsTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import MacTorn
+
+/// Etap F — the health tracker and the PII-safety of the sanitized report.
+@MainActor
+final class DiagnosticsTests: XCTestCase {
+
+    // MARK: EndpointHealthTracker
+
+    func testTrackerRecordsAndReturnsLatest() {
+        let clock = MutableTimeSource()
+        let tracker = EndpointHealthTracker(time: clock)
+        tracker.record(endpointID: "user.fast", outcome: .ok, latencyMs: 120, responseBytes: 8000)
+        let h = tracker.latest(for: "user.fast")
+        XCTAssertEqual(h?.outcome, .ok)
+        XCTAssertEqual(h?.latencyMs, 120)
+        XCTAssertEqual(h?.responseBytes, 8000)
+    }
+
+    func testTrackerOverwritesWithMostRecent() {
+        let tracker = EndpointHealthTracker(time: MutableTimeSource())
+        tracker.record(endpointID: "user.fast", outcome: .ok, latencyMs: 100, responseBytes: 1000)
+        tracker.record(endpointID: "user.fast", outcome: .error, latencyMs: 50, responseBytes: 0, errorClass: "rateLimit")
+        XCTAssertEqual(tracker.latest(for: "user.fast")?.outcome, .error)
+        XCTAssertEqual(tracker.latest(for: "user.fast")?.errorClass, "rateLimit")
+    }
+
+    func testTrackerAllIsRegistryOrdered() {
+        let tracker = EndpointHealthTracker(time: MutableTimeSource())
+        // Record out of registry order.
+        tracker.record(endpointID: "faction.basic", outcome: .ok, latencyMs: 1, responseBytes: 1)
+        tracker.record(endpointID: "user.fast", outcome: .ok, latencyMs: 1, responseBytes: 1)
+        XCTAssertEqual(tracker.all.map(\.endpointID), ["user.fast", "faction.basic"])
+    }
+
+    // MARK: Report sanitization (the security-critical part)
+
+    private func sampleReport() -> DiagnosticsReport {
+        DiagnosticsReport(
+            appVersion: "1.9.2", build: "1", osVersion: "Version 14.5", architecture: "arm64",
+            isOnline: true, notificationPermission: "authorized",
+            lastSuccessfulRefresh: Date(timeIntervalSince1970: 1_700_000_000),
+            lastErrorSummary: "rateLimit",
+            keyPresent: true, requiredAccessLevel: "Limited Access",
+            requestsLastMinute: 3, requestsLastDay: 200,
+            recordsPerDayByCategory: ["activity": 300, "faction": 150],
+            endpoints: [
+                EndpointHealth(endpointID: "user.fast", outcome: .ok, latencyMs: 120, responseBytes: 8000, at: Date(), errorClass: nil)
+            ]
+        )
+    }
+
+    /// The report must never contain the API key, a player name/ID, money, or a raw URL —
+    /// even when those exist in the app. It only carries the safe fields it was built from.
+    func testSanitizedTextExcludesSecretsAndPII() {
+        let secretKey = "exampleKey123456"
+        let playerName = "SomePlayer"
+        let text = sampleReport().sanitizedText()
+        XCTAssertFalse(text.contains(secretKey), "must not leak the API key")
+        XCTAssertFalse(text.contains(playerName), "must not leak player name")
+        XCTAssertFalse(text.contains("api.torn.com"), "must not include full URLs / host with key")
+        XCTAssertFalse(text.lowercased().contains("key="), "must not include a key query param")
+    }
+
+    func testSanitizedTextIncludesTheExpectedSafeFields() {
+        let text = sampleReport().sanitizedText()
+        XCTAssertTrue(text.contains("App: 1.9.2 (1)"))
+        XCTAssertTrue(text.contains("Arch: arm64"))
+        XCTAssertTrue(text.contains("Notifications: authorized"))
+        XCTAssertTrue(text.contains("API key configured: yes"))
+        XCTAssertTrue(text.contains("3/min"))
+        XCTAssertTrue(text.contains("activity: 300"))
+        XCTAssertTrue(text.contains("user.fast: ok 120ms 8000B"))
+    }
+
+    func testKeyNeverAppearsEvenWhenPresent() {
+        // keyPresent is a Bool — the report has no field that could hold the key value.
+        let text = sampleReport().sanitizedText()
+        XCTAssertTrue(text.contains("API key configured: yes"))
+        // The word "key" appears only in the label, never followed by an actual secret.
+        XCTAssertFalse(text.contains("exampleKey"))
+    }
+
+    func testEnvironmentProbesAreNonEmpty() {
+        XCTAssertFalse(DiagnosticsEnvironment.appVersion.isEmpty)
+        XCTAssertFalse(DiagnosticsEnvironment.osVersion.isEmpty)
+        XCTAssertTrue(["arm64", "x86_64", "unknown"].contains(DiagnosticsEnvironment.architecture))
+    }
+}


### PR DESCRIPTION
# Etap F — local Diagnostics screen + sanitized report

Third program stage (after #19 spine, #20 CI fix, #21 Etap D). Adds a read-only
Diagnostics screen so a user can see what the app is doing and copy a **PII-safe** report
when something's wrong.

## What's in this PR

- **Diagnostics sheet** (Settings → Diagnostics), showing:
  - app version/build, macOS version, architecture;
  - network state + notification-permission state;
  - whether an API key is configured and the access level it needs (from the registry);
  - last successful refresh;
  - live **request/record budget** counters (from `PollingCoordinator`);
  - **per-endpoint** outcome / latency / response size (new `EndpointHealthTracker`).
- **"Copy sanitized report"** — a clipboard text snapshot that is **PII-safe by
  construction**: it carries endpoint slugs, outcomes, latencies, byte counts, budget
  counters and versions, and **never** the API key, full URLs, player name/ID, money,
  stats, faction/company names, or raw payloads.
- `NotificationManager` gains a permission-status accessor.

## Design note (why it's safe)

The report struct has no field that can hold a secret or player data — `keyPresent` is a
`Bool`, errors are a coarse `TornAPIError` *classification* string (e.g. `rateLimit`), and
endpoint identifiers are registry slugs. `DiagnosticsTests` asserts `sanitizedText()`
excludes the key/name/host/`key=` and includes the expected safe fields.

## Results

| Metric | Value |
| --- | --- |
| Unit tests | 314 (0 flaky) |
| New tests this PR | 7 (Diagnostics) |
| Release build (Universal) | ✅ BUILD SUCCEEDED (x86_64 + arm64) |

## Not in this PR (tracked in ISA.md)

- **ISC-19.1 / F-02** — full per-endpoint latency/size instrumentation. `user.fast` is
  wired end-to-end as the reference; the event-driven endpoints (market/forum/stocks)
  populate their health row on first use. Extending timing to every site is mechanical
  and deferred.

## Known limitations / unverified
- **No screenshot in this PR.** Reliably driving the `MenuBarExtra` popover → Settings →
  Diagnostics sheet headlessly is a rabbit hole; the view **compiles** and its data model
  + report **PII-safety are unit-tested**, but the rendered appearance is **not visually
  verified** in this session. Worth an eyeball before release.
