### PR TITLE
Etap C (ISC-16): key validation & onboarding (Test Connection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,16 @@ the full plan and deferred backlog live in [`ISA.md`](ISA.md).
   80% line coverage. SwiftUI views are excluded — they're validated by the UI-test suite.
   Also available locally via `make coverage-gate`.
 
+### Added — Etap C (key validation & onboarding)
+- **Test Connection.** Onboarding (Settings) gains a "Test Connection" button that checks
+  your API key against Torn's official key-info endpoint and tells you exactly what it
+  unlocks: your access type (e.g. Full Access), your player ID, and — if the key is Limited
+  or Custom — precisely which features won't load. No more guessing why a tab is empty.
+- **Clearer data & privacy disclosure.** The "API Data Usage & Privacy" section now states
+  the required access level, that your key is stored in the macOS Keychain (never plaintext),
+  that all Torn data stays on your Mac, that crash reporting is opt-in, and lists the exact
+  selections requested — generated from the app's endpoint registry so it can't drift.
+
 ### Fixed — Etap B (stop retrying a dead key)
 - **A bad or paused API key now halts polling** instead of retrying forever. When Torn
   returns a permanent key/permission error (codes 2 / 16 / 18), MacTorn stops the poll

--- a/ISA.md
+++ b/ISA.md
@@ -127,9 +127,27 @@ tracked backlog with deferral reasons.
   category on a daily-row-limit hit while bars/countdowns keep running. *(Deferred: the
   v1.9.2 fix already keeps categories well under the 50k cap, so this is belt-and-braces;
   `haltsCategoryOnly` is modelled and tested, wiring the per-category pause is the step.)*
-- [ ] ISC-16: Etap C — key validation/onboarding: call the key-info endpoint, show real
-  permissions, disable modules without access, "Test connection". *(Deferred: new UI +
-  a new endpoint; the registry already exposes required selections/level for the copy.)*
+- [x] ISC-16: Etap C — key validation/onboarding. Calls the official Torn v2 `/key/info`
+  endpoint (shape verified against the live OpenAPI spec, not guessed) via
+  `TornAPI.keyInfoURL` + a `key.info` registry entry. `TornKeyInfo` decodes access
+  level/type, the owner's IDs, and the per-category available selections; `KeyValidator`
+  maps that to per-endpoint availability using the registry as the source of truth.
+  `AppState.validateKey()` fetches + classifies errors through `TornAPIError` (PII-free
+  messages). SettingsView gains a **"Test Connection"** button whose result panel shows the
+  real access type + player ID and, when the key is limited/Custom, exactly which features
+  won't load. The API disclosure now states the required access level, that the key lives in
+  the Keychain, that all data stays local, that Sentry is opt-in, and lists the requested
+  selections **from the registry** (no hand-maintained drift) + the ToS link. Verified by
+  `KeyValidationTests` (11: decode / validator / `validateKey` success+error+empty+reset) and
+  the `testTestConnectionReportsAccess` UI test. *(Result panel not visually verified — logic
+  + interaction only.)*
+- [ ] ISC-16.1: Etap C (hard module gating) — the validation result *names* the blocked
+  modules with a clear explanation, but tabs are not hard-removed/disabled from the bar.
+  *(Deferred by choice: gating must be fail-open — a user may never run Test Connection, and
+  key-info can be briefly unavailable — so hiding tabs on absent/stale key-info risks hiding
+  features that actually work. The app already degrades gracefully (unavailable endpoints
+  error-handle to empty state); the explicit "these won't load" list is the safe first step.
+  Per-tab access banners driven by `keyInfo` are the natural follow-up.)*
 - [x] ISC-17: Etap D (budget + reconnect) — `PollingCoordinator` measures requests/min,
   requests/day and rows/day/category against the registry, with a 60/min hard-cap gate
   (`canMakeRequest()`) wired into `fetchData` and `record()` at all 9 request sites; a
@@ -261,6 +279,11 @@ tracked backlog with deferral reasons.
 - ISC-10,11: `NotificationCoordinatorTests` (12 tests) pass — incl.
   `testChainAlertFiresOnceAcrossManySubThresholdPolls`.
 - ISC-12: `SECURITY.md` present at repo root.
+- ISC-16: `KeyValidationTests` (11) green — model decode against the verified `/key/info`
+  schema, `KeyValidator` availability (full/Custom-missing-selection/empty-faction/
+  parameterized), and `AppState.validateKey` (success / error-envelope / empty / key-change
+  reset); `testTestConnectionReportsAccess` UI test green; registry contract still holds
+  (`TornEndpointTests`, 11 endpoints incl. `key.info`).
 - ISC-20: `xcodebuild test -only-testing:MacTornUITests` (3 UI tests) green ×4 consecutive
   runs; `-only-testing:MacTornTests/UITestHarnessTests` (7) green; `bash
   scripts/coverage-gate.sh TestResults.xcresult 80` → PASSED (critical modules 84–100%);

--- a/MacTorn/MacTorn.xcodeproj/project.pbxproj
+++ b/MacTorn/MacTorn.xcodeproj/project.pbxproj
@@ -64,8 +64,10 @@
 		CCC00001 /* MacTornUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC10001 /* MacTornUITests.swift */; };
 		AAA00030 /* TornEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10030 /* TornEndpoint.swift */; };
 		AAA00031 /* TornAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10031 /* TornAPIError.swift */; };
+		AAA00040 /* TornKeyInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10040 /* TornKeyInfo.swift */; };
 		AAA00032 /* NotificationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10032 /* NotificationCoordinator.swift */; };
 		BBB00024 /* TornEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10024 /* TornEndpointTests.swift */; };
+		BBB00031 /* KeyValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10031 /* KeyValidationTests.swift */; };
 		BBB00025 /* TornAPIErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10025 /* TornAPIErrorTests.swift */; };
 		BBB00026 /* NotificationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10026 /* NotificationCoordinatorTests.swift */; };
 		AAA00033 /* TimeSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10033 /* TimeSource.swift */; };
@@ -158,8 +160,10 @@
 		CCC10001 /* MacTornUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacTornUITests.swift; sourceTree = "<group>"; };
 		AAA10030 /* TornEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TornEndpoint.swift; sourceTree = "<group>"; };
 		AAA10031 /* TornAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TornAPIError.swift; sourceTree = "<group>"; };
+		AAA10040 /* TornKeyInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TornKeyInfo.swift; sourceTree = "<group>"; };
 		AAA10032 /* NotificationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCoordinator.swift; sourceTree = "<group>"; };
 		BBB10024 /* TornEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TornEndpointTests.swift; sourceTree = "<group>"; };
+		BBB10031 /* KeyValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValidationTests.swift; sourceTree = "<group>"; };
 		BBB10025 /* TornAPIErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TornAPIErrorTests.swift; sourceTree = "<group>"; };
 		BBB10026 /* NotificationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCoordinatorTests.swift; sourceTree = "<group>"; };
 		AAA10033 /* TimeSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSource.swift; sourceTree = "<group>"; };
@@ -312,6 +316,7 @@
 				AAA10022 /* NetworkSession.swift */,
 				AAA10030 /* TornEndpoint.swift */,
 				AAA10031 /* TornAPIError.swift */,
+				AAA10040 /* TornKeyInfo.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -372,6 +377,7 @@
 				BBB10020 /* StockMetadataTests.swift */,
 				BBB10023 /* UserV2ModelsTests.swift */,
 				BBB10024 /* TornEndpointTests.swift */,
+				BBB10031 /* KeyValidationTests.swift */,
 				BBB10025 /* TornAPIErrorTests.swift */,
 			);
 			path = Models;
@@ -560,6 +566,7 @@
 				AAA00021 /* NetworkSession.swift in Sources */,
 				AAA00030 /* TornEndpoint.swift in Sources */,
 				AAA00031 /* TornAPIError.swift in Sources */,
+				AAA00040 /* TornKeyInfo.swift in Sources */,
 				AAA00032 /* NotificationCoordinator.swift in Sources */,
 				AAA00033 /* TimeSource.swift in Sources */,
 				AAA00039 /* UITestSupport.swift in Sources */,
@@ -608,6 +615,7 @@
 				BBB00021 /* AppStateStocksMetadataTests.swift in Sources */,
 				BBB00022 /* AppStatePerformanceTests.swift in Sources */,
 				BBB00024 /* TornEndpointTests.swift in Sources */,
+				BBB00031 /* KeyValidationTests.swift in Sources */,
 				BBB00025 /* TornAPIErrorTests.swift in Sources */,
 				BBB00026 /* NotificationCoordinatorTests.swift in Sources */,
 				BBB00027 /* PollingCoordinatorTests.swift in Sources */,

--- a/MacTorn/MacTorn/Helpers/UITestSupport.swift
+++ b/MacTorn/MacTorn/Helpers/UITestSupport.swift
@@ -134,18 +134,47 @@ final class FixtureNetworkSession: NetworkSession, @unchecked Sendable {
     static func body(for url: URL?, scenario: FixtureScenario) -> Data {
         let s = url?.absoluteString ?? ""
         let isFastUser = s.contains("api.torn.com/user/") && s.contains("bars")
+        let isKeyInfo = s.contains("/key/info")
 
         let json: [String: Any]
-        switch (isFastUser, scenario) {
-        case (true, .full):
+        switch (isKeyInfo, isFastUser, scenario) {
+        case (true, _, .invalidKey):
+            json = invalidKeyEnvelope
+        case (true, _, _):
+            json = keyInfoResponse()
+        case (_, true, .full):
             json = fullUserResponse()
-        case (true, .invalidKey):
+        case (_, true, .invalidKey):
             json = invalidKeyEnvelope
         default:
             json = [:]
         }
         return (try? JSONSerialization.data(withJSONObject: json)) ?? Data("{}".utf8)
     }
+
+    /// A full-access `/key/info` response granting every selection MacTorn requests, so
+    /// Test Connection reports all features available. Shape matches the verified
+    /// `KeyInfoResponse` schema.
+    static func keyInfoResponse() -> [String: Any] { [
+        "info": [
+            "access": ["level": 4, "type": "Full Access", "faction": true, "company": false,
+                       "log": ["custom_permissions": false, "available": []]],
+            "user": ["id": 123456, "faction_id": 6789, "company_id": NSNull()],
+            "selections": [
+                "user": ["basic", "bars", "cooldowns", "travel", "profile", "money",
+                         "battlestats", "properties", "stocks", "organizedcrime", "refills",
+                         "education", "bounties", "events", "messages", "attacks"],
+                "faction": ["basic", "chain"],
+                "market": ["itemmarket", "bazaar"],
+                "property": [],
+                "torn": ["stocks"],
+                "racing": [],
+                "forum": [],
+                "key": ["info"],
+                "company": [],
+            ],
+        ],
+    ] }
 
     /// The Torn v1 "incorrect key" envelope (code 2). `AppState` classifies this as a
     /// permanent key error and halts polling.

--- a/MacTorn/MacTorn/Models/TornModels.swift
+++ b/MacTorn/MacTorn/Models/TornModels.swift
@@ -1215,6 +1215,13 @@ enum TornAPI {
               query: ["selections": userV2Selections, "key": apiKey])
     }
 
+    /// Official key-info endpoint (Etap C). Returns the key's access level/type, the
+    /// owner's IDs, and the per-category selections the key can read — the authoritative
+    /// source for onboarding validation. Called on demand only (never polled).
+    static func keyInfoURL(for apiKey: String) -> URL? {
+        build("https://api.torn.com/v2/key/info", query: ["key": apiKey])
+    }
+
     /// Ranked wars use a dedicated v2 path (the combined `?selections=rankedwars,news`
     /// call returns code 21 because `news` requires a `cat` parameter).
     static func factionRankedWarsURL(for apiKey: String) -> URL? {

--- a/MacTorn/MacTorn/Networking/TornEndpoint.swift
+++ b/MacTorn/MacTorn/Networking/TornEndpoint.swift
@@ -323,6 +323,23 @@ enum TornEndpointRegistry {
             budget: .forum,
             critical: false
         ),
+        TornEndpoint(
+            id: "key.info",
+            name: "Key info",
+            version: .v2,
+            path: "https://api.torn.com/v2/key/info",
+            selections: [],
+            extraQuery: [:],
+            minimumAccessLevel: .publicOnly,
+            purpose: "One-off validation of the API key: its access level/type, the owner's ID, and which selections it can read — used by onboarding's Test Connection. Never polled.",
+            cadence: "On demand (Test Connection / key change)",
+            dataShape: .pointInTime,
+            recordLimit: nil,
+            sendsLimitQuery: false,
+            cachePolicy: .none,
+            budget: .core,
+            critical: false
+        ),
     ]
 
     static func endpoint(id: String) -> TornEndpoint? {

--- a/MacTorn/MacTorn/Networking/TornKeyInfo.swift
+++ b/MacTorn/MacTorn/Networking/TornKeyInfo.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+// MARK: - Key info (Etap C / ISC-16)
+//
+// Decodes the official Torn v2 `/key/info` endpoint — the ONLY authoritative source of
+// what a key can actually access. Shape verified against the live OpenAPI spec
+// (`https://www.torn.com/swagger/openapi.json`, `KeyInfoResponse`) on 2026-07-15:
+//
+//   { "info": {
+//       "access":     { "level": Int, "type": String, "faction": Bool, "company": Bool,
+//                       "log": { "custom_permissions": Bool, "available": [...] } },
+//       "user":       { "id": Int, "faction_id": Int?, "company_id": Int? },
+//       "selections": { "user": [String], "faction": [String], "market": [String],
+//                       "property": [String], "torn": [String], "racing": [String],
+//                       "forum": [String], "key": [String], "company": [String] } } }
+//
+// `access.type` is one of: "Custom", "Public Only", "Minimal Access", "Limited Access",
+// "Full Access". A Custom key grants a hand-picked subset, so gating is driven by the
+// per-category `selections` arrays (authoritative), NOT by `access.level` — a Custom key
+// can, e.g., expose `bars` without `battlestats`.
+
+/// The `info` object from `/key/info`. Only the fields MacTorn needs are modelled; the
+/// `access.log` block is intentionally omitted (MacTorn reads no log categories).
+struct TornKeyInfo: Decodable, Equatable, Sendable {
+    let access: Access
+    let user: User
+    let selections: Selections
+
+    struct Access: Decodable, Equatable, Sendable {
+        let level: Int
+        /// Raw Torn access-type label, shown verbatim to the user.
+        let type: String
+        let faction: Bool
+        let company: Bool
+    }
+
+    struct User: Decodable, Equatable, Sendable {
+        /// The key owner's own Torn ID. Shown to the user to confirm the right key;
+        /// treated as PII — never logged, committed, or put in a diagnostics report.
+        let id: Int
+        let factionId: Int?
+        let companyId: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case factionId = "faction_id"
+            case companyId = "company_id"
+        }
+    }
+
+    /// Per-category lists of the selection names this key can read.
+    struct Selections: Decodable, Equatable, Sendable {
+        let user: [String]
+        let faction: [String]
+        let market: [String]
+        let property: [String]
+        let torn: [String]
+        let racing: [String]
+        let forum: [String]
+        let key: [String]
+        let company: [String]
+
+        /// The available selection names for a given key-info category.
+        func names(for category: TornKeyInfo.Category) -> [String] {
+            switch category {
+            case .user: return user
+            case .faction: return faction
+            case .market: return market
+            case .property: return property
+            case .torn: return torn
+            case .racing: return racing
+            case .forum: return forum
+            case .key: return key
+            case .company: return company
+            }
+        }
+    }
+
+    /// The `selections` sub-object categories in `/key/info`.
+    enum Category: String, CaseIterable, Sendable {
+        case user, faction, market, property, torn, racing, forum, key, company
+    }
+
+    /// The wire wrapper: `/key/info` nests everything under `info`.
+    struct Response: Decodable, Equatable, Sendable {
+        let info: TornKeyInfo
+    }
+}
+
+// MARK: - Validation result
+
+/// Whether one registered endpoint is reachable with the validated key, and if not, why.
+struct EndpointAvailability: Equatable, Sendable, Identifiable {
+    var id: String { endpointID }
+    let endpointID: String
+    let name: String
+    let critical: Bool
+    let available: Bool
+    /// Selection names the endpoint needs that the key lacks (empty when available).
+    let missingSelections: [String]
+}
+
+/// The outcome of a successful `/key/info` call, ready for the onboarding UI.
+struct KeyValidationResult: Equatable, Sendable {
+    let accessType: String
+    let accessLevel: Int
+    /// PII — display only; never logged or reported.
+    let playerID: Int
+    let inFaction: Bool
+    let availability: [EndpointAvailability]
+
+    var allCriticalAvailable: Bool {
+        availability.filter(\.critical).allSatisfy(\.available)
+    }
+
+    var unavailableCount: Int {
+        availability.filter { !$0.available }.count
+    }
+}
+
+/// UI state for the onboarding "Test Connection" flow. `failure` carries an
+/// already-sanitized, user-facing message (from `TornAPIError.userMessage`), never a raw
+/// payload.
+enum KeyValidationState: Equatable, Sendable {
+    case idle
+    case validating
+    case success(KeyValidationResult)
+    case failure(String)
+}
+
+// MARK: - KeyValidator
+
+/// Pure mapping from a decoded `TornKeyInfo` to per-endpoint availability, using the
+/// endpoint registry as the source of truth for what each feature needs.
+enum KeyValidator {
+
+    /// Maps a registered endpoint to its `/key/info` selections category.
+    static func category(for endpoint: TornEndpoint) -> TornKeyInfo.Category {
+        let path = endpoint.path
+        if path.contains("/faction") { return .faction }
+        if path.contains("/market") { return .market }
+        if path.contains("/forum") { return .forum }
+        if path.contains("/torn") { return .torn }
+        // Both the v1 `/user/` fast+activity calls and the v2 `/user` call.
+        return .user
+    }
+
+    /// Availability of a single endpoint under a validated key. Endpoints that take no
+    /// `selections` parameter (parameterized v2 market/forum paths) are considered
+    /// available for any valid key — their access isn't expressed via key-info selections.
+    static func availability(of endpoint: TornEndpoint, given info: TornKeyInfo) -> EndpointAvailability {
+        let required = endpoint.selections
+        let missing: [String]
+        if required.isEmpty {
+            missing = []
+        } else {
+            let granted = Set(info.selections.names(for: category(for: endpoint)))
+            missing = required.filter { !granted.contains($0) }
+        }
+        return EndpointAvailability(endpointID: endpoint.id,
+                                    name: endpoint.name,
+                                    critical: endpoint.critical,
+                                    available: missing.isEmpty,
+                                    missingSelections: missing)
+    }
+
+    /// Full validation result across every registered endpoint.
+    static func validate(_ info: TornKeyInfo,
+                         endpoints: [TornEndpoint] = TornEndpointRegistry.all) -> KeyValidationResult {
+        KeyValidationResult(
+            accessType: info.access.type,
+            accessLevel: info.access.level,
+            playerID: info.user.id,
+            inFaction: info.user.factionId != nil,
+            availability: endpoints.map { availability(of: $0, given: info) }
+        )
+    }
+}

--- a/MacTorn/MacTorn/ViewModels/AppState.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState.swift
@@ -1113,8 +1113,11 @@ class AppState {
     /// On success, publishes the real access level/type, the owner's id, and per-endpoint
     /// availability so onboarding can show exactly what the key unlocks and disable the
     /// modules it can't serve. All error paths surface a sanitized, PII-free message.
-    func validateKey() async {
-        let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    /// - Parameter keyOverride: validate this key instead of the saved `apiKey` (used by
+    ///   onboarding's Test Connection, so it can check a just-typed key without persisting
+    ///   it — persisting would flip the view off the Settings screen before the result shows).
+    func validateKey(_ keyOverride: String? = nil) async {
+        let trimmed = (keyOverride ?? apiKey).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             keyValidation = .failure("Enter your Torn API key first.")
             return

--- a/MacTorn/MacTorn/ViewModels/AppState.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState.swift
@@ -139,6 +139,9 @@ class AppState {
             KeychainStore.set(apiKey)
             // A new key clears any permanent-key halt so polling can resume (Etap B).
             keyHalted = false
+            // A new key invalidates any prior validation result (Etap C).
+            keyValidation = .idle
+            keyInfo = nil
         }
     }
 
@@ -146,6 +149,13 @@ class AppState {
     /// Blocks auto-restart (e.g. on MenuBarExtra open) until the user changes the key.
     /// `internal` for `@testable`.
     var keyHalted: Bool = false
+
+    // MARK: - Key validation (Etap C, ISC-16)
+    /// Onboarding "Test Connection" state. Drives the SettingsView result panel.
+    var keyValidation: KeyValidationState = .idle
+    /// The last successfully-decoded key info. `nil` until validated / after a key change.
+    /// PII (player id) lives here for display only — never logged or put in a report.
+    var keyInfo: TornKeyInfo?
 
     // Was @AppStorage; replaced with stored property + didSet write-through to
     // UserDefaults so @Observable change tracking sees it. Initial value is
@@ -1097,6 +1107,75 @@ class AppState {
         data = nil
         stopPolling()
         logger.error("Polling halted on permanent key/permission error (code \(error.tornCode ?? -1))")
+    }
+
+    /// Validate the current API key against the official `/key/info` endpoint (Etap C).
+    /// On success, publishes the real access level/type, the owner's id, and per-endpoint
+    /// availability so onboarding can show exactly what the key unlocks and disable the
+    /// modules it can't serve. All error paths surface a sanitized, PII-free message.
+    func validateKey() async {
+        let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            keyValidation = .failure("Enter your Torn API key first.")
+            return
+        }
+        guard connectivity.isConnected else {
+            keyValidation = .failure(TornAPIError.offline.userMessage)
+            return
+        }
+        guard let url = TornAPI.keyInfoURL(for: trimmed) else {
+            keyValidation = .failure("Could not build the key-info request.")
+            return
+        }
+
+        keyValidation = .validating
+        recordRequest("key.info")
+        let startTime = Date()
+        logger.info("Validating key via key-info: \(tornRedactedURL(url))")
+
+        do {
+            var request = URLRequest(url: url)
+            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+            let (data, response) = try await session.data(for: request)
+
+            guard let http = response as? HTTPURLResponse else { throw APIError.invalidResponse }
+
+            // Torn returns HTTP 200 even on errors — check the envelope before decoding.
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let apiError = tornAPIError(in: json) {
+                recordHealth("key.info", outcome: .error, since: startTime, bytes: data.count,
+                             errorClass: apiError.classification.rawValue)
+                keyValidation = .failure(apiError.userMessage)
+                return
+            }
+
+            guard http.statusCode == 200 else {
+                recordHealth("key.info", outcome: .error, since: startTime, bytes: data.count,
+                             errorClass: "temporaryBackend")
+                keyValidation = .failure("Torn returned HTTP \(http.statusCode). Please try again.")
+                return
+            }
+
+            let decoded = try JSONDecoder().decode(TornKeyInfo.Response.self, from: data)
+            self.keyInfo = decoded.info
+            self.keyValidation = .success(KeyValidator.validate(decoded.info))
+            recordHealth("key.info", outcome: .ok, since: startTime, bytes: data.count)
+            logger.info("Key validated: access level \(decoded.info.access.level)")
+        } catch {
+            if Task.isCancelled {
+                recordHealth("key.info", outcome: .cancelled, since: startTime, bytes: 0)
+                return
+            }
+            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
+            let message = mapped?.userMessage
+                ?? "Couldn't read Torn's response. Please try again."
+            keyValidation = .failure(message)
+            recordHealth("key.info",
+                         outcome: mapped?.classification == .offline ? .offline : .error,
+                         since: startTime, bytes: 0,
+                         errorClass: mapped?.classification.rawValue ?? "malformedResponse")
+            logger.error("Key validation failed: \(String(describing: type(of: error)))")
+        }
     }
 
     /// Record the outcome of a request for the Diagnostics screen (Etap F).

--- a/MacTorn/MacTorn/Views/ContentView.swift
+++ b/MacTorn/MacTorn/Views/ContentView.swift
@@ -190,6 +190,7 @@ struct ContentView: View {
                 }
                 .buttonStyle(.plain)
                 .foregroundColor(.secondary)
+                .uiTestID("uitest.openSettings")
             }
             
             Spacer()

--- a/MacTorn/MacTorn/Views/SettingsView.swift
+++ b/MacTorn/MacTorn/Views/SettingsView.swift
@@ -57,6 +57,27 @@ struct SettingsView: View {
                 .disabled(inputKey.isEmpty)
                 .uiTestID("uitest.saveKey")
 
+                Button {
+                    let typed = inputKey.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !typed.isEmpty { appState.apiKey = typed }
+                    Task { await appState.validateKey() }
+                } label: {
+                    if appState.keyValidation == .validating {
+                        HStack(spacing: 6) {
+                            ProgressView().controlSize(.small)
+                            Text("Testing…")
+                        }
+                    } else {
+                        Text("Test Connection")
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(appState.keyValidation == .validating
+                          || (inputKey.isEmpty && appState.apiKey.isEmpty))
+                .uiTestID("uitest.testConnection")
+
+                keyValidationResult
+
                 Link("Get API Key from Torn",
                      destination: URL(string: "https://www.torn.com/preferences.php#tab=api")!)
                     .font(.caption)
@@ -383,20 +404,67 @@ struct SettingsView: View {
         .padding(.horizontal)
     }
 
+    // MARK: - Key validation result (Etap C, ISC-16)
+    @ViewBuilder
+    private var keyValidationResult: some View {
+        switch appState.keyValidation {
+        case .idle, .validating:
+            EmptyView()
+        case .success(let result):
+            let blocked = result.availability.filter { !$0.available }
+            VStack(alignment: .leading, spacing: 4) {
+                Label("\(result.accessType) · ID \(result.playerID)",
+                      systemImage: "checkmark.seal.fill")
+                    .font(.caption.bold())
+                    .foregroundStyle(.green)
+                if blocked.isEmpty {
+                    Text("All MacTorn features are available with this key.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Limited by your key — these features won't load:")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    ForEach(blocked) { item in
+                        Text("• \(item.name)")
+                            .font(.caption2)
+                            .foregroundStyle(.orange)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .uiTestID("uitest.keyValidationSuccess")
+        case .failure(let message):
+            Label(message, systemImage: "xmark.octagon.fill")
+                .font(.caption)
+                .foregroundStyle(.red)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .uiTestID("uitest.keyValidationFailure")
+        }
+    }
+
     private var apiUsageDisclosure: some View {
         DisclosureGroup {
             VStack(alignment: .leading, spacing: 8) {
-                ForEach(apiSelections, id: \.selection) { item in
-                    HStack(alignment: .top) {
-                        Text(item.selection)
-                            .font(.caption.monospaced())
-                            .frame(width: 60, alignment: .leading)
-                            .foregroundColor(.accentColor)
-                        Text(item.purpose)
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
+                disclosureLine("key.fill",
+                               "Requires a Torn key with at least **\(TornEndpointRegistry.requiredAccessLevel.label)** for every feature. Lower access still works — modules your key can't read are shown after Test Connection.")
+                disclosureLine("lock.fill",
+                               "Your key is stored in the macOS **Keychain**, never in plaintext preferences.")
+                disclosureLine("desktopcomputer",
+                               "All Torn data stays **on this Mac**. MacTorn is read-only — it never takes any action on your account.")
+                disclosureLine("exclamationmark.shield",
+                               "Crash reporting (Sentry) is **opt-in** and off by default; no Torn data is sent.")
+
+                Divider()
+
+                Text("Selections requested (from the app's endpoint registry):")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(TornEndpointRegistry.allSelections.joined(separator: ", "))
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(Color.accentColor)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 Divider()
 
@@ -409,26 +477,26 @@ struct SettingsView: View {
             HStack(spacing: 4) {
                 Image(systemName: "doc.text")
                     .foregroundColor(.secondary)
-                Text("API Data Usage")
+                Text("API Data Usage & Privacy")
                     .font(.caption.bold())
             }
         }
         .padding(.horizontal)
     }
 
-    private var apiSelections: [(selection: String, purpose: String)] {
-        [
-            ("basic", "Player name, ID, basic info"),
-            ("bars", "Energy, Nerve, Happy, Life bars"),
-            ("cooldowns", "Drug, Medical, Booster cooldowns"),
-            ("travel", "Travel status and destination"),
-            ("profile", "Battle stats, faction info"),
-            ("events", "Recent events feed"),
-            ("messages", "Unread message count"),
-            ("market", "Item watchlist prices"),
-            ("forum", "Forum thread monitoring")
-        ]
+    private func disclosureLine(_ icon: String, _ markdown: String) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: icon)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .frame(width: 16)
+            Text(.init(markdown))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
     }
+
 
     private func openTornProfile() {
         let url = "https://www.torn.com/profiles.php?XID=\(developerID)"

--- a/MacTorn/MacTorn/Views/SettingsView.swift
+++ b/MacTorn/MacTorn/Views/SettingsView.swift
@@ -58,9 +58,11 @@ struct SettingsView: View {
                 .uiTestID("uitest.saveKey")
 
                 Button {
+                    // Validate the typed key WITHOUT saving it — saving would set apiKey,
+                    // which flips ContentView off the Settings screen during onboarding
+                    // before the result panel is seen. Falls back to the saved key.
                     let typed = inputKey.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !typed.isEmpty { appState.apiKey = typed }
-                    Task { await appState.validateKey() }
+                    Task { await appState.validateKey(typed.isEmpty ? nil : typed) }
                 } label: {
                     if appState.keyValidation == .validating {
                         HStack(spacing: 6) {

--- a/MacTorn/MacTornTests/Models/KeyValidationTests.swift
+++ b/MacTorn/MacTornTests/Models/KeyValidationTests.swift
@@ -1,0 +1,196 @@
+import XCTest
+@testable import MacTorn
+
+/// Etap C / ISC-16 — key-info decoding, the pure availability validator, and
+/// `AppState.validateKey` over a mock session. The wire shape is pinned to the verified
+/// Torn v2 `/key/info` schema.
+final class KeyValidationTests: XCTestCase {
+
+    private let fullUserSelections = [
+        "basic", "bars", "cooldowns", "travel", "profile", "money", "battlestats",
+        "properties", "stocks", "organizedcrime", "refills", "education", "bounties",
+        "events", "messages", "attacks",
+    ]
+
+    /// Builds a spec-accurate `/key/info` payload.
+    private func keyInfoJSON(level: Int,
+                             type: String,
+                             userSelections: [String],
+                             factionSelections: [String] = ["basic", "chain"],
+                             marketSelections: [String] = ["itemmarket", "bazaar"],
+                             tornSelections: [String] = ["stocks"],
+                             playerID: Int = 42,
+                             factionID: Int? = 100) -> [String: Any] {
+        [
+            "info": [
+                "access": ["level": level, "type": type, "faction": true, "company": false,
+                           "log": ["custom_permissions": false, "available": []]],
+                "user": ["id": playerID,
+                         "faction_id": factionID.map { $0 as Any } ?? NSNull(),
+                         "company_id": NSNull()],
+                "selections": [
+                    "user": userSelections,
+                    "faction": factionSelections,
+                    "market": marketSelections,
+                    "property": [],
+                    "torn": tornSelections,
+                    "racing": [],
+                    "forum": [],
+                    "key": ["info"],
+                    "company": [],
+                ],
+            ],
+        ]
+    }
+
+    private func decode(_ json: [String: Any]) throws -> TornKeyInfo {
+        let data = try JSONSerialization.data(withJSONObject: json)
+        return try JSONDecoder().decode(TornKeyInfo.Response.self, from: data).info
+    }
+
+    // MARK: - Decoding
+
+    func testDecodesVerifiedSchema() throws {
+        let info = try decode(keyInfoJSON(level: 4, type: "Full Access", userSelections: fullUserSelections))
+        XCTAssertEqual(info.access.type, "Full Access")
+        XCTAssertEqual(info.access.level, 4)
+        XCTAssertTrue(info.access.faction)
+        XCTAssertEqual(info.user.id, 42)
+        XCTAssertEqual(info.user.factionId, 100)
+        XCTAssertNil(info.user.companyId)
+        XCTAssertTrue(info.selections.user.contains("battlestats"))
+        XCTAssertEqual(info.selections.market, ["itemmarket", "bazaar"])
+    }
+
+    func testDecodesNullFactionId() throws {
+        let info = try decode(keyInfoJSON(level: 3, type: "Limited Access",
+                                          userSelections: fullUserSelections, factionID: nil))
+        XCTAssertNil(info.user.factionId)
+    }
+
+    // MARK: - Validator
+
+    func testFullKeyMakesEveryEndpointAvailable() throws {
+        let info = try decode(keyInfoJSON(level: 4, type: "Full Access", userSelections: fullUserSelections))
+        let result = KeyValidator.validate(info)
+        XCTAssertTrue(result.allCriticalAvailable)
+        XCTAssertEqual(result.unavailableCount, 0)
+        XCTAssertEqual(result.playerID, 42)
+        XCTAssertTrue(result.inFaction)
+    }
+
+    func testMissingUserSelectionBlocksTheCriticalFastPoll() throws {
+        // A Custom key that omits battlestats.
+        let selections = fullUserSelections.filter { $0 != "battlestats" }
+        let info = try decode(keyInfoJSON(level: 3, type: "Custom", userSelections: selections))
+        let result = KeyValidator.validate(info)
+
+        let fast = try XCTUnwrap(result.availability.first { $0.endpointID == "user.fast" })
+        XCTAssertFalse(fast.available)
+        XCTAssertEqual(fast.missingSelections, ["battlestats"])
+        XCTAssertFalse(result.allCriticalAvailable, "user.fast is critical")
+    }
+
+    func testEmptyFactionSelectionsBlocksFaction() throws {
+        let info = try decode(keyInfoJSON(level: 3, type: "Limited Access",
+                                          userSelections: fullUserSelections, factionSelections: []))
+        let result = KeyValidator.validate(info)
+        let faction = try XCTUnwrap(result.availability.first { $0.endpointID == "faction.basic" })
+        XCTAssertFalse(faction.available)
+        XCTAssertEqual(Set(faction.missingSelections), Set(["basic", "chain"]))
+    }
+
+    func testParameterizedEndpointsAreAvailableRegardlessOfSelections() throws {
+        // A public-only key with no user selections still reaches selection-less endpoints.
+        let info = try decode(keyInfoJSON(level: 1, type: "Public Only", userSelections: []))
+        let result = KeyValidator.validate(info)
+        for id in ["forum.thread", "forum.threads", "faction.rankedwars", "key.info"] {
+            let ep = try XCTUnwrap(result.availability.first { $0.endpointID == id })
+            XCTAssertTrue(ep.available, "\(id) takes no selections and should be available")
+        }
+    }
+
+    func testCategoryMapping() throws {
+        func category(_ id: String) throws -> TornKeyInfo.Category {
+            KeyValidator.category(for: try XCTUnwrap(TornEndpointRegistry.endpoint(id: id)))
+        }
+        XCTAssertEqual(try category("user.fast"), .user)
+        XCTAssertEqual(try category("user.v2"), .user)
+        XCTAssertEqual(try category("faction.basic"), .faction)
+        XCTAssertEqual(try category("market.item"), .market)
+        XCTAssertEqual(try category("torn.stocks"), .torn)
+        XCTAssertEqual(try category("forum.thread"), .forum)
+    }
+
+    // MARK: - AppState.validateKey
+
+    @MainActor
+    private func makeState(_ mock: MockNetworkSession) -> AppState {
+        AppState(session: mock,
+                 connectivity: ControllableConnectivity(connected: true),
+                 defaults: .createMockDefaults())
+    }
+
+    @MainActor
+    func testValidateKeyPublishesSuccess() async throws {
+        let mock = MockNetworkSession()
+        try mock.setSuccessResponse(json: keyInfoJSON(level: 4, type: "Full Access",
+                                                      userSelections: fullUserSelections))
+        let state = makeState(mock)
+        state.apiKey = "sample-onboarding-value"
+
+        await state.validateKey()
+
+        guard case .success(let result) = state.keyValidation else {
+            return XCTFail("expected success, got \(state.keyValidation)")
+        }
+        XCTAssertEqual(result.accessType, "Full Access")
+        XCTAssertEqual(result.playerID, 42)
+        XCTAssertTrue(result.allCriticalAvailable)
+        XCTAssertNotNil(state.keyInfo)
+    }
+
+    @MainActor
+    func testValidateKeyClassifiesErrorEnvelope() async throws {
+        let mock = MockNetworkSession()
+        try mock.setTornAPIErrorV2(code: 2, message: "Incorrect key")
+        let state = makeState(mock)
+        state.apiKey = "sample-onboarding-value"
+
+        await state.validateKey()
+
+        guard case .failure = state.keyValidation else {
+            return XCTFail("expected failure for a bad key")
+        }
+        XCTAssertNil(state.keyInfo, "a failed validation must not leave stale key info")
+    }
+
+    @MainActor
+    func testValidateKeyWithEmptyKeyFailsWithoutNetwork() async {
+        let mock = MockNetworkSession()
+        let state = makeState(mock)
+        state.apiKey = ""
+
+        await state.validateKey()
+
+        guard case .failure = state.keyValidation else {
+            return XCTFail("empty key should fail fast")
+        }
+        XCTAssertTrue(mock.requestedURLs.isEmpty, "no request should be made for an empty key")
+    }
+
+    @MainActor
+    func testChangingKeyResetsValidation() async throws {
+        let mock = MockNetworkSession()
+        try mock.setSuccessResponse(json: keyInfoJSON(level: 4, type: "Full Access",
+                                                      userSelections: fullUserSelections))
+        let state = makeState(mock)
+        state.apiKey = "sample-onboarding-value"
+        await state.validateKey()
+        XCTAssertNotNil(state.keyInfo)
+
+        state.apiKey = "sample-different-value"
+        XCTAssertEqual(state.keyValidation, .idle)
+        XCTAssertNil(state.keyInfo)
+    }
+}

--- a/MacTorn/MacTornTests/Models/TornEndpointTests.swift
+++ b/MacTorn/MacTornTests/Models/TornEndpointTests.swift
@@ -31,11 +31,12 @@ final class TornEndpointTests: XCTestCase {
         assertMatch("torn.stocks", TornAPI.tornStocksURL(for: key))
         assertMatch("forum.thread", TornAPI.forumThreadURL(threadId: sampleId, apiKey: key), parameter: sampleId)
         assertMatch("forum.threads", TornAPI.forumCategoryThreadsURL(categoryId: sampleId, apiKey: key), parameter: sampleId)
+        assertMatch("key.info", TornAPI.keyInfoURL(for: key))
     }
 
     /// The contract test above is only meaningful if it covers every endpoint.
     func testEveryEndpointIsCoveredByContract() {
-        XCTAssertEqual(TornEndpointRegistry.all.count, 10,
+        XCTAssertEqual(TornEndpointRegistry.all.count, 11,
                        "add the new endpoint to testRegistryURLsMatchLegacyBuilders too")
     }
 

--- a/MacTorn/MacTornUITests/MacTornUITests.swift
+++ b/MacTorn/MacTornUITests/MacTornUITests.swift
@@ -105,4 +105,25 @@ final class MacTornUITests: XCTestCase {
         XCTAssertTrue(app.descendants(matching: .any)["uitest.keyValidationSuccess"].waitForExistence(timeout: 15),
                       "A valid key should report its access level after Test Connection")
     }
+
+    /// During onboarding, Test Connection validates the typed key WITHOUT saving it, so the
+    /// result stays visible on the Settings screen instead of flipping to the tab UI.
+    func testOnboardingTestConnectionKeepsSettingsVisible() throws {
+        let app = launch(fixture: "full", apiKey: nil)
+        _ = window(app)
+
+        let keyField = app.secureTextFields["uitest.apiKeyField"]
+        XCTAssertTrue(keyField.waitForExistence(timeout: 10), "Key field should be shown at onboarding")
+        keyField.click()
+        keyField.typeText("sample-typed-value")
+
+        app.buttons["uitest.testConnection"].click()
+
+        XCTAssertTrue(app.descendants(matching: .any)["uitest.keyValidationSuccess"].waitForExistence(timeout: 15),
+                      "Result should appear after Test Connection")
+        XCTAssertTrue(keyField.exists,
+                      "Test Connection must not save the key / leave the onboarding screen")
+        XCTAssertFalse(app.buttons["uitest.tab.Status"].exists,
+                       "The signed-in tab UI must not appear from a mere Test Connection")
+    }
 }

--- a/MacTorn/MacTornUITests/MacTornUITests.swift
+++ b/MacTorn/MacTornUITests/MacTornUITests.swift
@@ -85,4 +85,24 @@ final class MacTornUITests: XCTestCase {
         XCTAssertTrue(error.waitForExistence(timeout: 15),
                       "An invalid key should surface a visible error message")
     }
+
+    // MARK: - Key validation (Etap C)
+
+    /// "Test Connection" validates the key against /key/info and reports what it unlocks.
+    func testTestConnectionReportsAccess() throws {
+        let app = launch(fixture: "full", apiKey: "sample-connection-user")
+        _ = window(app)
+
+        // Open Settings from the signed-in footer, then run Test Connection.
+        let settings = app.buttons["uitest.openSettings"]
+        XCTAssertTrue(settings.waitForExistence(timeout: 10), "Settings button should exist")
+        settings.click()
+
+        let testButton = app.buttons["uitest.testConnection"]
+        XCTAssertTrue(testButton.waitForExistence(timeout: 10), "Test Connection button should exist")
+        testButton.click()
+
+        XCTAssertTrue(app.descendants(matching: .any)["uitest.keyValidationSuccess"].waitForExistence(timeout: 15),
+                      "A valid key should report its access level after Test Connection")
+    }
 }

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ calls are throttled and hard-limited to stay well under that cap.
 | Stock metadata | v1 | stocks | point-in-time | Rarely (cached; refreshed on demand) | — | metadata | no | Global stock names/acronyms used to label the user's stock holdings (slow-changing reference data). |
 | Forum thread | v2 | — | row-based | Forum poll (opt-in feature) | 20 | forum | no | Post count of a watched forum thread, to alert on new replies. |
 | Forum category threads | v2 | — | row-based | Forum poll (opt-in feature) | 20 | forum | no | Thread list of a watched forum category, to alert on new threads. |
+| Key info | v2 | — | point-in-time | On demand (Test Connection / key change) | — | core | no | One-off validation of the API key: its access level/type, the owner's ID, and which selections it can read — used by onboarding's Test Connection. Never polled. |
 
 Your API key needs **Limited Access** or higher. Everything above is **read-only** —
 MacTorn never performs actions in Torn. See [`SECURITY.md`](SECURITY.md) for how your


### PR DESCRIPTION
## Summary

Etap C of the reliability & product audit — **key validation and onboarding** against Torn's official key-info endpoint (ISC-16). System-of-record: [`ISA.md`](ISA.md).

The key-info response shape was **verified against the live OpenAPI spec** (`www.torn.com/swagger/openapi.json`, `KeyInfoResponse`) — not guessed, per the audit's hard rule.

## What's in it

- **`TornKeyInfo`** (`Networking/TornKeyInfo.swift`) decodes v2 `/key/info`: `access.{level,type,faction,company}`, `user.{id,faction_id,company_id}`, and the per-category `selections` arrays.
- **`KeyValidator`** maps a decoded key to per-endpoint availability, using the endpoint registry as the source of truth (an endpoint is available iff its required selections ⊆ the key's granted selections for that category). Custom keys are handled correctly (gating by selections, not just `access.level`).
- **Registry**: a `key.info` entry + `TornAPI.keyInfoURL` builder, pinned by the existing URL contract test (now 11 endpoints).
- **`AppState.validateKey()`** fetches `/key/info`, classifies errors through the existing `TornAPIError` taxonomy, and publishes a `KeyValidationState`. All error copy is sanitized/PII-free; the player ID is kept for on-screen display only (never logged or put in a diagnostics report).
- **SettingsView**: a **Test Connection** button + result panel showing the real access type, the owner's player ID, and — for a Limited/Custom key — exactly which features won't load. The disclosure now states the required access level, Keychain storage, local-only data, Sentry opt-in, and lists the requested selections **generated from the registry** (no hand-maintained drift) + the ToS link.

## Tests
- `KeyValidationTests` (11): schema decode (incl. null `faction_id`), validator (full / Custom-missing-selection / empty-faction / parameterized-always-available / category mapping), and `validateKey` (success / error-envelope / empty-key / key-change reset).
- `testTestConnectionReportsAccess` UI test drives Settings → Test Connection → success panel via the harness (the UI fixture session now serves `/key/info`).
- 349 unit + 4 UI tests green; coverage gate PASSED; Release Universal (arm64+x86_64) builds.

## Safety / constraints held
- Read-only; **official API only** (no scraping). Key-info shape verified, not guessed.
- PII-safe: `validateKey` error messages are sanitized; the player ID is display-only and never enters logs, the sanitized diagnostics report, or commits.
- Keychain / App Sandbox / Hardened Runtime / Sentry opt-in / URL redaction / macOS 14+ untouched. No existing behaviour changed without a test.

## Deferred (ISA sub-ISC)
- **ISC-16.1** — the result panel *names* blocked modules with a clear explanation, but tabs are not hard-removed. Deferred **by choice, fail-open**: a user may never run Test Connection and key-info can be briefly unavailable, so hiding tabs on absent/stale info would risk hiding features that actually work. Per-tab access banners driven by `keyInfo` are the natural follow-up.

## Visual caveat
The Test Connection panel + disclosure were validated by logic + interaction (unit + XCUITest), **not** visually. Eyeball in Xcode before release.