### PR TITLE
Reliability closures: error-14 category pause + poll-wide health (ISC-15.1, F-02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,16 @@ the full plan and deferred backlog live in [`ISA.md`](ISA.md).
   80% line coverage. SwiftUI views are excluded — they're validated by the UI-test suite.
   Also available locally via `make coverage-gate`.
 
+### Changed — reliability closures (Etap B/F follow-ups)
+- **A daily read-limit no longer stalls unrelated data.** If Torn returns "daily read limit
+  reached" (error 14) for a row-based feed (activity, faction news), MacTorn now pauses just
+  that feed for an hour and keeps everything else — bars, cooldowns, travel, the chain
+  counter — updating live. Previously the whole faction/activity overlay could be affected.
+- **Diagnostics now cover the whole poll.** Endpoint health (last outcome, latency, size) is
+  recorded for every endpoint the app polls (faction, activity, v2 user, ranked wars, news),
+  not only the fast user poll — so a "Copy sanitized report" is more useful when something's
+  off. (Rarely-called market/forum/stocks calls are a small follow-up.)
+
 ### Added — Etap C (key validation & onboarding)
 - **Test Connection.** Onboarding (Settings) gains a "Test Connection" button that checks
   your API key against Torn's official key-info endpoint and tells you exactly what it

--- a/ISA.md
+++ b/ISA.md
@@ -123,10 +123,13 @@ tracked backlog with deferral reasons.
   latch stops auto-restart on MenuBarExtra open) with a clear message, and clears when
   the key changes. Verified by `AppStateTests` (halt / no-restart / key-change-clears)
   and `TornAPIErrorTests` (envelope classification).
-- [ ] ISC-15.1: Etap B (category pause for error 14) — pause only the offending row-based
-  category on a daily-row-limit hit while bars/countdowns keep running. *(Deferred: the
-  v1.9.2 fix already keeps categories well under the 50k cap, so this is belt-and-braces;
-  `haltsCategoryOnly` is modelled and tested, wiring the per-category pause is the step.)*
+- [x] ISC-15.1: Etap B (category pause for error 14) — a daily-row-limit (code 14) on a
+  row-based source now pauses **only that source** (keyed by endpoint id, not budget
+  category, so `faction.news` pausing never stops the point-in-time `faction.basic` chain
+  data) for a rolling 1 h window, re-arming off the injected `TimeSource`; bars/countdowns
+  keep polling. Wired into `user.activity` and `faction.news` (the main poll's row sources).
+  Verified by `AppStateTests` (`testDailyRowLimitPausesOnlyRowSources`,
+  `testRowSourcePauseReArmsAfterWindow`).
 - [x] ISC-16: Etap C — key validation/onboarding. Calls the official Torn v2 `/key/info`
   endpoint (shape verified against the live OpenAPI spec, not guessed) via
   `TornAPI.keyInfoURL` + a `key.info` registry entry. `TornKeyInfo` decodes access
@@ -167,10 +170,12 @@ tracked backlog with deferral reasons.
   reachable from Settings, with a **"Copy sanitized report"** that carries none of: key,
   full URLs, player name/ID, money, stats, faction/company names, or raw payloads.
   Verified by `DiagnosticsTests` (PII-safety of `sanitizedText()`).
-- [ ] ISC-19.1: Etap F (full instrumentation, F-02) — extend outcome/latency/size health
-  to every endpoint (fast poll is the reference implementation); event-driven endpoints
-  (market/forum/stocks) currently populate on first use. *(Deferred: mechanical per-site
-  timing, low value vs. risk right now.)*
+- [x] ISC-19.1: Etap F (F-02) — endpoint health (outcome/latency/size) now recorded across
+  the **continuous poll fan-out** (`faction.basic`, `user.activity`, `user.v2`,
+  `faction.rankedwars`, `faction.news`), not just `user.fast`/`key.info`. Verified by
+  `testFetchDataRecordsHealthForFanOutEndpoints`. *(Remaining: the event-driven endpoints —
+  `market.item`, `forum.thread`/`threads`, `torn.stocks` — are per-item/rare and structurally
+  different (loops, backoff); instrumenting them is low value and left as a small follow-up.)*
 - [x] ISC-20: Etap G — deterministic UI-test harness + real UI tests + hardened CI.
   `--uitesting` builds `AppState` from fixtures/doubles (`FixtureNetworkSession` URL-routed
   canned JSON, isolated ephemeral `UserDefaults`, in-memory `KeychainStore` override,
@@ -279,6 +284,9 @@ tracked backlog with deferral reasons.
 - ISC-10,11: `NotificationCoordinatorTests` (12 tests) pass — incl.
   `testChainAlertFiresOnceAcrossManySubThresholdPolls`.
 - ISC-12: `SECURITY.md` present at repo root.
+- ISC-15.1 / ISC-19.1: `AppStateTests` — `testDailyRowLimitPausesOnlyRowSources`,
+  `testRowSourcePauseReArmsAfterWindow`, `testFetchDataRecordsHealthForFanOutEndpoints` green;
+  full unit suite 352 green; Release Universal builds; coverage gate PASSED.
 - ISC-16: `KeyValidationTests` (11) green — model decode against the verified `/key/info`
   schema, `KeyValidator` availability (full/Custom-missing-selection/empty-faction/
   parameterized), and `AppState.validateKey` (success / error-envelope / empty / key-change

--- a/MacTorn/MacTorn/ViewModels/AppState.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState.swift
@@ -301,6 +301,21 @@ class AppState {
     /// Per-endpoint last-result/latency/size health (Etap F, Diagnostics).
     @ObservationIgnored let endpointHealth: EndpointHealthTracker
 
+    /// Shared clock (injected). Used for the daily-row-limit pause windows below.
+    @ObservationIgnored private let time: TimeSource
+
+    /// Row-based sources paused after a Torn "daily read limit" hit (error code 14),
+    /// keyed by endpoint id → re-arm instant (ISC-15.1). Keyed by endpoint (NOT budget
+    /// category): `faction.news` and `faction.basic` share the `faction` budget, but only
+    /// the row-based `news` can trip code 14 — pausing it must never stop the point-in-time
+    /// `faction.basic` chain data that drives the chain alert. Point-in-time endpoints never
+    /// land here, so the live bars/countdowns keep running while a row source is paused.
+    @ObservationIgnored private var rowSourcePausedUntil: [String: Date] = [:]
+
+    /// How long a row source stays paused after a code-14 hit before it is retried. The cap
+    /// is a rolling 24 h window, so a conservative 1 h pause backs off without giving up.
+    private static let dailyRowLimitPause: TimeInterval = 3600
+
     /// Chain timeout (seconds remaining) below which the "Chain Expiring!" alert arms.
     static let chainWarningThreshold = 60
 
@@ -311,6 +326,7 @@ class AppState {
         self.session = session
         self.connectivity = connectivity ?? NetworkMonitor.shared
         self.defaults = defaults
+        self.time = time
         self.notificationCoordinator = NotificationCoordinator(defaults: defaults)
         self.pollingCoordinator = PollingCoordinator(time: time)
         self.endpointHealth = EndpointHealthTracker(time: time)
@@ -1091,6 +1107,24 @@ class AppState {
         startPolling(force: true)
     }
 
+    /// True while a row-based source is paused after a daily-row-limit (code 14) hit.
+    /// Auto-clears (and reports false) once the pause window elapses. `internal` for tests.
+    func isRowSourcePaused(_ endpointID: String) -> Bool {
+        guard let until = rowSourcePausedUntil[endpointID] else { return false }
+        if time.now >= until {
+            rowSourcePausedUntil[endpointID] = nil
+            return false
+        }
+        return true
+    }
+
+    /// Pause a single row-based source after Torn returns a daily-row-limit error (ISC-15.1),
+    /// so only that category backs off while everything point-in-time keeps polling.
+    private func pauseRowSource(_ endpointID: String, error: TornAPIError) {
+        rowSourcePausedUntil[endpointID] = time.now.addingTimeInterval(Self.dailyRowLimitPause)
+        logger.warning("Paused row source \(endpointID) for \(Int(Self.dailyRowLimitPause))s after daily read limit (code \(error.tornCode ?? 14))")
+    }
+
     /// Record an issued request against the API budget (Etap D). Defensive no-op if the
     /// id isn't in the registry.
     private func recordRequest(_ endpointID: String) {
@@ -1586,6 +1620,7 @@ class AppState {
     private func fetchFactionData() async {
         guard let url = TornAPI.factionURL(for: apiKey) else { return }
         recordRequest("faction.basic")
+        let startTime = Date()
 
         do {
             var request = URLRequest(url: url)
@@ -1594,8 +1629,9 @@ class AppState {
 
             if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
                 // Check for Torn API error first
-                if let errorMessage = tornAPIErrorMessage(in: json) {
-                    logger.warning("Faction API error: \(errorMessage)")
+                if let apiError = tornAPIError(in: json) {
+                    recordHealth("faction.basic", outcome: .error, since: startTime, bytes: data.count, errorClass: apiError.classification.rawValue)
+                    logger.warning("Faction API error: \(apiError.userMessage)")
                     return
                 }
 
@@ -1618,8 +1654,16 @@ class AppState {
 
                 self.factionData = FactionData(name: name, factionId: factionId, respect: respect, chain: chain)
                 logger.info("Faction data fetched: \(name)")
+                recordHealth("faction.basic", outcome: .ok, since: startTime, bytes: data.count)
+            } else {
+                recordHealth("faction.basic", outcome: .error, since: startTime, bytes: data.count, errorClass: "malformedResponse")
             }
         } catch {
+            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
+            recordHealth("faction.basic",
+                         outcome: mapped?.classification == .offline ? .offline : .error,
+                         since: startTime, bytes: 0,
+                         errorClass: mapped?.classification.rawValue ?? "transport")
             logger.warning("Faction fetch error (optional): \(error.localizedDescription)")
             // Faction data is optional, ignore errors
         }
@@ -1634,6 +1678,8 @@ class AppState {
     // the fast poll handles the live bars/cooldowns/travel data.
     private func fetchActivityData() async {
         guard !apiKey.isEmpty, let url = TornAPI.activityURL(for: apiKey) else { return }
+        // Skip while this row source is paused after a daily-row-limit hit (ISC-15.1).
+        guard !isRowSourcePaused("user.activity") else { return }
         // (recorded below, after the throttle guard, so a throttled skip isn't counted)
 
         // Self-throttle: always runs on the first poll (lastActivityFetch == nil), then
@@ -1645,15 +1691,22 @@ class AppState {
         }
         lastActivityFetch = Date()
         recordRequest("user.activity")
+        let startTime = Date()
 
         do {
             var request = URLRequest(url: url)
             request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
             let (data, _) = try await session.data(for: request)
 
-            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
-            if let errorMessage = tornAPIErrorMessage(in: json) {
-                logger.warning("Activity API error: \(errorMessage)")
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                recordHealth("user.activity", outcome: .error, since: startTime, bytes: data.count, errorClass: "malformedResponse")
+                return
+            }
+            if let apiError = tornAPIError(in: json) {
+                // A daily-row-limit (code 14) pauses only this row source (ISC-15.1).
+                if apiError.haltsCategoryOnly { pauseRowSource("user.activity", error: apiError) }
+                recordHealth("user.activity", outcome: .error, since: startTime, bytes: data.count, errorClass: apiError.classification.rawValue)
+                logger.warning("Activity API error: \(apiError.userMessage)")
                 return
             }
 
@@ -1680,7 +1733,13 @@ class AppState {
                     )
                 }.sorted(by: { ($0.timestampEnded ?? 0) > ($1.timestampEnded ?? 0) })
             }
+            recordHealth("user.activity", outcome: .ok, since: startTime, bytes: data.count)
         } catch {
+            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
+            recordHealth("user.activity",
+                         outcome: mapped?.classification == .offline ? .offline : .error,
+                         since: startTime, bytes: 0,
+                         errorClass: mapped?.classification.rawValue ?? "transport")
             logger.warning("Activity fetch error (optional): \(error.localizedDescription)")
         }
     }
@@ -1693,15 +1752,20 @@ class AppState {
     private func fetchUserV2Data() async {
         guard !apiKey.isEmpty, let url = TornAPI.userV2URL(for: apiKey) else { return }
         recordRequest("user.v2")
+        let startTime = Date()
 
         do {
             var request = URLRequest(url: url)
             request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
             let (data, _) = try await session.data(for: request)
 
-            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
-            if let errorMessage = tornAPIErrorMessage(in: json) {
-                logger.warning("User v2 API error: \(errorMessage)")
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                recordHealth("user.v2", outcome: .error, since: startTime, bytes: data.count, errorClass: "malformedResponse")
+                return
+            }
+            if let apiError = tornAPIError(in: json) {
+                recordHealth("user.v2", outcome: .error, since: startTime, bytes: data.count, errorClass: apiError.classification.rawValue)
+                logger.warning("User v2 API error: \(apiError.userMessage)")
                 return
             }
 
@@ -1752,7 +1816,13 @@ class AppState {
             notifyBountiesOnMe()
 
             logger.info("User v2 data fetched (OC: \(oc?.name ?? "none"), bounties: \(self.bountiesOnMe.count))")
+            recordHealth("user.v2", outcome: .ok, since: startTime, bytes: data.count)
         } catch {
+            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
+            recordHealth("user.v2",
+                         outcome: mapped?.classification == .offline ? .offline : .error,
+                         since: startTime, bytes: 0,
+                         errorClass: mapped?.classification.rawValue ?? "transport")
             logger.warning("User v2 fetch error (optional): \(error.localizedDescription)")
         }
     }
@@ -1804,14 +1874,16 @@ class AppState {
 
         if let url = TornAPI.factionRankedWarsURL(for: apiKey) {
             recordRequest("faction.rankedwars")
-            if let wars: [RankedWar] = await fetchV2Array(url: url, key: "rankedwars") {
+            if let wars: [RankedWar] = await fetchV2Array(url: url, key: "rankedwars", endpointID: "faction.rankedwars") {
                 self.rankedWars = wars
             }
         }
 
-        if let url = TornAPI.factionNewsURL(for: apiKey) {
+        // News is the only row-based faction call — skip while it is paused after a
+        // daily-row-limit hit (ISC-15.1). Ranked wars (point-in-time) keeps running.
+        if !isRowSourcePaused("faction.news"), let url = TornAPI.factionNewsURL(for: apiKey) {
             recordRequest("faction.news")
-            if let news: [FactionNews] = await fetchV2Array(url: url, key: "news") {
+            if let news: [FactionNews] = await fetchV2Array(url: url, key: "news", endpointID: "faction.news") {
                 self.factionNews = news
             }
         }
@@ -1819,20 +1891,34 @@ class AppState {
 
     /// Fetches a v2 endpoint whose payload is `{ "<key>": [ … ] }` and decodes the
     /// array. Returns nil on network/API error so the caller keeps its prior value.
-    private func fetchV2Array<T: Decodable>(url: URL, key: String) async -> [T]? {
+    /// Records endpoint health (Etap F) and, on a daily-row-limit error, pauses the source
+    /// (ISC-15.1) — only meaningful for the row-based `news` call.
+    private func fetchV2Array<T: Decodable>(url: URL, key: String, endpointID: String) async -> [T]? {
+        let startTime = Date()
         do {
             var request = URLRequest(url: url)
             request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
             let (data, _) = try await session.data(for: request)
-            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
-            if let errorMessage = tornAPIErrorMessage(in: json) {
-                logger.warning("Faction v2 (\(key)) API error: \(errorMessage)")
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                recordHealth(endpointID, outcome: .error, since: startTime, bytes: data.count, errorClass: "malformedResponse")
                 return nil
             }
+            if let apiError = tornAPIError(in: json) {
+                if apiError.haltsCategoryOnly { pauseRowSource(endpointID, error: apiError) }
+                recordHealth(endpointID, outcome: .error, since: startTime, bytes: data.count, errorClass: apiError.classification.rawValue)
+                logger.warning("Faction v2 (\(key)) API error: \(apiError.userMessage)")
+                return nil
+            }
+            recordHealth(endpointID, outcome: .ok, since: startTime, bytes: data.count)
             guard let arr = json[key] as? [[String: Any]],
                   let arrData = try? JSONSerialization.data(withJSONObject: arr) else { return nil }
             return try? JSONDecoder().decode([T].self, from: arrData)
         } catch {
+            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
+            recordHealth(endpointID,
+                         outcome: mapped?.classification == .offline ? .offline : .error,
+                         since: startTime, bytes: 0,
+                         errorClass: mapped?.classification.rawValue ?? "transport")
             logger.warning("Faction v2 (\(key)) fetch error (optional): \(error.localizedDescription)")
             return nil
         }

--- a/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
@@ -707,4 +707,66 @@ final class AppStateTests: XCTestCase {
         if case .traveling = appState.menuBarDisplay { /* ok */ }
         else { XCTFail("Expected .traveling to win, got \(appState.menuBarDisplay)") }
     }
+
+    // MARK: - ISC-15.1: daily-row-limit pauses only the offending row source
+
+    /// A code-14 "daily read limit" on the fan-out pauses the row-based sources
+    /// (`user.activity`, `faction.news`) but NOT the point-in-time `faction.basic` that
+    /// drives the chain alert.
+    func testDailyRowLimitPausesOnlyRowSources() async throws {
+        let clock = MutableTimeSource()
+        let mock = MockNetworkSession()
+        try mock.setTornAPIError(code: 14, message: "Daily read limit reached")
+        let state = AppState(session: mock,
+                             connectivity: ControllableConnectivity(connected: true),
+                             defaults: .createMockDefaults(),
+                             time: clock)
+        state.apiKey = "sample-value"
+
+        state.fetchData()
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
+        XCTAssertTrue(state.isRowSourcePaused("user.activity"), "activity should pause on code 14")
+        XCTAssertTrue(state.isRowSourcePaused("faction.news"), "faction news should pause on code 14")
+        XCTAssertFalse(state.isRowSourcePaused("faction.basic"),
+                       "point-in-time faction/chain must keep running")
+        state.stopPolling()
+    }
+
+    /// The pause re-arms once its window elapses (driven by the injected clock).
+    func testRowSourcePauseReArmsAfterWindow() async throws {
+        let clock = MutableTimeSource()
+        let mock = MockNetworkSession()
+        try mock.setTornAPIError(code: 14, message: "Daily read limit reached")
+        let state = AppState(session: mock,
+                             connectivity: ControllableConnectivity(connected: true),
+                             defaults: .createMockDefaults(),
+                             time: clock)
+        state.apiKey = "sample-value"
+
+        state.fetchData()
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        XCTAssertTrue(state.isRowSourcePaused("user.activity"))
+
+        clock.advance(3601)   // just past the 1 h pause window
+        XCTAssertFalse(state.isRowSourcePaused("user.activity"), "pause should re-arm after the window")
+        state.stopPolling()
+    }
+
+    // MARK: - F-02: endpoint health across the poll fan-out
+
+    /// A successful poll records health for every fan-out endpoint, not just the fast poll.
+    func testFetchDataRecordsHealthForFanOutEndpoints() async throws {
+        appState.apiKey = "valid_key"
+        try mockSession.setSuccessResponse(json: TornAPIFixtures.validFullResponse())
+
+        appState.fetchData()
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
+        for id in ["user.fast", "faction.basic", "user.v2", "user.activity",
+                   "faction.rankedwars", "faction.news"] {
+            XCTAssertEqual(appState.endpointHealth.latest(for: id)?.outcome, .ok,
+                           "health should be recorded (ok) for \(id)")
+        }
+    }
 }


### PR DESCRIPTION
## Summary

A bundle of two low-risk reliability closures from the audit backlog. System-of-record: [`ISA.md`](ISA.md).

### ISC-15.1 — daily-row-limit pauses only the offending row source
When Torn returns error 14 ("daily read limit reached") for a row-based feed, MacTorn now pauses **just that feed** for a rolling 1 h window and keeps everything point-in-time (bars, cooldowns, travel, **the chain counter**) polling.

Key design point: the pause is keyed by **endpoint id, not budget category**. `faction.news` and `faction.basic` share the `faction` budget, but only the row-based `news` can trip code 14 — pausing it must never stop the point-in-time `faction.basic` chain data that drives the chain-expiring alert. The re-arm window is driven by the injected `TimeSource`, so it's deterministically testable. Wired into the two main-poll row sources: `user.activity` and `faction.news`.

### F-02 — endpoint health across the poll fan-out
`recordHealth` (last outcome, latency, response size) previously covered only `user.fast` (+ `key.info`). It now covers the whole continuous poll fan-out — `faction.basic`, `user.activity`, `user.v2`, `faction.rankedwars`, `faction.news` — so the Diagnostics "Copy sanitized report" is useful when a secondary endpoint misbehaves. Purely additive observability; the row-based fetches also move from message-only to **classified** error handling (`tornAPIError(in:)`).

## Tests
- `AppStateTests`: `testDailyRowLimitPausesOnlyRowSources` (activity + news paused, chain not), `testRowSourcePauseReArmsAfterWindow` (clock-driven re-arm), `testFetchDataRecordsHealthForFanOutEndpoints`.
- 352 unit tests green (no regression from the error-handling change); coverage gate PASSED; Release Universal (arm64+x86_64) builds.

## Safety / constraints held
- Read-only; official API only. No PII in health records (outcome/latency/bytes/error-class only — same as the existing `user.fast` instrumentation).
- No behaviour change to existing features without a test. Bars/countdowns keep running during a row-source pause (that's the whole point).

## Remaining (ISA)
- **ISC-19.1** — the event-driven endpoints (`market.item`, `forum.thread`/`threads`, `torn.stocks`) are per-item/rare and structurally different (loops, backoff); instrumenting them is low value and left as a small follow-up.

## Visual caveat
No UI changes in this PR — pure reliability/observability wiring.