### PR TITLE
Etap G (ISC-20): deterministic UI-test harness + hardened CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,25 +34,30 @@ jobs:
             -scheme MacTorn \
             -destination 'platform=macOS' \
             -only-testing:MacTornTests \
-            -resultBundlePath TestResults \
+            -resultBundlePath TestResults.xcresult \
             -enableCodeCoverage YES \
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             | xcpretty --color --report junit
+
+      # ISC-20: reliability-critical modules must stay >= 80% line-covered (views excluded —
+      # they are validated by the UI-test job, not line coverage).
+      - name: Coverage gate (critical modules)
+        run: bash scripts/coverage-gate.sh TestResults.xcresult 80
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results
-          path: TestResults
+          path: TestResults.xcresult
 
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v4
         if: success()
         with:
           name: coverage-report
-          path: TestResults
+          path: TestResults.xcresult
 
   ui-tests:
     name: UI Tests
@@ -78,10 +83,6 @@ jobs:
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             | xcpretty --color
-        # TODO(Etap G): remove continue-on-error once the deterministic UI-test harness
-        # lands so UI tests block merges. Kept non-blocking for now to isolate this
-        # CI-infra fix from the (separate) UI-test hardening work.
-        continue-on-error: true
 
   build:
     name: Build Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,21 @@ the full plan and deferred backlog live in [`ISA.md`](ISA.md).
   with a live countdown, plus the list of what follows. All times come from one shared,
   testable clock. Pick which categories appear in **Settings → Next Action**.
 
+### Added — Etap G (deterministic UI tests + hardened CI)
+- **Hermetic UI-test harness.** Launched with `--uitesting`, the app builds itself from
+  fixtures and test doubles — a URL-routed fake network session, an isolated `UserDefaults`,
+  an in-memory Keychain (so a UI test never touches your real Torn key), and controllable
+  connectivity — and surfaces the menu-bar content in a real window the test runner can
+  drive. Real UI tests now cover onboarding-without-a-key, tab navigation, and invalid-key
+  error surfacing. This is developer-facing only: it is fully DEBUG-gated, so the Release
+  app carries none of the fixture/harness code.
+- **UI tests gate merges.** The CI UI-test job no longer swallows failures
+  (`continue-on-error` removed).
+- **Coverage gate.** CI fails if any reliability-critical module (API error taxonomy,
+  endpoint registry, polling/notification coordinators, Next Action engine) drops below
+  80% line coverage. SwiftUI views are excluded — they're validated by the UI-test suite.
+  Also available locally via `make coverage-gate`.
+
 ### Fixed — Etap B (stop retrying a dead key)
 - **A bad or paused API key now halts polling** instead of retrying forever. When Torn
   returns a permanent key/permission error (codes 2 / 16 / 18), MacTorn stops the poll

--- a/ISA.md
+++ b/ISA.md
@@ -153,10 +153,30 @@ tracked backlog with deferral reasons.
   to every endpoint (fast poll is the reference implementation); event-driven endpoints
   (market/forum/stocks) currently populate on first use. *(Deferred: mechanical per-site
   timing, low value vs. risk right now.)*
-- [ ] ISC-20: Etap G — deterministic UI-test harness (`--uitesting`, fixture selection,
-  fake clock/keychain/connectivity) + real UI tests; remove `continue-on-error` and
-  `|| echo "optional"`; coverage gate ≥80% on critical modules. *(Deferred: large;
-  the UserDefaults injection is the first brick.)*
+- [x] ISC-20: Etap G — deterministic UI-test harness + real UI tests + hardened CI.
+  `--uitesting` builds `AppState` from fixtures/doubles (`FixtureNetworkSession` URL-routed
+  canned JSON, isolated ephemeral `UserDefaults`, in-memory `KeychainStore` override,
+  `UITestConnectivity`) and surfaces the MenuBarExtra content in a real window XCUITest can
+  drive (accessory app promoted to a regular activation policy + explicit `openWindow`). Real
+  UI tests: onboarding-without-key, tab navigation, invalid-key error surfacing (green ×4
+  consecutive runs, deterministic). `continue-on-error` removed from the UI-tests job so it
+  gates merges. Coverage gate (`scripts/coverage-gate.sh`, dependency-free `xccov`) enforces
+  ≥80% line coverage on the reliability-critical modules — currently TornAPIError 99%,
+  TornEndpoint 84%, PollingCoordinator 100%, NotificationCoordinator 100%, NextAction 97% —
+  views excluded by design. All harness/fixture surface is DEBUG-gated (verified: no
+  `TestPlayer`/`FixtureNetworkSession`/launch-arg strings in the Release binary). Verified by
+  `MacTornUITests` (3) + `UITestHarnessTests` (7) + `make coverage-gate`. *(Views not visually
+  verified — logic/interaction only, per the audit's visual caveat.)*
+- [ ] ISC-20.1: Etap G (remaining UI scenarios, fake clock in UI harness) — offline→reconnect
+  and chain-alert-no-duplicates are **not** driven through the UI. *(Deferred: reconnect is
+  already proven by `PollingCoordinatorTests`/AppState reconnect tests, and chain-dedup by the
+  `NotificationCoordinator` regression tests (ISC-11); a MenuBarExtra window can't reliably
+  observe a system notification, so a UI test there would assert nothing new. The UI harness
+  uses the real clock — current UI tests assert no absolute time — while `MutableTimeSource`
+  stays wired for unit tests.)*
+- [ ] ISC-20.2: Etap G (key-validation in the coverage gate) — add the ISC-16 key-info/
+  validation module to `coverage-gate.sh` once Etap C lands. *(Deferred: the module does not
+  exist yet; gating a non-existent file would just fail the build.)*
 - [ ] ISC-21: Etap H — CI overhaul (current Xcode, required UI tests, archive smoke,
   coverage, SwiftLint, entitlements/codesign/lipo checks, Dependabot). *(Deferred:
   CI changes; `SECURITY.md` done.)*
@@ -241,3 +261,8 @@ tracked backlog with deferral reasons.
 - ISC-10,11: `NotificationCoordinatorTests` (12 tests) pass — incl.
   `testChainAlertFiresOnceAcrossManySubThresholdPolls`.
 - ISC-12: `SECURITY.md` present at repo root.
+- ISC-20: `xcodebuild test -only-testing:MacTornUITests` (3 UI tests) green ×4 consecutive
+  runs; `-only-testing:MacTornTests/UITestHarnessTests` (7) green; `bash
+  scripts/coverage-gate.sh TestResults.xcresult 80` → PASSED (critical modules 84–100%);
+  Release Universal build (`arm64`+`x86_64`) succeeds and `strings` shows no fixture/harness
+  surface.

--- a/MacTorn/MacTorn.xcodeproj/project.pbxproj
+++ b/MacTorn/MacTorn.xcodeproj/project.pbxproj
@@ -69,11 +69,13 @@
 		BBB00025 /* TornAPIErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10025 /* TornAPIErrorTests.swift */; };
 		BBB00026 /* NotificationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10026 /* NotificationCoordinatorTests.swift */; };
 		AAA00033 /* TimeSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10033 /* TimeSource.swift */; };
+		AAA00039 /* UITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10039 /* UITestSupport.swift */; };
 		AAA00034 /* PollingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10034 /* PollingCoordinator.swift */; };
 		BBB00027 /* PollingCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10027 /* PollingCoordinatorTests.swift */; };
 		AAA00035 /* Diagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10035 /* Diagnostics.swift */; };
 		AAA00036 /* DiagnosticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10036 /* DiagnosticsView.swift */; };
 		BBB00028 /* DiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10028 /* DiagnosticsTests.swift */; };
+		BBB00030 /* UITestHarnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10030 /* UITestHarnessTests.swift */; };
 		AAA00037 /* NextAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10037 /* NextAction.swift */; };
 		AAA00038 /* NextActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10038 /* NextActionView.swift */; };
 		BBB00029 /* NextActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10029 /* NextActionTests.swift */; };
@@ -161,11 +163,13 @@
 		BBB10025 /* TornAPIErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TornAPIErrorTests.swift; sourceTree = "<group>"; };
 		BBB10026 /* NotificationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCoordinatorTests.swift; sourceTree = "<group>"; };
 		AAA10033 /* TimeSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSource.swift; sourceTree = "<group>"; };
+		AAA10039 /* UITestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestSupport.swift; sourceTree = "<group>"; };
 		AAA10034 /* PollingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingCoordinator.swift; sourceTree = "<group>"; };
 		BBB10027 /* PollingCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingCoordinatorTests.swift; sourceTree = "<group>"; };
 		AAA10035 /* Diagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diagnostics.swift; sourceTree = "<group>"; };
 		AAA10036 /* DiagnosticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsView.swift; sourceTree = "<group>"; };
 		BBB10028 /* DiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsTests.swift; sourceTree = "<group>"; };
+		BBB10030 /* UITestHarnessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestHarnessTests.swift; sourceTree = "<group>"; };
 		AAA10037 /* NextAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextAction.swift; sourceTree = "<group>"; };
 		AAA10038 /* NextActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextActionView.swift; sourceTree = "<group>"; };
 		BBB10029 /* NextActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextActionTests.swift; sourceTree = "<group>"; };
@@ -317,6 +321,7 @@
 			children = (
 				AAA10025 /* TransparencyEnvironment.swift */,
 				AAA10033 /* TimeSource.swift */,
+				AAA10039 /* UITestSupport.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -385,6 +390,7 @@
 				BBB10027 /* PollingCoordinatorTests.swift */,
 				BBB10028 /* DiagnosticsTests.swift */,
 				BBB10029 /* NextActionTests.swift */,
+				BBB10030 /* UITestHarnessTests.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -556,6 +562,7 @@
 				AAA00031 /* TornAPIError.swift in Sources */,
 				AAA00032 /* NotificationCoordinator.swift in Sources */,
 				AAA00033 /* TimeSource.swift in Sources */,
+				AAA00039 /* UITestSupport.swift in Sources */,
 				AAA00034 /* PollingCoordinator.swift in Sources */,
 				AAA00035 /* Diagnostics.swift in Sources */,
 				AAA00036 /* DiagnosticsView.swift in Sources */,
@@ -605,6 +612,7 @@
 				BBB00026 /* NotificationCoordinatorTests.swift in Sources */,
 				BBB00027 /* PollingCoordinatorTests.swift in Sources */,
 				BBB00028 /* DiagnosticsTests.swift in Sources */,
+				BBB00030 /* UITestHarnessTests.swift in Sources */,
 				BBB00029 /* NextActionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MacTorn/MacTorn/Helpers/UITestSupport.swift
+++ b/MacTorn/MacTorn/Helpers/UITestSupport.swift
@@ -1,0 +1,265 @@
+import Foundation
+import SwiftUI
+
+// MARK: - UI-test accessibility identifiers (always compiled? no — DEBUG only)
+
+extension View {
+    /// Applies an accessibility identifier used solely by the UI-test harness. Compiled
+    /// out of Release, so no automation identifiers ship in the production binary while the
+    /// UI tests (built Debug) still see them.
+    @ViewBuilder func uiTestID(_ identifier: String) -> some View {
+        #if DEBUG
+        self.accessibilityIdentifier(identifier)
+        #else
+        self
+        #endif
+    }
+}
+
+// MARK: - UI-test harness (Etap G / ISC-20)
+//
+// A deterministic, hermetic harness for XCUITest runs. The production app never
+// exercises any of this: it only activates when the process is launched with the
+// `--uitesting` argument, which only the UI-test runner passes.
+//
+// Everything that fabricates data or bypasses real I/O is compiled **only in DEBUG**,
+// so no fixture/test surface ships in a Release build. A tiny always-compiled shim
+// (`#else` branch at the bottom) keeps `UITestConfiguration.isActive` referenceable
+// from Release code paths, where it is a constant `false`.
+//
+// When active it wires an `AppState` from fully controllable doubles:
+//   • `FixtureNetworkSession` — serves canned JSON per endpoint, never hits the network.
+//   • an isolated, ephemeral `UserDefaults` suite — a blank slate every run.
+//   • an in-memory Keychain (see `KeychainStore` in AppState.swift) — the real Torn
+//     key on the developer's machine is never read or overwritten by a UI test.
+//   • `UITestConnectivity` — connectivity the test can flip by hand.
+//
+// This is the "first brick" the audit ISA called out: it makes the MenuBarExtra UI
+// drivable and reproducible so real UI tests can gate merges.
+
+#if DEBUG
+
+/// Which canned world the UI test runs against. Selected via `-uitest-fixture <raw>`.
+enum FixtureScenario: String {
+    /// A fully-populated, healthy player (bars, travel home, chain inactive, money…).
+    case full
+    /// The Torn "incorrect key" envelope (code 2) on the fast user call — drives the
+    /// permanent-key halt + error UI without touching the real key.
+    case invalidKey
+    /// Every endpoint returns an empty (but valid) JSON object — used to assert the
+    /// onboarding / empty states render without a decode crash.
+    case empty
+}
+
+enum UITestConfiguration {
+    static let launchArgument = "--uitesting"
+    static let fixtureKey = "-uitest-fixture"   // value: FixtureScenario.rawValue
+    static let apiKeyKey = "-uitest-apikey"     // value: seeded key ("" / absent ⇒ onboarding)
+    static let onlineKey = "-uitest-online"     // value: "1" (default) / "0"
+
+    /// True only when the process was launched with `--uitesting`.
+    static var isActive: Bool {
+        ProcessInfo.processInfo.arguments.contains(launchArgument)
+    }
+
+    /// Reads a `-key value` pair from the launch arguments (nil if absent).
+    private static func argValue(_ key: String) -> String? {
+        let args = ProcessInfo.processInfo.arguments
+        guard let i = args.firstIndex(of: key), i + 1 < args.count else { return nil }
+        return args[i + 1]
+    }
+
+    static var scenario: FixtureScenario {
+        argValue(fixtureKey).flatMap(FixtureScenario.init(rawValue:)) ?? .full
+    }
+
+    /// The API key to seed. Absent or empty ⇒ the app shows onboarding.
+    static var seededAPIKey: String { argValue(apiKeyKey) ?? "" }
+
+    static var startsOnline: Bool { argValue(onlineKey) != "0" }
+
+    /// In-memory Keychain backing store, consulted by `KeychainStore` while a UI test
+    /// runs so the app process never reads or writes the real login Keychain.
+    static var keychainOverride: [String: String] = [:]
+
+    /// Builds the fully-injected `AppState` for a UI-test run. Must run on the main actor
+    /// because `AppState` is `@MainActor`.
+    @MainActor
+    static func makeAppState() -> AppState {
+        // Seed the in-memory Keychain *before* AppState.init reads it.
+        keychainOverride.removeAll()
+        if !seededAPIKey.isEmpty {
+            keychainOverride[KeychainStore.account] = seededAPIKey
+        }
+
+        // Isolated, ephemeral defaults so each run starts from a known blank slate.
+        let suiteName = "com.mactorn.uitests"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let session = FixtureNetworkSession(scenario: scenario)
+        let connectivity = UITestConnectivity(connected: startsOnline)
+
+        return AppState(session: session,
+                        connectivity: connectivity,
+                        defaults: defaults,
+                        time: SystemTimeSource())
+    }
+}
+
+// MARK: - Fixture network session
+
+/// A `NetworkSession` that serves canned JSON per endpoint and never touches the
+/// network. Routing is by URL so the fast user call, faction, and the v2 endpoints
+/// each get an appropriate, decodable body.
+final class FixtureNetworkSession: NetworkSession, @unchecked Sendable {
+    private let scenario: FixtureScenario
+
+    init(scenario: FixtureScenario) { self.scenario = scenario }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let url = request.url
+        let body = Self.body(for: url, scenario: scenario)
+        let response = HTTPURLResponse(url: url ?? URL(string: "https://api.torn.com")!,
+                                       statusCode: 200,
+                                       httpVersion: nil,
+                                       headerFields: nil)!
+        return (body, response)
+    }
+
+    /// Chooses the JSON body for a request URL. Only the fast user call (v1 `/user/`
+    /// with the point-in-time selections, identifiable by the `bars` selection) carries
+    /// the rich fixture; every other endpoint returns an empty—but valid—object, which
+    /// the app's `try?`-guarded overlays decode into "no extra data" cleanly.
+    static func body(for url: URL?, scenario: FixtureScenario) -> Data {
+        let s = url?.absoluteString ?? ""
+        let isFastUser = s.contains("api.torn.com/user/") && s.contains("bars")
+
+        let json: [String: Any]
+        switch (isFastUser, scenario) {
+        case (true, .full):
+            json = fullUserResponse()
+        case (true, .invalidKey):
+            json = invalidKeyEnvelope
+        default:
+            json = [:]
+        }
+        return (try? JSONSerialization.data(withJSONObject: json)) ?? Data("{}".utf8)
+    }
+
+    /// The Torn v1 "incorrect key" envelope (code 2). `AppState` classifies this as a
+    /// permanent key error and halts polling.
+    static let invalidKeyEnvelope: [String: Any] = [
+        "error": ["code": 2, "error": "Incorrect key"]
+    ]
+
+    /// A healthy, fully-populated fast-user response. Mirrors the shape of the unit
+    /// suite's `TornAPIFixtures.validFullResponse()` (kept in sync by construction —
+    /// same keys), with `server_time = now` so live countdowns anchor to the run.
+    static func fullUserResponse() -> [String: Any] { [
+        "name": "TestPlayer",
+        "player_id": 123456,
+        "server_time": Int(Date().timeIntervalSince1970),
+        "energy": ["current": 100, "maximum": 150, "increment": 5, "interval": 300, "ticktime": 60, "fulltime": 600],
+        "nerve": ["current": 50, "maximum": 60, "increment": 1, "interval": 300, "ticktime": 120, "fulltime": 1800],
+        "life": ["current": 7500, "maximum": 7500, "increment": 100, "interval": 300, "ticktime": 0, "fulltime": 0],
+        "happy": ["current": 5000, "maximum": 10000, "increment": 50, "interval": 300, "ticktime": 100, "fulltime": 30000],
+        "cooldowns": ["drug": 0, "medical": 0, "booster": 0],
+        "travel": ["destination": "Torn", "timestamp": 0, "departed": 0, "time_left": 0],
+        "status": ["description": "Okay", "details": "", "state": "Okay", "until": 0],
+        "chain": ["current": 0, "maximum": 10, "timeout": 0, "cooldown": 0],
+        "money_onhand": 1_000_000,
+        "points": 10,
+    ] }
+}
+
+// MARK: - UI-test root view
+
+import AppKit
+
+/// The production app is an accessory (`LSUIElement`), so its `WindowGroup` never
+/// auto-opens a window — leaving XCUITest with nothing to drive. Under the harness this
+/// delegate promotes the app to a regular activation policy *before* launch finishes, so
+/// the window materializes, and activates it so the test runner can see it.
+final class UITestAppDelegate: NSObject, NSApplicationDelegate {
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        guard UITestConfiguration.isActive else { return }
+        NSApp.setActivationPolicy(.regular)
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        guard UITestConfiguration.isActive else { return }
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}
+
+/// Hosts `ContentView` in the UI-test window. Because `SceneBuilder` can't conditionalize
+/// a scene at runtime, the window is always declared (in DEBUG); this view is what makes it
+/// appear *only* under the harness: with `--uitesting` it shows `ContentView` and brings the
+/// window to the front so XCUITest can drive it; otherwise it renders nothing and closes the
+/// window, so a normal Debug launch is unaffected.
+struct UITestRootView: View {
+    let appState: AppState
+    @AppStorage("reduceTransparency") private var reduceTransparency: Bool = false
+
+    var body: some View {
+        Group {
+            if UITestConfiguration.isActive {
+                // No accessibilityIdentifier here: a container-level identifier propagates
+                // to every descendant in AppKit-backed SwiftUI and shadows the per-element
+                // ids the tests rely on. The window itself is the query root instead.
+                ContentView()
+                    .environment(appState)
+                    .environment(\.reduceTransparency, reduceTransparency)
+                    .frame(width: 320, height: 640)
+            } else {
+                EmptyView()
+            }
+        }
+        .background(UITestWindowConfigurator(active: UITestConfiguration.isActive))
+    }
+}
+
+/// Grabs the enclosing `NSWindow` to either front it (UI test) or close it (normal Debug).
+private struct UITestWindowConfigurator: NSViewRepresentable {
+    let active: Bool
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async { [weak view] in
+            guard let window = view?.window else { return }
+            if active {
+                window.setContentSize(NSSize(width: 320, height: 640))
+                window.center()
+                window.makeKeyAndOrderFront(nil)
+                NSApp.activate(ignoringOtherApps: true)
+            } else {
+                window.close()
+            }
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+}
+
+// MARK: - Controllable connectivity
+
+/// Connectivity a UI test can flip by hand (mirrors `ControllableConnectivity` in the
+/// unit test target, but lives in the app target so the launched app process can use it).
+@MainActor
+final class UITestConnectivity: NetworkConnectivity {
+    var isConnected: Bool
+    var onConnectivityRestored: (() -> Void)?
+
+    init(connected: Bool = true) { isConnected = connected }
+}
+
+#else
+
+/// Release shim: the UI-test harness does not exist, so activation is always false.
+enum UITestConfiguration {
+    static var isActive: Bool { false }
+}
+
+#endif

--- a/MacTorn/MacTorn/MacTornApp.swift
+++ b/MacTorn/MacTorn/MacTornApp.swift
@@ -2,15 +2,33 @@ import SwiftUI
 
 @main
 struct MacTornApp: App {
-    @State private var appState = AppState()
+    @State private var appState: AppState
     @AppStorage("appearanceMode") private var appearanceModeRaw: String = AppearanceMode.system.rawValue
     @AppStorage("reduceTransparency") private var reduceTransparency: Bool = false
 
+    #if DEBUG
+    // Promotes the accessory app to a regular window when launched under `--uitesting`,
+    // so the UI-test window actually appears. Inert on any normal launch.
+    @NSApplicationDelegateAdaptor(UITestAppDelegate.self) private var uiTestDelegate
+    #endif
+
     init() {
+        #if DEBUG
+        // Under the UI-test harness, build a hermetic AppState from fixtures/doubles and
+        // skip Sentry (no crash reporter, no network) so runs are deterministic.
+        if UITestConfiguration.isActive {
+            _appState = State(initialValue: UITestConfiguration.makeAppState())
+            return
+        }
+        #endif
         SentryManager.startIfEnabled()
+        _appState = State(initialValue: AppState())
     }
 
     var body: some Scene {
+        #if DEBUG
+        uiTestWindow
+        #endif
         MenuBarExtra {
             ContentView()
                 .environment(appState)
@@ -26,6 +44,24 @@ struct MacTornApp: App {
         }
         .menuBarExtraStyle(.window)
     }
+
+    #if DEBUG
+    // A MenuBarExtra has no ordinary window, so XCUITest cannot see or drive its content.
+    // Under the UI-test harness, surface the exact same ContentView in a real window the
+    // test runner can query. Otherwise fall back to an inert `Settings` scene, which never
+    // auto-opens a window — so a normal Debug launch is unaffected. Production ships
+    // MenuBarExtra only (this whole scene is `#if DEBUG`).
+    //
+    // Note: `SceneBuilder` does not support runtime `if`/`else` (only `#available`), so the
+    // window cannot be conditionalized at the scene level — it is always present in DEBUG.
+    // `UITestRootView` gates its content on `UITestConfiguration.isActive` and closes this
+    // window on a normal (non-UI-test) Debug launch, so it is invisible outside UI tests.
+    private var uiTestWindow: some Scene {
+        WindowGroup(id: "uitest-window") {
+            UITestRootView(appState: appState)
+        }
+    }
+    #endif
 
     private func updateAppearance() {
         let mode = AppearanceMode(rawValue: appearanceModeRaw) ?? .system
@@ -48,6 +84,10 @@ struct MenuBarLabel: View {
     // types, but @Bindable keeps the call-site identical to before.
     @Bindable var appState: AppState
 
+    #if DEBUG
+    @Environment(\.openWindow) private var openWindow
+    #endif
+
     var body: some View {
         Group {
             switch appState.menuBarDisplay {
@@ -66,6 +106,16 @@ struct MenuBarLabel: View {
             }
         }
         .transaction { $0.animation = nil }
+        #if DEBUG
+        // The menu-bar label renders at launch even for an accessory app, so it's the one
+        // reliable place to explicitly open the UI-test window (a MenuBarExtra's own content
+        // only appears on click, which XCUITest can't trigger). Inert on a normal launch.
+        .onAppear {
+            if UITestConfiguration.isActive {
+                openWindow(id: "uitest-window")
+            }
+        }
+        #endif
     }
 
     private var menuBarIcon: String {

--- a/MacTorn/MacTorn/ViewModels/AppState.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState.swift
@@ -35,6 +35,12 @@ enum KeychainStore {
     }
 
     static func get() -> String? {
+        #if DEBUG
+        // Under the UI-test harness, the app runs as a separate process without the
+        // XCTest env var, so the real login Keychain would be hit. Route through an
+        // in-memory store instead so a UI test never reads a developer's real key.
+        if UITestConfiguration.isActive { return UITestConfiguration.keychainOverride[account] }
+        #endif
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -57,6 +63,12 @@ enum KeychainStore {
             delete()
             return
         }
+        #if DEBUG
+        if UITestConfiguration.isActive {
+            UITestConfiguration.keychainOverride[account] = value
+            return
+        }
+        #endif
         guard let data = value.data(using: .utf8) else { return }
         let baseQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -81,6 +93,12 @@ enum KeychainStore {
     }
 
     static func delete() {
+        #if DEBUG
+        if UITestConfiguration.isActive {
+            UITestConfiguration.keychainOverride[account] = nil
+            return
+        }
+        #endif
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,

--- a/MacTorn/MacTorn/Views/ContentView.swift
+++ b/MacTorn/MacTorn/Views/ContentView.swift
@@ -95,6 +95,9 @@ struct ContentView: View {
             checkSentryOptInPrompt()
         }
         .task {
+            // Skip system-permission prompts and the update-check network call under the
+            // UI-test harness so runs stay hermetic and no modal steals focus.
+            guard !UITestConfiguration.isActive else { return }
             await NotificationManager.shared.requestPermission()
             appState.checkForAppUpdates()
         }
@@ -135,6 +138,7 @@ struct ContentView: View {
                 }
                 .buttonStyle(.plain)
                 .foregroundColor(currentTab == tab ? .accentColor : .secondary)
+                .uiTestID("uitest.tab.\(tab.rawValue)")
             }
         }
         .padding(.horizontal, 8)
@@ -144,6 +148,14 @@ struct ContentView: View {
     // MARK: - Tab Content
     @ViewBuilder
     private var tabContent: some View {
+        tabContentBody
+            // A single element whose identifier tracks the active tab, so a UI test can
+            // assert navigation actually switched content (Etap G).
+            .uiTestID("uitest.tabContent.\(currentTab.rawValue)")
+    }
+
+    @ViewBuilder
+    private var tabContentBody: some View {
         switch currentTab {
         case .status:
             StatusView()
@@ -194,6 +206,7 @@ struct ContentView: View {
     }
     
     private func checkSentryOptInPrompt() {
+        guard !UITestConfiguration.isActive else { return }
         guard !appState.apiKey.isEmpty else { return }
         let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
         let shownFor = UserDefaults.standard.string(forKey: SentryManager.promptShownKey) ?? ""

--- a/MacTorn/MacTorn/Views/SettingsView.swift
+++ b/MacTorn/MacTorn/Views/SettingsView.swift
@@ -47,6 +47,7 @@ struct SettingsView: View {
             VStack(spacing: 8) {
                 SecureField("Torn API Key", text: $inputKey)
                     .textFieldStyle(.roundedBorder)
+                    .uiTestID("uitest.apiKeyField")
 
                 Button("Save & Connect") {
                     appState.apiKey = inputKey.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -54,6 +55,7 @@ struct SettingsView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .disabled(inputKey.isEmpty)
+                .uiTestID("uitest.saveKey")
 
                 Link("Get API Key from Torn",
                      destination: URL(string: "https://www.torn.com/preferences.php#tab=api")!)

--- a/MacTorn/MacTorn/Views/StatusView.swift
+++ b/MacTorn/MacTorn/Views/StatusView.swift
@@ -140,6 +140,8 @@ struct StatusView: View {
                 .foregroundColor(.secondary)
         }
         .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+        .uiTestID("uitest.error")
     }
     
     // MARK: - Travel

--- a/MacTorn/MacTornTests/ViewModels/UITestHarnessTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/UITestHarnessTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import MacTorn
+
+/// Unit coverage for the deterministic UI-test harness (Etap G / ISC-20). The XCUITest
+/// suite proves the harness end-to-end; these pin its pure routing/decoding contract so a
+/// regression is caught in milliseconds without launching the app.
+#if DEBUG
+final class UITestHarnessTests: XCTestCase {
+
+    private let fakeKey = "sample-harness-value"
+
+    // MARK: - Fixture routing
+
+    func testFullScenarioServesDecodableUserResponse() throws {
+        let url = TornAPI.url(for: fakeKey)
+        let data = FixtureNetworkSession.body(for: url, scenario: .full)
+
+        let decoded = try JSONDecoder().decode(TornResponse.self, from: data)
+        XCTAssertEqual(decoded.name, "TestPlayer")
+        XCTAssertNotNil(decoded.bars, "The full fixture should populate bars")
+    }
+
+    func testInvalidKeyScenarioServesErrorEnvelope() throws {
+        let url = TornAPI.url(for: fakeKey)
+        let data = FixtureNetworkSession.body(for: url, scenario: .invalidKey)
+
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let error = try XCTUnwrap(json["error"] as? [String: Any])
+        XCTAssertEqual(error["code"] as? Int, 2, "Invalid-key fixture must carry Torn code 2")
+    }
+
+    func testEmptyScenarioServesEmptyObject() throws {
+        let url = TornAPI.url(for: fakeKey)
+        let data = FixtureNetworkSession.body(for: url, scenario: .empty)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(json?.isEmpty, true, "Empty scenario should serve {}")
+    }
+
+    /// Only the fast user call (which carries the `bars` selection) gets the rich fixture;
+    /// the faction call must not be mistaken for it.
+    func testFactionEndpointServesEmptyObjectEvenInFullScenario() throws {
+        let url = TornAPI.factionURL(for: fakeKey)
+        let data = FixtureNetworkSession.body(for: url, scenario: .full)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(json?.isEmpty, true, "Faction endpoint should not receive the user fixture")
+    }
+
+    /// The row-based activity call also hits the `/user/` path but without `bars`; it must
+    /// not be served the fast-user fixture (which would double-count / mis-decode).
+    func testUserActivityCallIsNotServedFastFixture() throws {
+        let url = TornAPI.activityURL(for: fakeKey)
+        let data = FixtureNetworkSession.body(for: url, scenario: .full)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(json?.isEmpty, true, "Activity call must not get the fast-user fixture")
+    }
+
+    func testNilURLDoesNotCrashAndServesEmpty() {
+        let data = FixtureNetworkSession.body(for: nil, scenario: .full)
+        XCTAssertFalse(data.isEmpty, "A nil URL should still yield a valid (empty-object) body")
+    }
+
+    // MARK: - Scenario parsing
+
+    func testFixtureScenarioRawValues() {
+        XCTAssertEqual(FixtureScenario(rawValue: "full"), .full)
+        XCTAssertEqual(FixtureScenario(rawValue: "invalidKey"), .invalidKey)
+        XCTAssertEqual(FixtureScenario(rawValue: "empty"), .empty)
+        XCTAssertNil(FixtureScenario(rawValue: "nonsense"))
+    }
+}
+#endif

--- a/MacTorn/MacTornUITests/MacTornUITests.swift
+++ b/MacTorn/MacTornUITests/MacTornUITests.swift
@@ -1,45 +1,88 @@
 import XCTest
 
+/// Deterministic UI tests (Etap G / ISC-20).
+///
+/// Every launch is hermetic: the app runs under `--uitesting`, which wires it from
+/// fixtures + test doubles (see `UITestSupport.swift`) — no real network, Keychain, or
+/// notifications. The MenuBarExtra content is surfaced in a real window the runner drives.
 final class MacTornUITests: XCTestCase {
-
-    var app: XCUIApplication!
 
     override func setUpWithError() throws {
         continueAfterFailure = false
+    }
 
-        app = XCUIApplication()
-        // Reset state for each test
-        app.launchArguments = ["--uitesting"]
+    // MARK: - Launch helper
+
+    /// Launches the app under the harness with a chosen fixture and optional seeded key.
+    private func launch(fixture: String, apiKey: String? = nil,
+                        online: Bool = true) -> XCUIApplication {
+        let app = XCUIApplication()
+        var args = ["--uitesting", "-uitest-fixture", fixture,
+                    "-uitest-online", online ? "1" : "0"]
+        if let apiKey { args += ["-uitest-apikey", apiKey] }
+        app.launchArguments = args
         app.launch()
+        return app
     }
 
-    override func tearDownWithError() throws {
-        app = nil
+    /// The single UI-test window. Waits for it so tests don't race the launch.
+    private func window(_ app: XCUIApplication) -> XCUIElement {
+        let win = app.windows.firstMatch
+        XCTAssertTrue(win.waitForExistence(timeout: 15), "UI-test window never appeared")
+        return win
     }
 
-    // MARK: - Performance Tests
+    // MARK: - Onboarding
 
-    func testLaunchPerformance() throws {
-        if #available(macOS 10.15, *) {
-            measure(metrics: [XCTApplicationLaunchMetric()]) {
-                XCUIApplication().launch()
-            }
-        }
-    }
-}
+    /// With no API key, the app must present onboarding (the key entry), not the tabs.
+    func testOnboardingWithoutKeyShowsKeyEntry() throws {
+        let app = launch(fixture: "empty", apiKey: nil)
+        _ = window(app)
 
-// MARK: - UI Test Helpers
+        let keyField = app.descendants(matching: .any)["uitest.apiKeyField"]
+        XCTAssertTrue(keyField.waitForExistence(timeout: 10),
+                      "API-key field should be shown when no key is configured")
 
-extension XCUIElement {
-    /// Wait for element to appear within the given timeout
-    func waitForAppearance(timeout: TimeInterval = 5) -> Bool {
-        return self.waitForExistence(timeout: timeout)
+        // The tab bar belongs to the signed-in UI and must be absent during onboarding.
+        XCTAssertFalse(app.buttons["uitest.tab.Status"].exists,
+                       "Tabs must not be shown before a key is entered")
     }
 
-    /// Tap if element exists
-    func tapIfExists() {
-        if self.exists {
-            self.tap()
-        }
+    // MARK: - Navigation
+
+    /// With a key + a healthy fixture, tapping a tab switches the visible content.
+    func testTabNavigationSwitchesContent() throws {
+        let app = launch(fixture: "full", apiKey: "sample-full-user")
+        _ = window(app)
+
+        let statusTab = app.buttons["uitest.tab.Status"]
+        XCTAssertTrue(statusTab.waitForExistence(timeout: 10), "Status tab should exist")
+
+        // Status content is the default.
+        XCTAssertTrue(app.descendants(matching: .any)["uitest.tabContent.Status"].waitForExistence(timeout: 10),
+                      "Status content should be shown by default")
+
+        // Switch to Watchlist and assert the content element tracks the new tab.
+        app.buttons["uitest.tab.Watchlist"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["uitest.tabContent.Watchlist"].waitForExistence(timeout: 10),
+                      "Watchlist content should be shown after tapping the Watchlist tab")
+
+        // And back to Money.
+        app.buttons["uitest.tab.Money"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["uitest.tabContent.Money"].waitForExistence(timeout: 10),
+                      "Money content should be shown after tapping the Money tab")
+    }
+
+    // MARK: - Error surfacing
+
+    /// A permanent key error (Torn code 2) must surface an error in the UI, not silently
+    /// leave the user on a blank screen.
+    func testInvalidKeySurfacesError() throws {
+        let app = launch(fixture: "invalidKey", apiKey: "sample-bad-user")
+        _ = window(app)
+
+        let error = app.descendants(matching: .any)["uitest.error"]
+        XCTAssertTrue(error.waitForExistence(timeout: 15),
+                      "An invalid key should surface a visible error message")
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # MacTorn Makefile
 # Run tests and build commands for local development
 
-.PHONY: test test-unit test-ui build clean coverage help release release-signed hooks scan
+.PHONY: test test-unit test-ui build clean coverage coverage-gate help release release-signed hooks scan
 
 # Default target
 help:
@@ -14,6 +14,7 @@ help:
 	@echo "  make release-signed  - Build Release signed with Developer ID (set DEVELOPER_ID)"
 	@echo "  make clean           - Clean build artifacts"
 	@echo "  make coverage        - Run tests with code coverage"
+	@echo "  make coverage-gate   - Enforce >=80% coverage on critical modules"
 	@echo "  make hooks           - Install the gitleaks pre-commit secret scan"
 	@echo "  make scan            - Scan full git history for secrets"
 	@echo ""
@@ -123,12 +124,27 @@ coverage:
 		-scheme MacTorn \
 		-destination 'platform=macOS' \
 		-enableCodeCoverage YES \
-		-resultBundlePath TestResults \
+		-resultBundlePath TestResults.xcresult \
 		CODE_SIGN_IDENTITY="-" \
 		CODE_SIGNING_REQUIRED=NO
 	@echo ""
-	@echo "Coverage report generated in TestResults/"
-	@echo "Open TestResults/action.xccovreport to view in Xcode"
+	@echo "Coverage report generated in TestResults.xcresult"
+	@echo "Open TestResults.xcresult to view in Xcode"
+
+# Enforce >=80% line coverage on reliability-critical modules (Etap G / ISC-20).
+# Runs the unit suite with coverage, then the gate. Views are intentionally excluded.
+coverage-gate:
+	rm -rf TestResults.xcresult
+	xcodebuild test \
+		-project MacTorn/MacTorn.xcodeproj \
+		-scheme MacTorn \
+		-destination 'platform=macOS' \
+		-only-testing:MacTornTests \
+		-resultBundlePath TestResults.xcresult \
+		-enableCodeCoverage YES \
+		CODE_SIGN_IDENTITY="-" \
+		CODE_SIGNING_REQUIRED=NO
+	bash scripts/coverage-gate.sh TestResults.xcresult 80
 
 # Quick test - faster iteration
 quick-test:

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# coverage-gate.sh — fail if any critical module's line coverage drops below a threshold.
+#
+# Etap G / ISC-20: the reliability-critical, pure modules must stay well-tested. This gate
+# is deliberately scoped to those modules — NOT to SwiftUI views (which are validated by the
+# UI-test suite, not line coverage) — so it protects correctness without penalising view code.
+#
+# Usage: scripts/coverage-gate.sh <path-to-.xcresult> [threshold]
+#   threshold defaults to 80 (percent).
+#
+# Requires: xcrun xccov (Xcode). No external dependencies (no jq).
+
+set -euo pipefail
+
+RESULT_BUNDLE="${1:?usage: coverage-gate.sh <path-to-.xcresult> [threshold]}"
+THRESHOLD="${2:-80}"
+TARGET="MacTorn.app"
+
+# Reliability-critical modules gated at >= THRESHOLD. Matched by basename so the check is
+# path-agnostic. Add the key-validation module here when Etap C (ISC-16) lands.
+CRITICAL_FILES=(
+  "TornAPIError.swift"
+  "TornEndpoint.swift"
+  "PollingCoordinator.swift"
+  "NotificationCoordinator.swift"
+  "NextAction.swift"
+)
+
+if [[ ! -e "$RESULT_BUNDLE" ]]; then
+  echo "coverage-gate: result bundle not found: $RESULT_BUNDLE" >&2
+  exit 2
+fi
+
+REPORT="$(xcrun xccov view --report --files-for-target "$TARGET" "$RESULT_BUNDLE" 2>/dev/null)"
+if [[ -z "$REPORT" ]]; then
+  echo "coverage-gate: no coverage report for target $TARGET (was -enableCodeCoverage YES set?)" >&2
+  exit 2
+fi
+
+echo "Coverage gate: requiring >= ${THRESHOLD}% line coverage on critical modules"
+echo "-------------------------------------------------------------------------"
+
+failed=0
+for file in "${CRITICAL_FILES[@]}"; do
+  # Grab the report line for this file and pull the first "NN.NN%" token from it.
+  line="$(grep -F "/$file " <<<"$REPORT" | head -1 || true)"
+  if [[ -z "$line" ]]; then
+    echo "MISSING  $file — not present in coverage report" >&2
+    failed=1
+    continue
+  fi
+
+  pct="$(grep -oE '[0-9]+\.[0-9]+%' <<<"$line" | head -1 | tr -d '%')"
+  if [[ -z "$pct" ]]; then
+    echo "MISSING  $file — could not parse coverage from: $line" >&2
+    failed=1
+    continue
+  fi
+
+  # Compare as floats via awk (bash can't do decimals).
+  if awk "BEGIN { exit !($pct < $THRESHOLD) }"; then
+    printf 'FAIL     %-32s %6s%% (< %s%%)\n' "$file" "$pct" "$THRESHOLD"
+    failed=1
+  else
+    printf 'ok       %-32s %6s%%\n' "$file" "$pct"
+  fi
+done
+
+echo "-------------------------------------------------------------------------"
+if [[ "$failed" -ne 0 ]]; then
+  echo "coverage-gate: FAILED — a critical module is below ${THRESHOLD}% coverage." >&2
+  exit 1
+fi
+echo "coverage-gate: PASSED"


### PR DESCRIPTION
## Summary

Etap G of the reliability & product audit — a **deterministic, hermetic UI-test harness**, real UI tests that gate merges, and a **coverage gate** on the reliability-critical modules. System-of-record: [`ISA.md`](ISA.md) ISC-20.

A `MenuBarExtra` app has no ordinary window, so XCUITest can't drive it. Under `--uitesting` the app now builds itself from fixtures + test doubles and surfaces the exact same `ContentView` in a real window the runner can query.

## What's in it

**Harness (`Helpers/UITestSupport.swift`, all DEBUG-gated)**
- `UITestConfiguration` — launch-arg parser (`--uitesting`, `-uitest-fixture`, `-uitest-apikey`, `-uitest-online`) that wires `AppState` from doubles.
- `FixtureNetworkSession` — URL-routed canned JSON (`full` / `invalidKey` / `empty`); only the fast-user call gets the rich fixture, everything else a benign `{}`.
- Isolated ephemeral `UserDefaults`, in-memory `KeychainStore` override (**a UI test never reads/writes the real Torn key**), `UITestConnectivity`.
- The accessory app is promoted to a regular activation policy and the window opened explicitly (`openWindow` from the always-rendered menu-bar label), then fronted.
- `.uiTestID()` applies accessibility identifiers only in DEBUG.

**App wiring** — under the harness, Sentry / notification-permission / update-check are suppressed so runs are hermetic and no modal steals focus.

**Tests**
- UI (`MacTornUITests`): onboarding-without-key, tab navigation, invalid-key error surfacing. Green ×4 consecutive local runs.
- Unit (`UITestHarnessTests`, 7): fixture routing + scenario parsing.

**CI (`.github/workflows/tests.yml`)**
- `continue-on-error` removed from the UI-tests job → it gates merges.
- New coverage gate (`scripts/coverage-gate.sh`, dependency-free `xccov`): fails if any critical module < 80%. Current: TornAPIError 99%, TornEndpoint 84%, PollingCoordinator 100%, NotificationCoordinator 100%, NextAction 97%. **Views excluded by design** (validated by the UI suite). Also `make coverage-gate`.

## Safety / constraints held
- **Read-only**, official API only — unchanged.
- All harness/fixture code is `#if DEBUG`. Verified: the Release Universal binary (`arm64`+`x86_64`) contains no `TestPlayer` / `FixtureNetworkSession` / launch-arg strings. (Two benign `uitest.tabContent.` accessibility-identifier fragments from a string interpolation remain — no PII, no fixture data.)
- Keychain / App Sandbox / Hardened Runtime / Sentry opt-in / URL redaction / macOS 14+ untouched.
- 338 unit tests green; no existing behaviour changed.

## Deferred (recorded in ISA as sub-ISCs)
- **ISC-20.1** — offline→reconnect and chain-alert-no-duplicates are **not** driven through the UI (already proven by `PollingCoordinator`/`NotificationCoordinator` unit + regression tests; a menu-bar window can't reliably observe a system notification). UI harness uses the real clock; `MutableTimeSource` stays wired for unit tests.
- **ISC-20.2** — add the key-validation module (ISC-16 / Etap C) to the coverage gate once it exists.

## Visual caveat
New/changed views were validated by logic + interaction (XCUITest), **not** visually — MenuBarExtra can't be screenshotted headless. Eyeball in Xcode before release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic UI testing for onboarding, tab navigation, and invalid API-key errors.
  * Added accessibility identifiers to key controls and error messages.
  * Added coverage gating requiring at least 80% coverage for critical modules.

* **Bug Fixes**
  * UI test failures now correctly block the CI workflow instead of being ignored.

* **Documentation**
  * Updated release documentation and verification records for the new testing and coverage safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->