### PR TITLE
Etap B (wiring) — halt polling on a permanent key error (ISC-15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,9 +68,18 @@ the full plan and deferred backlog live in [`ISA.md`](ISA.md).
   with a live countdown, plus the list of what follows. All times come from one shared,
   testable clock. Pick which categories appear in **Settings → Next Action**.
 
+### Fixed — Etap B (stop retrying a dead key)
+- **A bad or paused API key now halts polling** instead of retrying forever. When Torn
+  returns a permanent key/permission error (codes 2 / 16 / 18), MacTorn stops the poll
+  loop, shows the specific message, and stays stopped even when the menu re-opens —
+  until you change the key. Previously it showed "API Error: …" and kept hammering the
+  dead key every cycle. Transient errors (rate limit, backend) are unaffected.
+
 ### Notes
-- 70 new unit tests since `main` (323 total, all green). No existing feature behaviour
-  changed. CI's Release build was also un-broken (Xcode 16 for `Package.resolved` v3).
+- 77 new unit tests since `main` (330 total, all green). The one existing test that
+  encoded the old "keep retrying a dead key" behaviour was updated to the new halt
+  contract; no other feature behaviour changed. CI's Release build was also un-broken
+  (Xcode 16 for `Package.resolved` v3).
 
 ## [1.9.2] - 2026-07-15
 

--- a/ISA.md
+++ b/ISA.md
@@ -118,11 +118,15 @@ tracked backlog with deferral reasons.
 
 **Deferred — backlog (later stages, with reasons):**
 
-- [ ] ISC-15: Etap B/C — wire `TornAPIError` classification into the live fetch paths so
-  a permanent key error stops polling and error 14 pauses only its category.
-  *(Deferred: touches the live polling loop; needs its own regression harness around
-  `AppState.fetchData` to change error handling safely. Typed model + classifier are
-  ready and tested.)*
+- [x] ISC-15: Etap B — `tornAPIError(in:)` classifies the live v1/v2 error envelope; a
+  permanent key/permission error (codes 2/16/18) now **halts polling** (`keyHalted`
+  latch stops auto-restart on MenuBarExtra open) with a clear message, and clears when
+  the key changes. Verified by `AppStateTests` (halt / no-restart / key-change-clears)
+  and `TornAPIErrorTests` (envelope classification).
+- [ ] ISC-15.1: Etap B (category pause for error 14) — pause only the offending row-based
+  category on a daily-row-limit hit while bars/countdowns keep running. *(Deferred: the
+  v1.9.2 fix already keeps categories well under the 50k cap, so this is belt-and-braces;
+  `haltsCategoryOnly` is modelled and tested, wiring the per-category pause is the step.)*
 - [ ] ISC-16: Etap C — key validation/onboarding: call the key-info endpoint, show real
   permissions, disable modules without access, "Test connection". *(Deferred: new UI +
   a new endpoint; the registry already exposes required selections/level for the copy.)*

--- a/MacTorn/MacTorn/Models/TornModels.swift
+++ b/MacTorn/MacTorn/Models/TornModels.swift
@@ -1289,6 +1289,24 @@ func tornAPIErrorMessage(in json: [String: Any]) -> String? {
     return nil
 }
 
+/// Like `tornAPIErrorMessage`, but returns the *classified* error (Etap B) so callers can
+/// react to its kind — halt on a permanent key/permission error (codes 2/16/18), pause a
+/// category on the daily-row-limit (14), back off on transient ones. Returns nil when the
+/// payload is not an error envelope. Recognises both v1 and v2 shapes.
+func tornAPIError(in json: [String: Any]) -> TornAPIError? {
+    // v1 envelope: { "error": { "code": Int, "error": String } }
+    if let nested = json["error"] as? [String: Any] {
+        let code = nested["code"] as? Int ?? 0
+        let message = nested["error"] as? String ?? ""
+        return TornAPIError.classify(code: code, message: message)
+    }
+    // v2 envelope: { "code": Int, "error": String }
+    if let code = json["code"] as? Int, let message = json["error"] as? String {
+        return TornAPIError.classify(code: code, message: message)
+    }
+    return nil
+}
+
 // MARK: - Notification Settings
 struct NotificationRule: Codable, Identifiable, Equatable {
     let id: String

--- a/MacTorn/MacTorn/ViewModels/AppState.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState.swift
@@ -119,8 +119,15 @@ class AppState {
             // SwiftUI's binding lifecycle.
             guard apiKey != oldValue else { return }
             KeychainStore.set(apiKey)
+            // A new key clears any permanent-key halt so polling can resume (Etap B).
+            keyHalted = false
         }
     }
+
+    /// True after a permanent key/permission error (Torn codes 2/16/18) halted polling.
+    /// Blocks auto-restart (e.g. on MenuBarExtra open) until the user changes the key.
+    /// `internal` for `@testable`.
+    var keyHalted: Bool = false
 
     // Was @AppStorage; replaced with stored property + didSet write-through to
     // UserDefaults so @Observable change tracking sees it. Initial value is
@@ -1011,6 +1018,12 @@ class AppState {
 
     // MARK: - Polling
     func startPolling(force: Bool = false) {
+        // A permanently-bad key won't work no matter how often we retry — don't restart
+        // the loop (Etap B). Changing the key clears `keyHalted` and lets polling resume.
+        guard !keyHalted else {
+            logger.warning("startPolling skipped: polling halted on a permanent key error")
+            return
+        }
         // MenuBarExtra fires onAppear on every menu open, so this is called repeatedly.
         // If the timer is already running and we fetched recently (< refreshInterval/2 ago),
         // skip the restart + immediate refetch — it just burns API quota.
@@ -1056,6 +1069,16 @@ class AppState {
         if let endpoint = TornEndpointRegistry.endpoint(id: endpointID) {
             pollingCoordinator.record(endpoint)
         }
+    }
+
+    /// Handle a permanent key/permission error (Etap B): stop the loop, show the user a
+    /// clear message, and latch `keyHalted` so it won't auto-restart until the key changes.
+    func handlePermanentKeyError(_ error: TornAPIError) {
+        keyHalted = true
+        errorMsg = error.userMessage
+        data = nil
+        stopPolling()
+        logger.error("Polling halted on permanent key/permission error (code \(error.tornCode ?? -1))")
     }
 
     /// Record the outcome of a request for the Diagnostics screen (Etap F).
@@ -1227,6 +1250,14 @@ class AppState {
                     // it contains player name, money, stats, attacks, and other PII (and the
                     // request URL with the API key already passed through redacted logging).
                     if let topLevel = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                        // Etap B: Torn returns key/permission errors with HTTP 200 in an
+                        // envelope. A permanent one (codes 2/16/18) must halt polling —
+                        // retrying a dead/paused/under-privileged key forever is pointless.
+                        if let apiError = tornAPIError(in: topLevel), apiError.haltsAllRequests {
+                            self.recordHealth("user.fast", outcome: .error, since: startTime, bytes: data.count, errorClass: apiError.classification.rawValue)
+                            await MainActor.run { self.handlePermanentKeyError(apiError) }
+                            return
+                        }
                         let keys = topLevel.keys.sorted().joined(separator: ",")
                         logger.debug("API response: \(data.count) bytes, keys=[\(keys)]")
                     } else {

--- a/MacTorn/MacTornTests/Models/TornAPIErrorTests.swift
+++ b/MacTorn/MacTornTests/Models/TornAPIErrorTests.swift
@@ -133,4 +133,27 @@ final class TornAPIErrorTests: XCTestCase {
             XCTAssertLessThanOrEqual(policy.delay(attempt: attempt, jitter: 1), policy.cap)
         }
     }
+
+    // MARK: - Envelope classification (tornAPIError)
+
+    func testEnvelopeV2Classifies() {
+        let error = tornAPIError(in: ["code": 2, "error": "Incorrect key"])
+        XCTAssertEqual(error?.classification, .permanentKey)
+        XCTAssertEqual(error?.tornCode, 2)
+    }
+
+    func testEnvelopeV1Classifies() {
+        let error = tornAPIError(in: ["error": ["code": 16, "error": "Access level too low"]])
+        XCTAssertEqual(error?.classification, .insufficientPermissions)
+    }
+
+    func testEnvelopeDailyLimit() {
+        let error = tornAPIError(in: ["code": 14, "error": "Daily read limit reached"])
+        XCTAssertTrue(error!.haltsCategoryOnly)
+        XCTAssertFalse(error!.haltsAllRequests)
+    }
+
+    func testNonEnvelopeReturnsNil() {
+        XCTAssertNil(tornAPIError(in: ["player_id": 123, "name": "Someone", "money": 5000]))
+    }
 }

--- a/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
@@ -62,6 +62,40 @@ final class AppStateTests: XCTestCase {
         app.stopPolling()
     }
 
+    // MARK: - Etap B: permanent key error halts polling (ISC-15)
+
+    func testPermanentKeyErrorHaltsPolling() async throws {
+        let conn = ControllableConnectivity(connected: true)
+        let mock = MockNetworkSession()
+        let app = AppState(session: mock, connectivity: conn, defaults: .createMockDefaults())
+        app.apiKey = "bad_key"
+        try mock.setSuccessResponse(json: ["code": 2, "error": "Incorrect key"]) // HTTP 200 + Torn envelope
+        app.startPolling()
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        XCTAssertTrue(app.keyHalted, "a code-2 error must halt polling")
+        XCTAssertNil(app.data)
+        XCTAssertNotNil(app.errorMsg)
+        app.stopPolling()
+    }
+
+    func testChangingKeyClearsHalt() {
+        let app = AppState(session: MockNetworkSession(), connectivity: ControllableConnectivity(), defaults: .createMockDefaults())
+        app.apiKey = "bad_key"
+        app.keyHalted = true
+        app.apiKey = "fresh_key"   // didSet clears the halt
+        XCTAssertFalse(app.keyHalted)
+    }
+
+    func testHaltedPollingIssuesNoRequests() {
+        let app = AppState(session: MockNetworkSession(), connectivity: ControllableConnectivity(), defaults: .createMockDefaults())
+        app.apiKey = "key"
+        app.keyHalted = true       // set after apiKey (which would otherwise clear it)
+        let before = app.pollingCoordinator.requestsInLastMinute
+        app.startPolling()         // must early-return without issuing a request
+        XCTAssertEqual(app.pollingCoordinator.requestsInLastMinute, before)
+        app.stopPolling()
+    }
+
     // MARK: - API Key Validation Tests
 
     func testFetchData_emptyAPIKey() async {
@@ -409,7 +443,11 @@ final class AppStateTests: XCTestCase {
 
         try await Task.sleep(nanoseconds: 1_000_000_000)
 
-        XCTAssertEqual(appState.errorMsg, "API Error: Incorrect Key")
+        // Etap B: code 2 is a permanent key error — polling now halts and the classified
+        // message surfaces (previously this showed "API Error: Incorrect Key" and kept
+        // retrying a dead key forever).
+        XCTAssertTrue(appState.keyHalted)
+        XCTAssertEqual(appState.errorMsg, "Incorrect Key")
         XCTAssertNil(appState.data)
     }
 


### PR DESCRIPTION
# Etap B (wiring) — halt polling on a permanent key error

Closes the loose end from the reliability spine (#19): the `TornAPIError` taxonomy was
shipped and tested but not yet wired into the live path. It is now. (Program: #19 spine,
#20 CI, #21 D, #22 F, #23 J, this = ISC-15.)

## What's in this PR

- **`tornAPIError(in:)`** — classifies Torn's live v1 (nested) and v2 (sibling) error
  envelopes into a typed `TornAPIError`.
- **Halt on a permanent key/permission error.** When the main user poll returns Torn
  code **2 / 16 / 18** (`haltsAllRequests`), `AppState`:
  - stops the poll loop and shows the specific classified message;
  - **latches `keyHalted`** so `startPolling()` won't auto-restart on the next
    `MenuBarExtra` open — no more hammering a dead key every cycle;
  - clears `keyHalted` when the key changes, so *Save & Connect* resumes polling.
- Transient errors (rate limit code 5, backend) are **unaffected** — they still surface
  as before and keep polling.

## Behaviour change (intentional, tested)

The one existing test that asserted a code-2 error shows `"API Error: Incorrect Key"`
*and keeps retrying* was updated: code 2 now halts and surfaces `"Incorrect Key"`. This
is the DoD item *"błędny klucz zatrzymuje dalsze requesty"*. No other behaviour changed.

## Results

| Metric | Value |
| --- | --- |
| Unit tests | 330 (0 flaky) |
| New tests this PR | 7 (halt / no-restart / key-change-clears + envelope classification) |
| Release build (Universal) | ✅ BUILD SUCCEEDED (x86_64 + arm64) |

## Not in this PR (tracked in ISA.md)
- **ISC-15.1** — pause only the offending row-based category on a daily-row-limit hit
  (code 14) while bars/countdowns keep running. `haltsCategoryOnly` is modelled + tested;
  wiring the per-category pause is deferred (the v1.9.2 split already keeps categories
  well under the 50k/day cap, so this is belt-and-braces).
