### PR TITLE
Reliability closures 2: persistent OC-ready dedup + stocks health (ISC-18, F-02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,15 @@ the full plan and deferred backlog live in [`ISA.md`](ISA.md).
   80% line coverage. SwiftUI views are excluded — they're validated by the UI-test suite.
   Also available locally via `make coverage-gate`.
 
+### Fixed — duplicate OC-ready alert after relaunch (Etap E)
+- **"OC Ready!" no longer re-alerts when you reopen the app.** The organized-crime ready
+  notification is now deduplicated persistently (once per OC), so relaunching MacTorn while
+  the same OC is still ready won't fire it again. A new OC still alerts.
+
+### Changed — more reliability closures (Etap F)
+- **Diagnostics now cover the stock-metadata call too** (last outcome/latency/size), alongside
+  the poll fan-out added earlier.
+
 ### Changed — reliability closures (Etap B/F follow-ups)
 - **A daily read-limit no longer stalls unrelated data.** If Torn returns "daily read limit
   reached" (error 14) for a row-based feed (activity, faction news), MacTorn now pauses just

--- a/ISA.md
+++ b/ISA.md
@@ -160,10 +160,15 @@ tracked backlog with deferral reasons.
   cadence and sleep/wake handling out of `AppState` into the coordinator so it owns the
   schedule, not just the accounting. *(Deferred: the high-regression-risk extraction; the
   measurable budget/reconnect wins land first without destabilising the poll loop.)*
-- [ ] ISC-18: Etap E — route the remaining categories (cooldown ready, landing,
-  release, OC ready, bounty, price alert, forum, bar threshold) through the
-  coordinator's epoch dedup. *(Deferred: coordinator primitives are built + tested;
-  this is mechanical wiring per category with a test each.)*
+- [ ] ISC-18: Etap E — route the remaining categories through the coordinator's persistent
+  dedup. **OC-ready is done** (`shouldNotifyOCReady` → `NotificationCoordinator.shouldFireOnce`,
+  epoch = OC id), which fixes a real cross-restart duplicate — the old in-memory
+  `previousOCReadyId` re-alerted after relaunch. Verified by
+  `testOCReadyDedupIsPerIdAndPersistsAcrossRestart`. *(Remaining: cooldown-ready / landing /
+  released are already guarded by an in-memory `if let prev…` that is nil on restart, so they
+  don't cross-restart-duplicate — migrating them changes no behaviour and isn't a clean win.
+  Bounty deliberately keeps its in-memory set: persistent dedup would break its intended
+  re-alert when a bounty is cleared and re-listed. Price alerts are transient by design.)*
 - [x] ISC-19: Etap F — Diagnostics screen (app/macOS/arch, network + notification
   permission, key present + required access, last refresh, request/record counters from
   PollingCoordinator, and per-endpoint outcome/latency/size from `EndpointHealthTracker`)
@@ -172,10 +177,11 @@ tracked backlog with deferral reasons.
   Verified by `DiagnosticsTests` (PII-safety of `sanitizedText()`).
 - [x] ISC-19.1: Etap F (F-02) — endpoint health (outcome/latency/size) now recorded across
   the **continuous poll fan-out** (`faction.basic`, `user.activity`, `user.v2`,
-  `faction.rankedwars`, `faction.news`), not just `user.fast`/`key.info`. Verified by
-  `testFetchDataRecordsHealthForFanOutEndpoints`. *(Remaining: the event-driven endpoints —
-  `market.item`, `forum.thread`/`threads`, `torn.stocks` — are per-item/rare and structurally
-  different (loops, backoff); instrumenting them is low value and left as a small follow-up.)*
+  `faction.rankedwars`, `faction.news`), not just `user.fast`/`key.info`, plus the single-call
+  `torn.stocks`. Verified by `testFetchDataRecordsHealthForFanOutEndpoints` and
+  `testFetchStocksMetadataRecordsHealth`. *(Remaining: `market.item` and `forum.thread`/
+  `threads` are per-item loops where a single health slot would just show the last item — low
+  value, left as a small follow-up.)*
 - [x] ISC-20: Etap G — deterministic UI-test harness + real UI tests + hardened CI.
   `--uitesting` builds `AppState` from fixtures/doubles (`FixtureNetworkSession` URL-routed
   canned JSON, isolated ephemeral `UserDefaults`, in-memory `KeychainStore` override,
@@ -287,6 +293,9 @@ tracked backlog with deferral reasons.
 - ISC-15.1 / ISC-19.1: `AppStateTests` — `testDailyRowLimitPausesOnlyRowSources`,
   `testRowSourcePauseReArmsAfterWindow`, `testFetchDataRecordsHealthForFanOutEndpoints` green;
   full unit suite 352 green; Release Universal builds; coverage gate PASSED.
+- ISC-18 (OC-ready) / ISC-19.1 (stocks): `AppStateTests` —
+  `testOCReadyDedupIsPerIdAndPersistsAcrossRestart`, `testFetchStocksMetadataRecordsHealth`
+  green; full unit suite 354 green; Release Universal builds; coverage gate PASSED.
 - ISC-16: `KeyValidationTests` (11) green — model decode against the verified `/key/info`
   schema, `KeyValidator` availability (full/Custom-missing-selection/empty-faction/
   parameterized), and `AppState.validateKey` (success / error-envelope / empty / key-change

--- a/MacTorn/MacTorn/ViewModels/AppState.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState.swift
@@ -251,7 +251,6 @@ class AppState {
     @ObservationIgnored private var previousTravel: Travel?
     @ObservationIgnored private var previousChain: Chain?
     @ObservationIgnored private var previousStatus: Status?
-    @ObservationIgnored private var previousOCReadyId: Int?
     @ObservationIgnored private var notifiedBountyKeys: Set<String> = []
     /// Throttle for the heavy, slow-changing faction v2 overlays (ranked wars + news).
     /// `news` is a row-based cloud category, so this doubles as its rate control:
@@ -381,13 +380,17 @@ class AppState {
     func fetchStocksMetadata() async {
         guard !apiKey.isEmpty, let url = TornAPI.tornStocksURL(for: apiKey) else { return }
         recordRequest("torn.stocks")
+        let startTime = Date()
         do {
             var request = URLRequest(url: url)
             request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
             let (data, _) = try await session.data(for: request)
             let parsed = AppState.parseStocksMetadata(from: data, logger: logger)
             guard !parsed.isEmpty else {
-                await MainActor.run { self.recordStocksMetadataFailure() }
+                await MainActor.run {
+                    self.recordStocksMetadataFailure()
+                    self.recordHealth("torn.stocks", outcome: .error, since: startTime, bytes: data.count, errorClass: "malformedResponse")
+                }
                 return
             }
             await MainActor.run {
@@ -397,10 +400,18 @@ class AppState {
                 }
                 self.stocksFailureCount = 0
                 self.stocksNextRetryAfter = nil
+                self.recordHealth("torn.stocks", outcome: .ok, since: startTime, bytes: data.count)
                 logger.info("Stocks metadata loaded: \(parsed.count) stocks")
             }
         } catch {
-            await MainActor.run { self.recordStocksMetadataFailure() }
+            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
+            await MainActor.run {
+                self.recordStocksMetadataFailure()
+                self.recordHealth("torn.stocks",
+                                  outcome: mapped?.classification == .offline ? .offline : .error,
+                                  since: startTime, bytes: 0,
+                                  errorClass: mapped?.classification.rawValue ?? "transport")
+            }
             logger.error("Failed to fetch stocks metadata: \(error.localizedDescription)")
         }
     }
@@ -1799,18 +1810,13 @@ class AppState {
                 self.bountiesOnMe = []
             }
 
-            // OC-ready notification: fire once per OC as it crosses its ready time.
-            if let oc, oc.isReady {
-                if previousOCReadyId != oc.id {
-                    NotificationManager.shared.send(
-                        title: "OC Ready! 💼",
-                        body: "\(oc.name) is ready to execute",
-                        type: .ocReady
-                    )
-                }
-                previousOCReadyId = oc.id
-            } else {
-                previousOCReadyId = nil
+            // OC-ready notification: fire once per distinct OC id (see shouldNotifyOCReady).
+            if shouldNotifyOCReady(oc), let oc {
+                NotificationManager.shared.send(
+                    title: "OC Ready! 💼",
+                    body: "\(oc.name) is ready to execute",
+                    type: .ocReady
+                )
             }
 
             notifyBountiesOnMe()
@@ -1825,6 +1831,15 @@ class AppState {
                          errorClass: mapped?.classification.rawValue ?? "transport")
             logger.warning("User v2 fetch error (optional): \(error.localizedDescription)")
         }
+    }
+
+    /// Whether an OC-ready alert should fire now: true once per distinct OC id, deduped
+    /// **persistently** via the NotificationCoordinator (Etap E / ISC-18), so relaunching
+    /// while the same OC is still ready doesn't re-alert (the old in-memory `previousOCReadyId`
+    /// did). A new OC (new id) re-arms naturally. `internal` for tests.
+    func shouldNotifyOCReady(_ oc: OrganizedCrime2?) -> Bool {
+        guard let oc, oc.isReady else { return false }
+        return notificationCoordinator.shouldFireOnce("oc.ready", epoch: "\(oc.id)")
     }
 
     /// Alerts once per distinct bounty placed on Paweł (safety signal). Re-remembers

--- a/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
@@ -769,4 +769,44 @@ final class AppStateTests: XCTestCase {
                            "health should be recorded (ok) for \(id)")
         }
     }
+
+    /// A successful stocks-metadata fetch records endpoint health (F-02 completion).
+    func testFetchStocksMetadataRecordsHealth() async throws {
+        appState.apiKey = "valid_key"
+        try mockSession.setSuccessResponse(json: TornAPIFixtures.stocksData)
+
+        await appState.fetchStocksMetadata()
+
+        XCTAssertEqual(appState.endpointHealth.latest(for: "torn.stocks")?.outcome, .ok)
+    }
+
+    // MARK: - ISC-18: OC-ready dedup routed through the coordinator (persistent)
+
+    /// OC-ready fires once per distinct OC id, and the dedup survives a relaunch (the old
+    /// in-memory `previousOCReadyId` re-alerted after restart). A new OC id re-arms.
+    func testOCReadyDedupIsPerIdAndPersistsAcrossRestart() {
+        let defaults = UserDefaults.createMockDefaults()
+        let mock = MockNetworkSession()
+        let state = AppState(session: mock,
+                             connectivity: ControllableConnectivity(connected: true),
+                             defaults: defaults)
+
+        let now = Int(Date().timeIntervalSince1970)
+        let ready5 = OrganizedCrime2(id: 5, name: "Test OC", readyAt: now - 10)
+
+        XCTAssertTrue(state.shouldNotifyOCReady(ready5), "first ready id should fire")
+        XCTAssertFalse(state.shouldNotifyOCReady(ready5), "the same id should be suppressed")
+
+        let planning = OrganizedCrime2(id: 7, name: "Planning", readyAt: now + 3600)
+        XCTAssertFalse(state.shouldNotifyOCReady(planning), "a not-ready OC never fires")
+        XCTAssertFalse(state.shouldNotifyOCReady(nil), "nil OC never fires")
+
+        // Relaunch on the same store: id 5 stays deduped; a new OC id re-arms.
+        let relaunched = AppState(session: mock,
+                                  connectivity: ControllableConnectivity(connected: true),
+                                  defaults: defaults)
+        XCTAssertFalse(relaunched.shouldNotifyOCReady(ready5), "dedup persists across restart")
+        let ready6 = OrganizedCrime2(id: 6, name: "New OC", readyAt: now - 10)
+        XCTAssertTrue(relaunched.shouldNotifyOCReady(ready6), "a new OC id re-arms")
+    }
 }


### PR DESCRIPTION
## Summary

Second bundle of low-risk reliability closures. System-of-record: [`ISA.md`](ISA.md).

### ISC-18 (slice) — OC-ready alert deduplicated persistently
The "OC Ready! 💼" notification now routes through the `NotificationCoordinator`'s persistent epoch dedup (`shouldNotifyOCReady` → `shouldFireOnce("oc.ready", epoch: OC id)`). This **fixes a real cross-restart duplicate**: the old in-memory `previousOCReadyId` was nil after relaunch, so reopening the app while the same OC was still ready fired the alert again. A new OC (new id) re-arms naturally. `previousOCReadyId` is removed.

Why only OC-ready (and not the whole ISC-18 list): cooldown-ready / landing / released are already guarded by an in-memory `if let prev…` that's nil on restart, so they don't cross-restart-duplicate — migrating them changes no behaviour. Bounty deliberately keeps its in-memory set (persistent dedup would break its intended re-alert when a bounty is cleared and re-listed). Price alerts are transient by design.

### F-02 — stocks endpoint health
`recordHealth` now covers the single-call `torn.stocks` fetch, alongside the poll fan-out from the previous bundle. (`market.item` / `forum.*` are per-item loops where one health slot would only show the last item — left as a small follow-up.)

## Tests
- `testOCReadyDedupIsPerIdAndPersistsAcrossRestart` — fires once per id, suppressed on repeat, persists across a relaunch (new AppState on the same store), re-arms on a new id, never fires for a not-ready/nil OC. (A testable `shouldNotifyOCReady` seam was extracted because `NotificationManager` isn't injectable.)
- `testFetchStocksMetadataRecordsHealth`.
- 354 unit tests green (no regression); coverage gate PASSED; Release Universal builds.

## Safety
Read-only; official API only; no PII in health records. No behaviour change without a test — and the one behaviour change (OC-ready) is a strict improvement (kills a duplicate) covered by a persistence test.

## Note
If CI "Build Release" flakes on a Sentry-dependency compiler crash (seen on #27), it's transient — re-run the failed job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * “OC Ready!” notifications now appear only once per operation, including after reopening the app.
  * New operations continue to trigger notifications as expected.

* **Improvements**
  * Diagnostics now include stock-metadata request results alongside existing polling checks.
  * Stock data health reporting provides clearer success and failure status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->