### PR TITLE
release: v1.11.0 compact UX and resilience

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,115 +6,174 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# macos-15 currently ships Xcode 16.4 at this exact path. Using DEVELOPER_DIR
+# avoids the mutable "latest-stable" selector and does not change runner-global state.
+env:
+  DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
+
 jobs:
   unit-tests:
-    name: Unit Tests
+    name: Unit Tests and Coverage
     runs-on: macos-15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      # The repo's Package.resolved is in Xcode 16's PinsStorage v3 format, which the
-      # previously-pinned Xcode 15.2 cannot parse ("unknown 'PinsStorage' version '3'"),
-      # so every job failed package resolution. Use the latest stable Xcode on the image.
-      - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
+      - name: Verify toolchain
+        run: |
+          xcodebuild -version
+          test "$(xcodebuild -version | head -1)" = "Xcode 16.4"
 
-      - name: Show Xcode version
-        run: xcodebuild -version
-
-      - name: Build and Test
+      - name: Run unit tests with coverage
         run: |
           set -o pipefail
+          mkdir -p TestResults
           xcodebuild test \
             -project MacTorn/MacTorn.xcodeproj \
             -scheme MacTorn \
             -destination 'platform=macOS' \
             -only-testing:MacTornTests \
-            -resultBundlePath TestResults.xcresult \
+            -parallel-testing-enabled NO \
+            -resultBundlePath TestResults/UnitTests.xcresult \
+            -derivedDataPath DerivedData/UnitTests \
             -enableCodeCoverage YES \
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
-            | xcpretty --color --report junit
+            | tee TestResults/unit-tests.log
 
-      # ISC-20: reliability-critical modules must stay >= 80% line-covered (views excluded —
-      # they are validated by the UI-test job, not line coverage).
-      - name: Coverage gate (critical modules)
-        run: bash scripts/coverage-gate.sh TestResults.xcresult 80
+      # Reliability-critical modules stay >= 80% line-covered. SwiftUI views are
+      # exercised by the hermetic fixture UI suite instead.
+      - name: Enforce coverage gate
+        run: |
+          set -o pipefail
+          bash scripts/coverage-gate.sh TestResults/UnitTests.xcresult 80 \
+            | tee TestResults/coverage-gate.log
+          xcrun xccov view --report TestResults/UnitTests.xcresult \
+            > TestResults/coverage.txt
 
-      - name: Upload Test Results
-        uses: actions/upload-artifact@v4
+      - name: Upload unit-test xcresult
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
-          name: test-results
-          path: TestResults.xcresult
-
-      - name: Upload Coverage Report
-        uses: actions/upload-artifact@v4
-        if: success()
-        with:
-          name: coverage-report
-          path: TestResults.xcresult
+          name: unit-test-results-${{ github.run_attempt }}
+          path: TestResults/
+          if-no-files-found: warn
+          retention-days: 14
 
   ui-tests:
-    name: UI Tests
+    name: Fixture UI Tests
     runs-on: macos-15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
+      - name: Verify toolchain
+        run: |
+          xcodebuild -version
+          test "$(xcodebuild -version | head -1)" = "Xcode 16.4"
 
-      - name: Build and Run UI Tests
+      - name: Run hermetic fixture UI suite
         run: |
           set -o pipefail
+          mkdir -p TestResults
           xcodebuild test \
             -project MacTorn/MacTorn.xcodeproj \
             -scheme MacTorn \
             -destination 'platform=macOS' \
             -only-testing:MacTornUITests \
+            -parallel-testing-enabled NO \
+            -resultBundlePath TestResults/UITests.xcresult \
+            -derivedDataPath DerivedData/UITests \
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
-            | xcpretty --color
+            | tee TestResults/ui-tests.log
 
-  build:
-    name: Build Release
+      - name: Upload UI-test xcresult
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: ui-test-results-${{ github.run_attempt }}
+          path: TestResults/
+          if-no-files-found: warn
+          retention-days: 14
+
+  analyze-and-release:
+    name: Analyze and Universal Ad-hoc Release
     runs-on: macos-15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
-
-      - name: Build Release
+      - name: Verify toolchain
         run: |
+          xcodebuild -version
+          test "$(xcodebuild -version | head -1)" = "Xcode 16.4"
+
+      - name: Analyze
+        run: |
+          set -o pipefail
+          mkdir -p TestResults
+          xcodebuild analyze \
+            -project MacTorn/MacTorn.xcodeproj \
+            -scheme MacTorn \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            -resultBundlePath TestResults/Analyze.xcresult \
+            -derivedDataPath DerivedData/Analyze \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            | tee TestResults/analyze.log
+
+      - name: Build universal ad-hoc Release
+        run: |
+          set -o pipefail
           xcodebuild build \
             -project MacTorn/MacTorn.xcodeproj \
             -scheme MacTorn \
             -configuration Release \
             -destination 'generic/platform=macOS' \
+            -resultBundlePath TestResults/Release.xcresult \
+            -derivedDataPath DerivedData/Release \
             ARCHS="arm64 x86_64" \
             ONLY_ACTIVE_ARCH=NO \
+            CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="-" \
-            CODE_SIGNING_REQUIRED=NO
+            CODE_SIGNING_ALLOWED=YES \
+            CODE_SIGNING_REQUIRED=YES \
+            | tee TestResults/release.log
 
-      - name: Archive Build
+      - name: Verify universal architectures and ad-hoc signature
         run: |
-          xcodebuild archive \
-            -project MacTorn/MacTorn.xcodeproj \
-            -scheme MacTorn \
-            -destination 'generic/platform=macOS' \
-            -archivePath build/MacTorn.xcarchive \
-            CODE_SIGN_IDENTITY="-" \
-            CODE_SIGNING_REQUIRED=NO
+          set -euo pipefail
+          app='DerivedData/Release/Build/Products/Release/MacTorn.app'
+          binary="$app/Contents/MacOS/MacTorn"
+          archs="$(lipo -archs "$binary")"
+          echo "Architectures: $archs"
+          grep -qw arm64 <<<"$archs"
+          grep -qw x86_64 <<<"$archs"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          codesign -dv --verbose=4 "$app" 2>&1 \
+            | tee TestResults/codesign.txt
+          grep -q '^Signature=adhoc$' TestResults/codesign.txt
+
+      - name: Upload analyze and Release xcresults
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: analyze-release-results-${{ github.run_attempt }}
+          path: TestResults/
+          if-no-files-found: warn
+          retention-days: 14

--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,0 +1,167 @@
+# MacTorn — raport audytu technicznego i bezpieczeństwa
+
+Data audytu: 2026-07-30
+Audytowana wersja bazowa: 1.10.0 (build 1), macOS 14+
+Stan dokumentu: po wdrożeniach T01–T17 i zielonych lokalnych bramkach automatycznych
+
+## Executive summary
+
+MacTorn ma solidny fundament: natywny SwiftUI, minimalny sandbox, klucz Torn w Keychain, opt-in Sentry bez domyślnego PII oraz hermetyczne fixture'y. Audyt i kolejne fale prac usunęły potwierdzone problemy z izolacją konta, budżetem API, semantyką odpowiedzi, wiarygodnością freshness, odwracalnością akcji, nawigacją i dostępnością.
+
+Stan potwierdzony:
+
+- 0 otwartych P0/P1;
+- Debug build: PASS;
+- finalny `build-for-testing`: PASS;
+- `make coverage-gate`: PASS;
+- 428/428 testów jednostkowych: PASS, 0 failed, 0 skipped;
+- 8/8 testów UI: PASS, 0 failed, 0 skipped;
+- Sentry Cocoa resolved: 9.23.0;
+- `AppState.swift`: 377 linii; pięć wydzielonych serwisów/store i sześć plików extension;
+- Quick Travel ma aktualne czasy Standard i Airstrip + pilot, a aktywny lot pozostaje API-driven;
+- docelowy Release pozostaje universal i podpisywany ad hoc zgodnie z decyzją T16-A.
+
+Ocena gotowości: **lokalny automated release candidate jest zielony**. Otwarte pozostaje manualne QA systemowe T14/T15 oraz pierwszy rzeczywisty run nowego workflow CI. Developer ID i notarization nie są częścią przyjętego zakresu T16-A.
+
+## Zakres i mapa projektu
+
+Aktualny snapshot drzewa:
+
+- 51 plików produkcyjnych Swift, 11 920 linii;
+- 37 plików testowych Swift, 7 265 linii;
+- 428 metod unit i 8 metod UI w źródłach;
+- jedna zewnętrzna zależność SPM: Sentry Cocoa 9.23.0.
+
+```mermaid
+flowchart LR
+    UI["MenuBarExtra / SwiftUI"] --> AS["AppState facade, 377 linii"]
+    AS --> AC["AccountSessionStore"]
+    AS --> US["UserSnapshotService"]
+    AS --> FS["FactionService"]
+    AS --> MS["MarketWatchService"]
+    AS --> FWS["ForumWatchService"]
+    AS --> PC["PollingCoordinator"]
+    AS --> NC["NotificationCoordinator"]
+    AS --> EH["EndpointHealthTracker"]
+    AC --> KC["macOS Keychain"]
+    US --> API["Torn API v1/v2"]
+    FS --> API
+    MS --> API
+    FWS --> API
+    AS --> DG["Diagnostics bez PII"]
+    SM["SentryManager opt-in"] --> SE["Sentry Cocoa 9.23.0"]
+```
+
+`AppState.swift` spełnia cel cienkiego facade poniżej 800 linii. Logika wspierająca jest rozłożona na sześć tematycznych extension files, a granice account/user/faction/market/forum są dodatkowo wydzielone do pięciu testowalnych serwisów/store.
+
+## Naprawione problemy
+
+| ID | Priorytet | Problem | Aktualny stan i dowód |
+|---|---:|---|---|
+| F-01 | P1 | Spóźniona odpowiedź starego klucza mogła opublikować dane poprzedniego konta. | Generation token, `AccountSessionStore`, anulowanie i kontrola przed publikacją. Test unit oraz syntetyczny UI A→B przechodzą. |
+| F-02 | P1 | Część ścieżek mogła ominąć wspólny limit requestów. | Jedna bramka `reserveRequest`; testy wszystkich ścieżek i hard cap przechodzą. |
+| F-03 | P2 | Niepoprawny payload mógł wyglądać jak udany refresh. | Semantyczny kontrakt odpowiedzi, freshness per endpoint i zachowanie ostatnich dobrych danych. |
+| F-04 | P2 | Logi lub transportowy błąd mogły ujawniać URL/dane domenowe. | Typowane komunikaty, redakcja URL, ograniczone logi i Diagnostics bez PII. |
+| F-05 | P2 | Uszkodzone preferencje i niepoprawne dane formularzy. | Allowlisty interwałów, walidacja klucza/forum/watchlisty i dodatniego progu ceny. |
+| F-06 | P2 | Kolizje `TornEvent.id`. | Stabilny klucz API, z bezpiecznym fallbackiem. |
+| F-07 | P2 | Brak pełnej semantyki AX i niespójny feedback błędów. | AX labels/values/selected traits, wspólny `ModuleStateView`, recovery CTA i semantyczne fonty. |
+| F-08 | P2 | Usuwanie watchlisty i wątku było nieodwracalne. | Sześciosekundowe Undo przywraca pełny element i pierwotną pozycję. |
+| F-09 | P2 | Siedem tabów i tekst 8 pt w powierzchni 320 pt. | Nawigacja `Now / Account / Watch`, aktywny drugi picker i skróty `⌘1…⌘7`. |
+| F-10 | P3 | Watchlist/forum uruchamiały nieograniczony fan-out. | `BoundedTaskQueue` z limitem 4 i obsługą anulowania. |
+| F-11 | P3 | Monolityczny `AppState.swift` zwiększał ryzyko regresji. | 377-liniowy facade, 5 serwisów/store, 6 extension files i 31 izolowanych testów serwisów. |
+| F-12 | P3 | Sentry Cocoa pozostawał na 9.12.0. | Resolved 9.23.0; testy opt-in/off, crash-only i PII scrubbera przechodzą w pełnym unit suite. |
+| F-13 | P2 | Quick Travel używał nieaktualnej tabeli i nie rozróżniał metod. | Oficjalne czasy po Patch #438, jawny Standard/Airstrip + pilot, ±3%; aktywny lot używa pól API. |
+| F-14 | P2 | Status i Settings tworzyły zbyt długie, powtarzalne powierzchnie przewijania. | Status ma wysokość 480 pt i pojedynczy pasek najbliższej akcji; Settings pokazuje jedną z sześciu stale dostępnych sekcji. |
+| F-14 | P2 | Prefilled SecureField w Settings tracił placeholder na macOS 26 i eksponował pustą etykietę AX. | Dodano jawne `.accessibilityLabel("Torn API Key")`; finalny all-modules+Settings AX test przechodzi. |
+
+## Pozostałe ryzyka i blokery
+
+| ID | Priorytet | Stan | Następna akcja |
+|---|---:|---|---|
+| R-01 | P2 | Manualny VoiceOver audio, real Full Keyboard Access oraz systemowe Reduce Motion/Increase Contrast nie zostały wykonane. | Przejść macierz 7 modułów + Settings na dedykowanym profilu macOS. |
+| R-02 | P2 | Test z dwoma prawdziwymi kontami nie został wykonany; automatyczny fixture A→B jest zielony. | Użytkownik dostarcza dwa testowe klucze przez UI i zatwierdza scenariusz. |
+| R-03 | P2 | Powiadomienia systemowe i Launch at Login wymagają zgody oraz trwałej zmiany stanu systemu. | Wykonać na osobnym profilu macOS po jawnej akceptacji. |
+| R-04 | P3 | Sześć extension files ma łącznie 1 640 linii; część orkiestracji nadal należy do facade. | Dalszy podział tylko przy konkretnych metrykach regresji/utrzymania, bez rewrite'u. |
+| R-05 | P3 | Nowy workflow CI jest skonfigurowany, ale nie był jeszcze wykonany zdalnie z tego nieopublikowanego worktree. | Po pushu zachować pierwszy zielony zestaw artefaktów CI. |
+
+## Bezpieczeństwo i prywatność
+
+- Klucz Torn pozostaje w macOS Keychain; dawna wartość `UserDefaults` jest migrowana/usuwana.
+- Logi requestów są redagowane, a Diagnostics nie pokazuje klucza, nazwy ani ID gracza.
+- Sentry 9.23.0 jest off-by-default, nie startuje w UI tests, ma `sendDefaultPii = false`, wyłączone śledzenie requestów i scrubbery zdarzeń/breadcrumbs.
+- Jedna atomowa bramka budżetu działa przed każdą ścieżką sieciową.
+- Release używa minimalnych entitlementów: app sandbox i network client.
+- T16-A świadomie pozostawia lokalny artefakt przy strict ad-hoc signing; Developer ID, notarization, stapling i publikacja są poza zakresem.
+- Finalny `make scan` przeszedł bez wykrytych wycieków.
+
+## Wydajność i niezawodność
+
+- Parsowanie snapshotu odbywa się poza MainActor; publikacja wraca na MainActor.
+- Cięższe endpointy mają osobne minimalne interwały i per-endpoint backoff.
+- Watchlist i forum korzystają z bounded concurrency = 4.
+- Daily-row-limit pauzuje wyłącznie dotknięte źródło.
+- Freshness nie zastępuje ostatnich poprawnych danych przejściowym błędem.
+- Brak świeżych pomiarów Instruments; nie rekomenduje się mikrooptymalizacji bez metryk.
+
+## Zależności
+
+Jedyna zależność zewnętrzna:
+
+- wymaganie SPM: `upToNextMajor` od 9.0.0;
+- resolved: **Sentry Cocoa 9.23.0**;
+- revision: `afa7510e05b99f35c1febe47566bfd868fa53fb9`;
+- opt-in/off i PII contract są przypięte testami.
+
+## Wyniki walidacji
+
+### Baseline audytu
+
+| Kontrola | Wynik |
+|---|---|
+| `make test` | PASS, 354/354. |
+| `make coverage-gate` | PASS, wszystkie krytyczne moduły ≥80%. |
+| Debug / analyze / universal ad-hoc Release | PASS dla bazowego zakresu audytu. |
+| UI runner | Pierwotnie BLOCKED przez lokalny bootstrap/automation timeout. |
+
+### Aktualny stan po T01–T17
+
+| Kontrola | Wynik |
+|---|---|
+| Final Debug build | PASS. |
+| Final `build-for-testing` | PASS. |
+| `make coverage-gate` | **PASS; 428/428, 0 failed, 0 skipped.** |
+| Result bundle | `/Users/pawelorzech/Programowanie/MacTorn/TestResults.xcresult` |
+| `TornAPIError` | 99,07%. |
+| `TornEndpoint` | 83,56%. |
+| `PollingCoordinator` | 100%. |
+| `NotificationCoordinator` | 100%. |
+| `NextAction` | 96,51%. |
+| 320 pt accessibility-display navigation smoke | PASS. |
+| Syntetyczny UI account A→B | PASS. |
+| Finalny all-modules + Settings AX | PASS, 48.535 s. |
+| Finalny stale account-switch UI | PASS, 15.534 s. |
+| Pełny final UI suite | **PASS; 8/8, 0 failed, 0 skipped, 0 expected failures.** Bundle: `/tmp/mactorn-final-ui-suite-20260730-1058-clean.xcresult`. |
+| Final post-merge `make analyze` | PASS, ponowiony po poprawce AX produkcyjnego SecureField. |
+| Final `make scan` | PASS, brak wycieków. |
+| `make release` | PASS po usunięciu wyłącznie przestarzałego Sentry PCM z `DerivedData/Release`; początkowy błąd cache nie był błędem kodu. |
+| `make verify-release` | PASS; artefakt `DerivedData/Release/Build/Products/Release/MacTorn.app`. |
+| Final universal strict ad-hoc Release | PASS; `x86_64 arm64`, `Signature=adhoc`, brak TeamIdentifier, strict/deep codesign i DR valid. |
+
+## Manualny QA przed lokalnym wydaniem
+
+- [x] Hermetyczny full fixture, invalid key i offline.
+- [x] Grouped navigation oraz selected state w AX.
+- [x] Walidacja progu ceny i forum zachowuje błędny input.
+- [x] Undo watchlisty i forum ma testy regresyjne.
+- [x] Synthetic account A→B nie pokazuje spóźnionej tożsamości A.
+- [ ] VoiceOver audio: wszystkie moduły i Settings.
+- [ ] Rzeczywisty Full Keyboard Access.
+- [ ] Systemowe Reduce Motion, Increase Contrast i Reduce Transparency.
+- [ ] Dwa rzeczywiste konta testowe A→B.
+- [ ] Permission, treść i kliknięcie powiadomienia.
+- [ ] Launch at Login po wylogowaniu/zalogowaniu.
+- [x] Finalny pełny UI suite 8/8.
+- [x] Finalny post-merge analyze i scan.
+- [x] Universal strict ad-hoc Release.
+
+Developer ID, notarization i Gatekeeper distribution smoke nie są blockerem przyjętego lokalnego T16-A. Wymagałyby nowej decyzji i osobnej zgody.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] — 2026-07-30 — compact UX & resilience
+
+### Changed
+- **Status at a glance.** The oversized Next Action panel is now a compact single-row
+  summary, and the Status popover uses a fixed, denser layout so the important timers
+  remain visible without excessive scrolling.
+- **Settings by category.** Settings now opens one of six focused sections at a time
+  instead of presenting one long, deeply scrollable form.
+- **Current travel planning.** Destination times follow Torn's current official values
+  and can be calculated for either standard airport travel or a Private Island airstrip
+  with a pilot.
+- **Clearer navigation and commands.** Related destinations are grouped consistently,
+  common actions have keyboard shortcuts, and destructive actions expose Undo where
+  appropriate.
+- **Privacy-safe diagnostics.** Sentry was updated to 9.23 and diagnostics, feedback,
+  and account transitions were tightened to avoid leaking sensitive Torn data.
+
+### Added
+- **Freshness and recovery states** across live modules, including explicit loading,
+  stale-data, empty, permission, and retry states.
+- **Account-scoped sessions and snapshots** so switching API keys cannot retain data,
+  notifications, or pending work from the previous Torn account.
+- **Bounded service fan-out** for faction, market, forum, stocks, and user snapshots,
+  with focused service tests and deterministic persistence coverage.
+- **Accessibility and UX audit artifacts** with an implementation backlog and traceable
+  recommendations for the completed quality pass.
+
+### Fixed
+- Long-lived polling and notification state now resets safely when the active account
+  changes.
+- Input validation, semantic snapshot comparison, and endpoint error handling now
+  produce actionable recovery paths instead of ambiguous or duplicated UI states.
+- The monolithic `AppState` implementation was split into focused services and
+  extensions, reducing state coupling while preserving existing behavior.
+
+### Quality
+- Expanded unit, integration, UI-harness, and service coverage; reliability-critical
+  modules remain protected by the 80% line-coverage gate.
+- Release validation now checks a universal `arm64` + `x86_64` binary and strict
+  ad-hoc signing, matching the project's ad-hoc distribution policy.
+
 ## [1.10.0] — 2026-07-15 — reliability & product audit
 
 A large reliability + product pass (audit Etaps A–G, C, and follow-ups). Highlights: key

--- a/CHANGELOG_AGENT.md
+++ b/CHANGELOG_AGENT.md
@@ -1,0 +1,118 @@
+# CHANGELOG_AGENT
+
+## 2026-07-30 — audyt i wdrożenia T01–T17
+
+### Zakres
+
+Przeprowadzono audyt kodu, bezpieczeństwa, sieci, pollingów, buildów, zależności, architektury i interfejsu macOS. Wdrożono testowane poprawki T01–T13 i T17, przygotowano automatyczną część T14/T15 oraz zachowano decyzję T16-A o lokalnym universal Release podpisywanym ad hoc.
+
+### Zmiany produkcyjne
+
+#### Izolacja konta i stan
+
+- Dodano generation barrier oraz `AccountSessionStore`.
+- Zmiana klucza anuluje stare zadania i czyści dane poprzedniego konta.
+- Odpowiedzi user/faction/activity/v2 oraz key validation publikują stan wyłącznie dla bieżącej sesji.
+- Wydzielono `UserSnapshotService`, `FactionService`, `MarketWatchService` i `ForumWatchService`.
+- `AppState.swift` zmniejszono z 2 256 do 377 linii; logika pomocnicza znajduje się w sześciu extension files.
+
+#### Sieć, freshness i współbieżność
+
+- Wszystkie ścieżki rezerwują request przez wspólną bramkę przed wykonaniem.
+- Watchlist i forum korzystają z bounded concurrency = 4 z obsługą anulowania.
+- Semantyczny kontrakt odpowiedzi nie traktuje brakującego krytycznego payloadu jako sukcesu.
+- Freshness i zdrowie są śledzone per endpoint.
+- Ostatnie poprawne dane pozostają widoczne podczas błędu chwilowego.
+- `lastUpdated` zmienia się wyłącznie po poprawnym głównym snapshotcie.
+
+#### UX, Accessibility i Settings
+
+- Dodano wspólny `ModuleStateView` dla loading / empty / stale / offline / permission / rate limit i recovery.
+- Dodano walidację dodatniego progu ceny, inline error, disabled Set i bezpieczny Enter.
+- Watchlist i forum mają sześciosekundowe Undo pełnego elementu i pozycji.
+- Nawigację siedmiu tabów zastąpiły grupy `Now / Account / Watch`.
+- Produkcyjne widoki używają fontów semantycznych co najmniej `.caption2`.
+- Commands zapewnia Refresh `⌘R`, Settings `⌘,` i moduły `⌘1…⌘7`.
+- Kliknięcia, Commands i UI-test window współdzielą `AppNavigationState`.
+- Settings ma stały przełącznik sześciu kategorii i pokazuje jedną sekcję naraz; przewija się tylko treść aktywnej sekcji, gdy naprawdę nie mieści się w panelu.
+- Status ma ograniczoną wysokość, a rozbudowana lista Next Action została zastąpiona pojedynczym paskiem najbliższej akcji.
+- Rozszerzono AX labels, values, selected traits i widoczny focus.
+- Prefilled Settings SecureField dostał jawną etykietę AX `Torn API Key`; na macOS 26 placeholder znikał po wypełnieniu i pozostawiał pustą nazwę.
+
+#### Quick Travel
+
+- Zaktualizowano 11 kierunków do oficjalnych czasów po Torn Patch #438.
+- Dodano jawny wybór Standard / Airstrip + pilot i informację o wymaganym upgrade/pilocie.
+- UI informuje o wariancji ±3%.
+- Aktywny lot nadal używa API `timestamp`, `departed` i `time_left`, nie lokalnej estymaty.
+- Preferencja Private Island steruje wyłącznie skrótem/ikoną powrotu.
+
+#### Prywatność i zależności
+
+- Sentry Cocoa zaktualizowano z 9.12.0 do **9.23.0**.
+- Sentry pozostaje off-by-default, nie startuje w UI tests, ma wyłączone PII/network tracking i scrubbery URL.
+- Usunięto wrażliwe wartości domenowe oraz surowe transportowe opisy z logów.
+- Diagnostics pozostaje bez PII.
+
+#### CI i lokalne bramki
+
+- Workflow macOS ma osobne joby unit/coverage, fixture UI oraz analyze/universal ad-hoc Release.
+- Akcje GitHub są przypięte do pełnych SHA.
+- Dodano read-only diagnostykę lokalnego runnera XCTest.
+- Makefile rozróżnia lokalny ad-hoc Release i opcjonalny, nieużywany `release-signed`.
+
+### Testy dodane lub rozszerzone
+
+- izolacja A→B, reset konta i spóźnione odpowiedzi/walidacje;
+- wszystkie request paths i wspólny hard cap;
+- semantyczne kontrakty full/custom/underprivileged/empty payload;
+- bounded concurrency i anulowanie watchlist/forum;
+- freshness, recovery i endpoint health;
+- walidacja progu ceny i Undo;
+- grouped navigation, Commands i sekcje Settings;
+- Sentry opt-in/off, crash-only i PII scrubber;
+- pięć wydzielonych serwisów/store: 31 izolowanych metod testowych;
+- Quick Travel: 24 testy, w tym komplet Standard/Airstrip i API-driven active flight;
+- hermetyczny syntetyczny scenariusz UI account A→B.
+
+Aktualna liczba metod w źródłach:
+
+- unit: **428**;
+- UI: **8**;
+- razem: **436**.
+
+### Walidacja
+
+- `make coverage-gate`: PASS.
+- MacTornTests: **428 passed, 0 failed, 0 skipped**.
+- Result bundle: `/Users/pawelorzech/Programowanie/MacTorn/TestResults.xcresult`.
+- Coverage: `TornAPIError` 99,07%, `TornEndpoint` 83,56%, `PollingCoordinator` 100%, `NotificationCoordinator` 100%, `NextAction` 96,51%.
+- Final Debug build: PASS.
+- Final `build-for-testing`: PASS.
+- Final post-merge `make analyze`: PASS, ponowiony po poprawce AX SecureField.
+- Final `make scan`: PASS, brak wycieków.
+- 320 pt accessibility-display navigation smoke: PASS.
+- Synthetic account A→B UI regression: PASS.
+- Final MacTornUITests: **8/8 passed, 0 failed, 0 skipped, 0 expected failures**.
+- UI result bundle: `/tmp/mactorn-final-ui-suite-20260730-1058-clean.xcresult`.
+- All-modules + Settings AX: PASS, 48.535 s.
+- Stale account switch: PASS, 15.534 s.
+- `make release`: PASS po wyczyszczeniu wyłącznie przestarzałego cache Sentry PCM w `DerivedData/Release`; początkowy błąd cache nie był błędem kodu.
+- `make verify-release`: PASS.
+- Artefakt: `DerivedData/Release/Build/Products/Release/MacTorn.app`.
+- Architektury: `x86_64 arm64`.
+- Podpis: `Signature=adhoc`, brak `TeamIdentifier`; strict/deep codesign i designated requirement są poprawne.
+
+### Nadal oczekujące manualnie
+
+- manualny VoiceOver audio;
+- rzeczywisty Full Keyboard Access;
+- systemowe Reduce Motion / Increase Contrast / Reduce Transparency;
+- dwa rzeczywiste konta testowe;
+- systemowe notifications i Launch at Login.
+
+Pierwszy rzeczywisty run nowego workflow CI pozostaje niezweryfikowany do czasu publikacji zmian.
+
+### Decyzja dystrybucyjna T16
+
+Pozostajemy przy **T16-A: universal strict ad-hoc Release do użytku lokalnego**. Developer ID, notarization, stapling, Gatekeeper distribution smoke i publikacja nie zostały wykonane i nie są blockerem lokalnego zakresu. Każde rozszerzenie dystrybucji wymaga nowej decyzji oraz jawnej zgody.

--- a/IMPLEMENTATION_BACKLOG.md
+++ b/IMPLEMENTATION_BACKLOG.md
@@ -1,0 +1,160 @@
+# MacTorn — stan realizacji i pozostały backlog
+
+Data: 2026-07-30
+Status: lokalne bramki automatyczne T01 i wdrożenia T02–T13/T17 zakończone; T14/T15 wymagają manualnego QA; T16-A pozostaje decyzją końcową
+
+Skala dawnych decyzji: Impact, Confidence, Effort i Risk 1–5.
+`Priority score = Impact × Confidence / Effort`.
+
+## Stan tematów
+
+| ID | Temat | Wybrany wariant | Stan | Aktualny dowód / następny krok |
+|---|---|---|---|---|
+| T01 | Zielone testy i CI | B — macOS CI + lokalny recovery | Lokalne bramki zakończone | 428/428 unit i 8/8 UI; coverage, Debug, build-for-testing, analyze, scan i Release PASS. Pierwszy zdalny workflow pozostaje niezweryfikowany do czasu publikacji. |
+| T02 | Walidacja alertu cenowego | A — inline validation | Zakończone | Dodatnia liczba całkowita, inline error, disabled Set, błędny Enter nie zamyka formularza. |
+| T03 | Odwracalne usuwanie | B — Undo 6 s | Zakończone | Watchlist i forum przywracają pełny element, ustawienia i pozycję. |
+| T04 | Nawigacja siedmiu modułów | B — Now / Account / Watch | Zakończone | Maks. 2 akcje do modułu, selected AX, zachowane test IDs. |
+| T05 | Semantic fonts | B — migracja + layout checks | Zakończone automatycznie | Brak 8 pt, minimum `.caption2`; 320 pt smoke PASS. Real system contrast/większy tekst pozostaje w T14. |
+| T06 | Loading/empty/error/recovery | A — wspólny komponent | Zakończone | `ModuleStateView` i kontekstowe Retry/Settings. |
+| T07 | Freshness per moduł | B — status per endpoint | Zakończone | Fresh/stale/error bez usuwania ostatnich dobrych danych. |
+| T08 | Współbieżność watchlist/forum | B — bounded concurrency = 4 | Zakończone | `BoundedTaskQueue`, limit 4, anulowanie i testy. |
+| T09 | Semantyczna walidacja odpowiedzi | B — kontrakt capabilities | Zakończone | Full/custom/underprivileged/empty payload i brak fałszywego `lastUpdated`. |
+| T10 | Podział `AppState` | A — serwisy + facade | Zakończone | `AppState.swift` 377 linii, 5 serwisów/store, 6 extension files, izolowane testy. |
+| T11 | Aktualizacja Sentry | A — 9.23.x | Zakończone | Resolved 9.23.0; opt-in/off, crash-only i PII scrubber w zielonym unit suite. |
+| T12 | Keyboard-first | B — skróty + focus + testy | Zakończone w kodzie | Commands, `⌘R`, `⌘,`, `⌘1…⌘7`, Escape i focus. Real Full Keyboard Access pozostaje w T14. |
+| T13 | Porządek w Settings | A — stały przełącznik sekcji | Zakończone | 6 stale widocznych kategorii; jedna aktywna sekcja naraz, z lokalnym scrollem tylko dla nadmiarowej treści. |
+| T14 | Pełny audyt accessibility | B — VoiceOver + keyboard + kontrast | Częściowo | Automatyczny AX/320 pt smoke PASS; manualna macierz systemowa otwarta. |
+| T15 | Scenariusze systemowe i konta | B — fixture + dwa konta | Częściowo | Synthetic A→B PASS; realne konta, notifications i Launch at Login otwarte. |
+| T16 | Dystrybucja | A — pozostajemy przy ad-hoc | Zakończona decyzja | Universal `x86_64 arm64`, strict/deep ad-hoc PASS. Bez Developer ID/notary/publikacji. |
+| T17 | Aktualne czasy lotów | A — API live + Patch #438 + Airstrip | Zakończone | 24 TravelTests; 11×Standard, 11×Airstrip; aktywny lot API-driven. |
+
+## Aktualny punkt odniesienia
+
+- Produkcja Swift: 51 plików / 11 920 linii.
+- Testy Swift: 37 plików / 7 265 linii.
+- Unit methods w źródłach: 428.
+- UI methods w źródłach: 8.
+- Sentry Cocoa resolved: 9.23.0.
+- `AppState.swift`: 377 linii.
+- Sześć plików extension `AppState+*.swift`: łącznie 1 640 linii.
+- Serwisy/store:
+  - `AccountSessionStore`;
+  - `UserSnapshotService`;
+  - `FactionService`;
+  - `MarketWatchService`;
+  - `ForumWatchService`.
+
+## Zamknięte fale wykonawcze
+
+### Fala 1 — niezawodność i quick wins
+
+- [x] T02 walidacja alertu.
+- [x] T03 Undo.
+- [x] T06 wspólne stany/recovery.
+- [x] T07 freshness.
+- [x] T08 bounded concurrency.
+- [x] T09 kontrakty odpowiedzi.
+
+### Fala 2 — nawigacja, dostępność i maintenance
+
+- [x] T04 grouped navigation.
+- [x] T05 semantic fonts i 320 pt checks.
+- [x] T11 Sentry 9.23.0.
+- [x] T12 Commands i keyboard-first.
+- [x] T13 Settings IA.
+- [x] T17 Quick Travel Standard/Airstrip + pilot.
+
+### Fala 3 — architektura
+
+- [x] `AccountSessionStore` i `UserSnapshotService`.
+- [x] `FactionService`, `MarketWatchService` i `ForumWatchService`.
+- [x] 377-liniowy `AppState.swift` facade.
+- [x] 31 izolowanych testów pięciu serwisów/store.
+
+## Pozostała kolejka
+
+### T01 — końcowe bramki automatyczne
+
+Potwierdzone:
+
+- [x] final Debug;
+- [x] final build-for-testing;
+- [x] `make coverage-gate`;
+- [x] 428/428 unit, 0 failed, 0 skipped;
+- [x] finalny post-merge `make analyze`;
+- [x] finalny `make scan`, brak wycieków;
+- [x] universal strict ad-hoc Release;
+- [x] 320 pt accessibility-display smoke;
+- [x] synthetic A→B UI regression.
+- [x] finalny pełny zestaw 8 UI tests, 0 failed/skipped/expected.
+
+Oczekujące:
+
+- [ ] pierwszy zdalny run nowego workflow CI i zachowanie artefaktów.
+
+Unit result bundle: `/Users/pawelorzech/Programowanie/MacTorn/TestResults.xcresult`.
+UI result bundle: `/tmp/mactorn-final-ui-suite-20260730-1058-clean.xcresult`.
+
+Coverage:
+
+- `TornAPIError`: 99,07%;
+- `TornEndpoint`: 83,56%;
+- `PollingCoordinator`: 100%;
+- `NotificationCoordinator`: 100%;
+- `NextAction`: 96,51%.
+
+### T14 — manualny audit systemowej dostępności
+
+Automatyczne kontrakty AX i 320 pt smoke są zielone, ale nie zastępują:
+
+- [ ] VoiceOver audio i kolejności czytania dla 7 modułów + Settings;
+- [ ] rzeczywistego Full Keyboard Access, focus ring i kolejności Tab/Shift-Tab;
+- [ ] systemowego Reduce Motion;
+- [ ] systemowego Increase Contrast;
+- [ ] systemowego Reduce Transparency;
+- [ ] większego tekstu/zoom w powierzchni 320 pt.
+
+Definition of done: manualna macierz bez otwartego P1/P2; automatyzowalne regresje dostają test.
+
+### T15 — manualne konta i integracje systemowe
+
+Automatyczny fixture A→B przechodzi i dowodzi, że opóźniona, niekooperatywna odpowiedź A nie wraca po publikacji B.
+
+Nadal wymagają jawnej zgody i przygotowania użytkownika:
+
+- [ ] dwa dedykowane testowe klucze podane wyłącznie przez UI;
+- [ ] brak flasha i danych A w każdym module po przejściu na B;
+- [ ] permission, treść, timing, kliknięcie i odmowa notifications;
+- [ ] Launch at Login po wylogowaniu/zalogowaniu oraz po wyłączeniu.
+
+Agent nie odczytuje Keychain, nie zapisuje kluczy w logach i nie zmienia zgód/systemowego login item bez autoryzacji.
+
+### T16 — utrzymana decyzja ad-hoc
+
+Decyzja użytkownika: **T16-A**.
+
+- [x] `make release`: PASS.
+- [x] `make verify-release`: PASS.
+- [x] Artefakt: `DerivedData/Release/Build/Products/Release/MacTorn.app`.
+- [x] `x86_64 arm64`.
+- [x] `Signature=adhoc`, brak `TeamIdentifier`.
+- [x] Strict/deep codesign i designated requirement: PASS.
+- [ ] Developer ID: poza zakresem.
+- [ ] Notarization/stapling: poza zakresem.
+- [ ] Gatekeeper distribution smoke/publikacja: poza zakresem.
+
+Początkowy błąd Sentry PCM po zmianie zależności był wyłącznie starym cache w `DerivedData/Release`. Po usunięciu tego scoped cache niezmienione polecenie Release przeszło.
+
+## Globalne Definition of Done
+
+Każda przyszła zmiana musi zachować:
+
+- test regresyjny dla zmienionej logiki;
+- brak sekretów i PII w logach/diagnostyce;
+- `git diff --check`;
+- build-for-testing, unit i coverage gate;
+- analyze;
+- dla lokalnego Release: universal binary i strict ad-hoc codesign;
+- manualny smoke zmienionej ścieżki;
+- aktualizację dokumentacji;
+- brak commit/push/publikacji bez osobnej zgody.

--- a/MacTorn/MacTorn.xcodeproj/project.pbxproj
+++ b/MacTorn/MacTorn.xcodeproj/project.pbxproj
@@ -15,6 +15,17 @@
 		AAA00003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AAA10003 /* Assets.xcassets */; };
 		AAA00004 /* TornModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10004 /* TornModels.swift */; };
 		AAA00005 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10005 /* AppState.swift */; };
+		AAA00041 /* AccountSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10041 /* AccountSessionStore.swift */; };
+		AAA00042 /* UserSnapshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10042 /* UserSnapshotService.swift */; };
+		AAA00043 /* MarketWatchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10043 /* MarketWatchService.swift */; };
+		AAA00044 /* ForumWatchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10044 /* ForumWatchService.swift */; };
+		AAA00045 /* FactionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10045 /* FactionService.swift */; };
+		AAA00046 /* AppState+MarketForum.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10046 /* AppState+MarketForum.swift */; };
+		AAA00047 /* AppState+NotificationsFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10047 /* AppState+NotificationsFeedback.swift */; };
+		AAA00048 /* AppState+PersistenceStocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10048 /* AppState+PersistenceStocks.swift */; };
+		AAA00049 /* AppState+LiveNextAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10049 /* AppState+LiveNextAction.swift */; };
+		AAA00050 /* AppState+PollingUserFetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10050 /* AppState+PollingUserFetch.swift */; };
+		AAA00051 /* AppState+FactionFetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10051 /* AppState+FactionFetch.swift */; };
 		AAA00006 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10006 /* SettingsView.swift */; };
 		AAA00007 /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10007 /* StatusView.swift */; };
 		AAA00008 /* ProgressBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10008 /* ProgressBarView.swift */; };
@@ -78,6 +89,11 @@
 		AAA00036 /* DiagnosticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10036 /* DiagnosticsView.swift */; };
 		BBB00028 /* DiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10028 /* DiagnosticsTests.swift */; };
 		BBB00030 /* UITestHarnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10030 /* UITestHarnessTests.swift */; };
+		BBB00032 /* AccountSessionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10032 /* AccountSessionStoreTests.swift */; };
+		BBB00033 /* UserSnapshotServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10033 /* UserSnapshotServiceTests.swift */; };
+		BBB00034 /* MarketWatchServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10034 /* MarketWatchServiceTests.swift */; };
+		BBB00035 /* ForumWatchServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10035 /* ForumWatchServiceTests.swift */; };
+		BBB00036 /* FactionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10036 /* FactionServiceTests.swift */; };
 		AAA00037 /* NextAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10037 /* NextAction.swift */; };
 		AAA00038 /* NextActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10038 /* NextActionView.swift */; };
 		BBB00029 /* NextActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10029 /* NextActionTests.swift */; };
@@ -108,6 +124,17 @@
 		AAA10003 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AAA10004 /* TornModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TornModels.swift; sourceTree = "<group>"; };
 		AAA10005 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		AAA10041 /* AccountSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSessionStore.swift; sourceTree = "<group>"; };
+		AAA10042 /* UserSnapshotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSnapshotService.swift; sourceTree = "<group>"; };
+		AAA10043 /* MarketWatchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketWatchService.swift; sourceTree = "<group>"; };
+		AAA10044 /* ForumWatchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForumWatchService.swift; sourceTree = "<group>"; };
+		AAA10045 /* FactionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactionService.swift; sourceTree = "<group>"; };
+		AAA10046 /* AppState+MarketForum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+MarketForum.swift"; sourceTree = "<group>"; };
+		AAA10047 /* AppState+NotificationsFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+NotificationsFeedback.swift"; sourceTree = "<group>"; };
+		AAA10048 /* AppState+PersistenceStocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+PersistenceStocks.swift"; sourceTree = "<group>"; };
+		AAA10049 /* AppState+LiveNextAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+LiveNextAction.swift"; sourceTree = "<group>"; };
+		AAA10050 /* AppState+PollingUserFetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+PollingUserFetch.swift"; sourceTree = "<group>"; };
+		AAA10051 /* AppState+FactionFetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+FactionFetch.swift"; sourceTree = "<group>"; };
 		AAA10006 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		AAA10007 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
 		AAA10008 /* ProgressBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBarView.swift; sourceTree = "<group>"; };
@@ -174,6 +201,11 @@
 		AAA10036 /* DiagnosticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsView.swift; sourceTree = "<group>"; };
 		BBB10028 /* DiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsTests.swift; sourceTree = "<group>"; };
 		BBB10030 /* UITestHarnessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestHarnessTests.swift; sourceTree = "<group>"; };
+		BBB10032 /* AccountSessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSessionStoreTests.swift; sourceTree = "<group>"; };
+		BBB10033 /* UserSnapshotServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSnapshotServiceTests.swift; sourceTree = "<group>"; };
+		BBB10034 /* MarketWatchServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketWatchServiceTests.swift; sourceTree = "<group>"; };
+		BBB10035 /* ForumWatchServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForumWatchServiceTests.swift; sourceTree = "<group>"; };
+		BBB10036 /* FactionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactionServiceTests.swift; sourceTree = "<group>"; };
 		AAA10037 /* NextAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextAction.swift; sourceTree = "<group>"; };
 		AAA10038 /* NextActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextActionView.swift; sourceTree = "<group>"; };
 		BBB10029 /* NextActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextActionTests.swift; sourceTree = "<group>"; };
@@ -254,6 +286,17 @@
 			isa = PBXGroup;
 			children = (
 				AAA10005 /* AppState.swift */,
+				AAA10041 /* AccountSessionStore.swift */,
+				AAA10042 /* UserSnapshotService.swift */,
+				AAA10043 /* MarketWatchService.swift */,
+				AAA10044 /* ForumWatchService.swift */,
+				AAA10045 /* FactionService.swift */,
+				AAA10046 /* AppState+MarketForum.swift */,
+				AAA10047 /* AppState+NotificationsFeedback.swift */,
+				AAA10048 /* AppState+PersistenceStocks.swift */,
+				AAA10049 /* AppState+LiveNextAction.swift */,
+				AAA10050 /* AppState+PollingUserFetch.swift */,
+				AAA10051 /* AppState+FactionFetch.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -397,6 +440,11 @@
 				BBB10028 /* DiagnosticsTests.swift */,
 				BBB10029 /* NextActionTests.swift */,
 				BBB10030 /* UITestHarnessTests.swift */,
+				BBB10032 /* AccountSessionStoreTests.swift */,
+				BBB10033 /* UserSnapshotServiceTests.swift */,
+				BBB10034 /* MarketWatchServiceTests.swift */,
+				BBB10035 /* ForumWatchServiceTests.swift */,
+				BBB10036 /* FactionServiceTests.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -548,6 +596,17 @@
 				AAA00002 /* ContentView.swift in Sources */,
 				AAA00004 /* TornModels.swift in Sources */,
 				AAA00005 /* AppState.swift in Sources */,
+				AAA00041 /* AccountSessionStore.swift in Sources */,
+				AAA00042 /* UserSnapshotService.swift in Sources */,
+				AAA00043 /* MarketWatchService.swift in Sources */,
+				AAA00044 /* ForumWatchService.swift in Sources */,
+				AAA00045 /* FactionService.swift in Sources */,
+				AAA00046 /* AppState+MarketForum.swift in Sources */,
+				AAA00047 /* AppState+NotificationsFeedback.swift in Sources */,
+				AAA00048 /* AppState+PersistenceStocks.swift in Sources */,
+				AAA00049 /* AppState+LiveNextAction.swift in Sources */,
+				AAA00050 /* AppState+PollingUserFetch.swift in Sources */,
+				AAA00051 /* AppState+FactionFetch.swift in Sources */,
 				AAA00006 /* SettingsView.swift in Sources */,
 				AAA00007 /* StatusView.swift in Sources */,
 				AAA00008 /* ProgressBarView.swift in Sources */,
@@ -622,6 +681,11 @@
 				BBB00028 /* DiagnosticsTests.swift in Sources */,
 				BBB00030 /* UITestHarnessTests.swift in Sources */,
 				BBB00029 /* NextActionTests.swift in Sources */,
+				BBB00032 /* AccountSessionStoreTests.swift in Sources */,
+				BBB00033 /* UserSnapshotServiceTests.swift in Sources */,
+				BBB00034 /* MarketWatchServiceTests.swift in Sources */,
+				BBB00035 /* ForumWatchServiceTests.swift in Sources */,
+				BBB00036 /* FactionServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -793,7 +857,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = 1.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mactorn.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -820,7 +884,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = 1.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mactorn.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -837,7 +901,7 @@
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = 1.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mactorn.MacTornTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -855,7 +919,7 @@
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = 1.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mactorn.MacTornTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -872,7 +936,7 @@
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = 1.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mactorn.MacTornUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -889,7 +953,7 @@
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = 1.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mactorn.MacTornUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/MacTorn/MacTorn.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MacTorn/MacTorn.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "0baded16c4bd1f2471949e89bf36289ca2b93080",
-        "version" : "9.12.0"
+        "revision" : "afa7510e05b99f35c1febe47566bfd868fa53fb9",
+        "version" : "9.23.0"
       }
     }
   ],

--- a/MacTorn/MacTorn/Helpers/TransparencyEnvironment.swift
+++ b/MacTorn/MacTorn/Helpers/TransparencyEnvironment.swift
@@ -5,9 +5,30 @@ private struct ReduceTransparencyKey: EnvironmentKey {
     static let defaultValue: Bool = false
 }
 
+struct OpenMacTornSettingsAction: @unchecked Sendable {
+    private let action: () -> Void
+
+    init(_ action: @escaping () -> Void = {}) {
+        self.action = action
+    }
+
+    func callAsFunction() {
+        action()
+    }
+}
+
+private struct OpenMacTornSettingsKey: EnvironmentKey {
+    static let defaultValue = OpenMacTornSettingsAction()
+}
+
 extension EnvironmentValues {
     var reduceTransparency: Bool {
         get { self[ReduceTransparencyKey.self] }
         set { self[ReduceTransparencyKey.self] = newValue }
+    }
+
+    var openMacTornSettings: OpenMacTornSettingsAction {
+        get { self[OpenMacTornSettingsKey.self] }
+        set { self[OpenMacTornSettingsKey.self] = newValue }
     }
 }

--- a/MacTorn/MacTorn/Helpers/UITestSupport.swift
+++ b/MacTorn/MacTorn/Helpers/UITestSupport.swift
@@ -319,6 +319,7 @@ private struct UITestWindowConfigurator: NSViewRepresentable {
         DispatchQueue.main.async { [weak view] in
             guard let window = view?.window else { return }
             if active {
+                window.title = "MacTorn UI Tests"
                 window.setContentSize(NSSize(width: 320, height: height))
                 window.center()
                 window.makeKeyAndOrderFront(nil)

--- a/MacTorn/MacTorn/Helpers/UITestSupport.swift
+++ b/MacTorn/MacTorn/Helpers/UITestSupport.swift
@@ -49,6 +49,10 @@ enum FixtureScenario: String {
     /// Every endpoint returns an empty (but valid) JSON object — used to assert the
     /// onboarding / empty states render without a decode crash.
     case empty
+    /// Two synthetic identities selected by the request's fake key. A repeated request
+    /// for account A is deliberately delayed and ignores task cancellation so XCUITest
+    /// can prove that a stale A response never flashes after switching to B.
+    case accountSwitch
 }
 
 enum UITestConfiguration {
@@ -56,6 +60,7 @@ enum UITestConfiguration {
     static let fixtureKey = "-uitest-fixture"   // value: FixtureScenario.rawValue
     static let apiKeyKey = "-uitest-apikey"     // value: seeded key ("" / absent ⇒ onboarding)
     static let onlineKey = "-uitest-online"     // value: "1" (default) / "0"
+    static let windowHeightKey = "-uitest-window-height"
 
     /// True only when the process was launched with `--uitesting`.
     static var isActive: Bool {
@@ -77,6 +82,10 @@ enum UITestConfiguration {
     static var seededAPIKey: String { argValue(apiKeyKey) ?? "" }
 
     static var startsOnline: Bool { argValue(onlineKey) != "0" }
+    static var windowHeight: CGFloat {
+        let requested = argValue(windowHeightKey).flatMap(Double.init) ?? 640
+        return CGFloat(min(max(requested, 640), 1_000))
+    }
 
     /// In-memory Keychain backing store, consulted by `KeychainStore` while a UI test
     /// runs so the app process never reads or writes the real login Keychain.
@@ -113,12 +122,35 @@ enum UITestConfiguration {
 /// network. Routing is by URL so the fast user call, faction, and the v2 endpoints
 /// each get an appropriate, decodable body.
 final class FixtureNetworkSession: NetworkSession, @unchecked Sendable {
+    static let accountAKey = "fixture-account-a"
+    static let accountBKey = "fixture-account-b"
+
     private let scenario: FixtureScenario
+    private let requestCountQueue = DispatchQueue(label: "com.mactorn.uitests.fixture-counts")
+    private var accountAFastRequestCount = 0
 
     init(scenario: FixtureScenario) { self.scenario = scenario }
 
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
         let url = request.url
+        if scenario == .accountSwitch,
+           Self.isFastUserURL(url),
+           Self.apiKey(in: url) == Self.accountAKey {
+            let requestNumber = requestCountQueue.sync {
+                accountAFastRequestCount += 1
+                return accountAFastRequestCount
+            }
+            if requestNumber > 1 {
+                // A continuation backed by asyncAfter is intentionally non-cancellable.
+                // This models a transport that still delivers A after AppState cancelled it.
+                await withCheckedContinuation { continuation in
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 3) {
+                        continuation.resume()
+                    }
+                }
+            }
+        }
+
         let body = Self.body(for: url, scenario: scenario)
         let response = HTTPURLResponse(url: url ?? URL(string: "https://api.torn.com")!,
                                        statusCode: 200,
@@ -133,7 +165,7 @@ final class FixtureNetworkSession: NetworkSession, @unchecked Sendable {
     /// the app's `try?`-guarded overlays decode into "no extra data" cleanly.
     static func body(for url: URL?, scenario: FixtureScenario) -> Data {
         let s = url?.absoluteString ?? ""
-        let isFastUser = s.contains("api.torn.com/user/") && s.contains("bars")
+        let isFastUser = isFastUserURL(url)
         let isKeyInfo = s.contains("/key/info")
 
         let json: [String: Any]
@@ -144,12 +176,34 @@ final class FixtureNetworkSession: NetworkSession, @unchecked Sendable {
             json = keyInfoResponse()
         case (_, true, .full):
             json = fullUserResponse()
+        case (_, true, .accountSwitch):
+            switch apiKey(in: url) {
+            case accountAKey:
+                json = fullUserResponse(name: "Fixture Account A", playerID: 100_001)
+            case accountBKey:
+                json = fullUserResponse(name: "Fixture Account B", playerID: 200_002)
+            default:
+                json = invalidKeyEnvelope
+            }
         case (_, true, .invalidKey):
             json = invalidKeyEnvelope
         default:
             json = [:]
         }
         return (try? JSONSerialization.data(withJSONObject: json)) ?? Data("{}".utf8)
+    }
+
+    private static func isFastUserURL(_ url: URL?) -> Bool {
+        let value = url?.absoluteString ?? ""
+        return value.contains("api.torn.com/user/") && value.contains("bars")
+    }
+
+    private static func apiKey(in url: URL?) -> String? {
+        guard let url,
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        return components.queryItems?.first(where: { $0.name == "key" })?.value
     }
 
     /// A full-access `/key/info` response granting every selection MacTorn requests, so
@@ -185,9 +239,10 @@ final class FixtureNetworkSession: NetworkSession, @unchecked Sendable {
     /// A healthy, fully-populated fast-user response. Mirrors the shape of the unit
     /// suite's `TornAPIFixtures.validFullResponse()` (kept in sync by construction —
     /// same keys), with `server_time = now` so live countdowns anchor to the run.
-    static func fullUserResponse() -> [String: Any] { [
-        "name": "TestPlayer",
-        "player_id": 123456,
+    static func fullUserResponse(name: String = "TestPlayer",
+                                 playerID: Int = 123456) -> [String: Any] { [
+        "name": name,
+        "player_id": playerID,
         "server_time": Int(Date().timeIntervalSince1970),
         "energy": ["current": 100, "maximum": 150, "increment": 5, "interval": 300, "ticktime": 60, "fulltime": 600],
         "nerve": ["current": 50, "maximum": 60, "increment": 1, "interval": 300, "ticktime": 120, "fulltime": 1800],
@@ -240,25 +295,31 @@ struct UITestRootView: View {
                 ContentView()
                     .environment(appState)
                     .environment(\.reduceTransparency, reduceTransparency)
-                    .frame(width: 320, height: 640)
+                    .frame(width: 320, height: UITestConfiguration.windowHeight)
             } else {
                 EmptyView()
             }
         }
-        .background(UITestWindowConfigurator(active: UITestConfiguration.isActive))
+        .background(
+            UITestWindowConfigurator(
+                active: UITestConfiguration.isActive,
+                height: UITestConfiguration.windowHeight
+            )
+        )
     }
 }
 
 /// Grabs the enclosing `NSWindow` to either front it (UI test) or close it (normal Debug).
 private struct UITestWindowConfigurator: NSViewRepresentable {
     let active: Bool
+    let height: CGFloat
 
     func makeNSView(context: Context) -> NSView {
         let view = NSView()
         DispatchQueue.main.async { [weak view] in
             guard let window = view?.window else { return }
             if active {
-                window.setContentSize(NSSize(width: 320, height: 640))
+                window.setContentSize(NSSize(width: 320, height: height))
                 window.center()
                 window.makeKeyAndOrderFront(nil)
                 NSApp.activate(ignoringOtherApps: true)

--- a/MacTorn/MacTorn/MacTornApp.swift
+++ b/MacTorn/MacTorn/MacTornApp.swift
@@ -62,7 +62,7 @@ struct MacTornApp: App {
     // `UITestRootView` gates its content on `UITestConfiguration.isActive` and closes this
     // window on a normal (non-UI-test) Debug launch, so it is invisible outside UI tests.
     private var uiTestWindow: some Scene {
-        WindowGroup(id: "uitest-window") {
+        WindowGroup("MacTorn UI Tests", id: "uitest-window") {
             UITestRootView(appState: appState)
                 .environment(navigation)
         }

--- a/MacTorn/MacTorn/MacTornApp.swift
+++ b/MacTorn/MacTorn/MacTornApp.swift
@@ -3,6 +3,7 @@ import SwiftUI
 @main
 struct MacTornApp: App {
     @State private var appState: AppState
+    @State private var navigation = AppNavigationState()
     @AppStorage("appearanceMode") private var appearanceModeRaw: String = AppearanceMode.system.rawValue
     @AppStorage("reduceTransparency") private var reduceTransparency: Bool = false
 
@@ -32,6 +33,7 @@ struct MacTornApp: App {
         MenuBarExtra {
             ContentView()
                 .environment(appState)
+                .environment(navigation)
                 .environment(\.reduceTransparency, reduceTransparency)
                 .onAppear {
                     updateAppearance()
@@ -43,6 +45,9 @@ struct MacTornApp: App {
             MenuBarLabel(appState: appState)
         }
         .menuBarExtraStyle(.window)
+        .commands {
+            MacTornCommands(appState: appState, navigation: navigation)
+        }
     }
 
     #if DEBUG
@@ -59,6 +64,7 @@ struct MacTornApp: App {
     private var uiTestWindow: some Scene {
         WindowGroup(id: "uitest-window") {
             UITestRootView(appState: appState)
+                .environment(navigation)
         }
     }
     #endif
@@ -72,6 +78,49 @@ struct MacTornApp: App {
             NSApp.appearance = NSAppearance(named: .aqua)
         case .dark:
             NSApp.appearance = NSAppearance(named: .darkAqua)
+        }
+    }
+}
+
+/// Native macOS command menu. The popover also exposes the same actions in its visible
+/// Commands menu, while these entries make the standard shortcuts discoverable and usable
+/// whenever MacTorn is the active application.
+struct MacTornCommands: Commands {
+    let appState: AppState
+    let navigation: AppNavigationState
+
+    var body: some Commands {
+        CommandGroup(replacing: .appSettings) {
+            Button(MacTornCommand.settings.title) {
+                navigation.showSettings()
+            }
+            .keyboardShortcut(
+                KeyEquivalent(MacTornCommand.settings.keyEquivalent),
+                modifiers: .command
+            )
+        }
+
+        CommandMenu("Commands") {
+            Button(MacTornCommand.refresh.title) {
+                appState.refreshNow()
+            }
+            .keyboardShortcut(
+                KeyEquivalent(MacTornCommand.refresh.keyEquivalent),
+                modifiers: .command
+            )
+            .disabled(appState.apiKey.isEmpty)
+
+            Divider()
+
+            ForEach(MacTornCommand.navigation) { command in
+                Button(command.title) {
+                    if let tab = command.tab {
+                        navigation.select(tab)
+                    }
+                }
+                .keyboardShortcut(KeyEquivalent(command.keyEquivalent), modifiers: .command)
+                .disabled(appState.apiKey.isEmpty)
+            }
         }
     }
 }

--- a/MacTorn/MacTorn/Models/TornModels.swift
+++ b/MacTorn/MacTorn/Models/TornModels.swift
@@ -68,7 +68,9 @@ struct TornResponse: Codable {
     // Recent events sorted
     var recentEvents: [TornEvent] {
         guard let events = events else { return [] }
-        return events.values.sorted { $0.timestamp > $1.timestamp }
+        return events
+            .map { apiID, event in event.identified(by: apiID) }
+            .sorted { $0.timestamp > $1.timestamp }
     }
 }
 
@@ -256,6 +258,14 @@ enum TornDestination: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
+    enum FlightMethod: String, CaseIterable {
+        case standard = "Standard"
+        case airstrip = "Airstrip + pilot"
+    }
+
+    /// Torn documents up to 3% variance around the published base durations.
+    static let estimateVariancePercent = 3
+
     var flag: String {
         switch self {
         case .mexico: return "🇲🇽"
@@ -272,30 +282,58 @@ enum TornDestination: String, CaseIterable, Identifiable {
         }
     }
 
-    /// Approximate flight time in minutes
-    var flightTimeMinutes: Int {
-        switch self {
-        case .mexico: return 26
-        case .caymanIslands: return 35
-        case .canada: return 41
-        case .hawaii: return 134
-        case .unitedKingdom: return 159
-        case .argentina: return 167
-        case .switzerland: return 175
-        case .japan: return 225
-        case .china: return 242
-        case .uae: return 271
-        case .southAfrica: return 297
+    /// Current one-way base duration published by Torn.
+    ///
+    /// Patch #438 (2026-06-23) reduced every travel method by 5.26%. These values
+    /// intentionally mirror the official table instead of deriving one method from
+    /// another, because Torn rounds each displayed duration independently.
+    /// Live flights never use this estimate: their countdown comes from the API's
+    /// `travel.timestamp`, `departed`, and `time_left` fields.
+    func flightTimeMinutes(method: FlightMethod = .standard) -> Int {
+        switch (self, method) {
+        case (.mexico, .standard): return 24
+        case (.caymanIslands, .standard): return 33
+        case (.canada, .standard): return 39
+        case (.hawaii, .standard): return 127
+        case (.unitedKingdom, .standard): return 151
+        case (.argentina, .standard): return 158
+        case (.switzerland, .standard): return 166
+        case (.japan, .standard): return 213
+        case (.china, .standard): return 229
+        case (.uae, .standard): return 257
+        case (.southAfrica, .standard): return 282
+        case (.mexico, .airstrip): return 17
+        case (.caymanIslands, .airstrip): return 23
+        case (.canada, .airstrip): return 27
+        case (.hawaii, .airstrip): return 89
+        case (.unitedKingdom, .airstrip): return 106
+        case (.argentina, .airstrip): return 111
+        case (.switzerland, .airstrip): return 116
+        case (.japan, .airstrip): return 149
+        case (.china, .airstrip): return 160
+        case (.uae, .airstrip): return 180
+        case (.southAfrica, .airstrip): return 197
         }
     }
 
-    var flightTimeFormatted: String {
-        let hours = flightTimeMinutes / 60
-        let minutes = flightTimeMinutes % 60
+    /// Compatibility accessor for callers that want the standard estimate.
+    var flightTimeMinutes: Int {
+        flightTimeMinutes()
+    }
+
+    func flightTimeFormatted(method: FlightMethod = .standard) -> String {
+        let duration = flightTimeMinutes(method: method)
+        let hours = duration / 60
+        let minutes = duration % 60
         if hours > 0 {
             return "\(hours)h \(minutes)m"
         }
         return "\(minutes)m"
+    }
+
+    /// Compatibility accessor for callers that want the standard estimate.
+    var flightTimeFormatted: String {
+        flightTimeFormatted()
     }
 
     var travelAgencyURL: URL {
@@ -389,8 +427,21 @@ struct TornEvent: Codable, Identifiable {
     let timestamp: Int
     let event: String
     let seen: Int?
-    
-    var id: Int { timestamp }
+    /// Dictionary key supplied by Torn. Two events can share a second-level timestamp,
+    /// so the timestamp alone is not a stable SwiftUI identity.
+    private var apiID: String? = nil
+
+    enum CodingKeys: String, CodingKey {
+        case timestamp, event, seen
+    }
+
+    var id: String { apiID ?? "\(timestamp):\(event)" }
+
+    func identified(by apiID: String) -> TornEvent {
+        var copy = self
+        copy.apiID = apiID
+        return copy
+    }
     
     var date: Date {
         Date(timeIntervalSince1970: TimeInterval(timestamp))

--- a/MacTorn/MacTorn/Utilities/Diagnostics.swift
+++ b/MacTorn/MacTorn/Utilities/Diagnostics.swift
@@ -9,7 +9,7 @@ import Foundation
 // The "Copy sanitized diagnostic report" text is assembled only from these safe fields.
 
 /// Outcome of the most recent call to an endpoint.
-enum EndpointOutcome: String, Equatable, Sendable {
+enum EndpointOutcome: String, Equatable, Hashable, Sendable {
     case ok
     case error
     case offline
@@ -57,6 +57,105 @@ final class EndpointHealthTracker {
     /// All tracked endpoints, ordered by the registry's display order.
     var all: [EndpointHealth] {
         TornEndpointRegistry.all.compactMap { health[$0.id] }
+    }
+}
+
+// MARK: - Module presentation state
+
+/// A compact, PII-free state shared by every feature screen. It deliberately keeps
+/// "has cached content" separate from endpoint health so a transient failure can label
+/// existing data as stale instead of replacing it with an empty error screen.
+struct ModulePresentationState: Equatable, Sendable {
+    enum Kind: Equatable, Sendable {
+        case loading
+        case empty
+        case fresh
+        case stale
+        case offline
+        case permission
+        case rateLimited
+        case error
+    }
+
+    enum Recovery: Equatable, Sendable {
+        case none
+        case retry
+        case settings
+    }
+
+    let kind: Kind
+    let hasContent: Bool
+    let updatedAt: Date?
+    let recovery: Recovery
+
+    static func resolve(health: [EndpointHealth],
+                        hasContent: Bool,
+                        isLoading: Bool,
+                        fallbackError: String?,
+                        now: Date = Date(),
+                        staleAfter: TimeInterval) -> ModulePresentationState {
+        if isLoading, !hasContent {
+            return ModulePresentationState(kind: .loading, hasContent: false,
+                                           updatedAt: newestDate(in: health), recovery: .none)
+        }
+
+        let updatedAt = newestDate(in: health)
+        let errorClasses = Set(health.compactMap(\.errorClass))
+        let outcomes = Set(health.map(\.outcome))
+
+        if outcomes.contains(.offline) || fallbackError == "No internet connection" {
+            return ModulePresentationState(kind: .offline, hasContent: hasContent,
+                                           updatedAt: updatedAt, recovery: .retry)
+        }
+        if !errorClasses.isDisjoint(with: ["permanentKey", "insufficientPermissions"]) {
+            return ModulePresentationState(kind: .permission, hasContent: hasContent,
+                                           updatedAt: updatedAt, recovery: .settings)
+        }
+        if !errorClasses.isDisjoint(with: ["rateLimit", "dailyRowLimit"]) {
+            return ModulePresentationState(kind: .rateLimited, hasContent: hasContent,
+                                           updatedAt: updatedAt, recovery: .retry)
+        }
+        if outcomes.contains(.error) {
+            return ModulePresentationState(kind: hasContent ? .stale : .error,
+                                           hasContent: hasContent, updatedAt: updatedAt,
+                                           recovery: .retry)
+        }
+
+        if let updatedAt, now.timeIntervalSince(updatedAt) > staleAfter {
+            return ModulePresentationState(kind: .stale, hasContent: hasContent,
+                                           updatedAt: updatedAt, recovery: .retry)
+        }
+        if hasContent {
+            return ModulePresentationState(kind: .fresh, hasContent: true,
+                                           updatedAt: updatedAt, recovery: .none)
+        }
+        if fallbackError != nil {
+            return ModulePresentationState(kind: .error, hasContent: false,
+                                           updatedAt: updatedAt, recovery: .retry)
+        }
+        return ModulePresentationState(kind: .empty, hasContent: false,
+                                       updatedAt: updatedAt, recovery: .retry)
+    }
+
+    private static func newestDate(in health: [EndpointHealth]) -> Date? {
+        health.map(\.at).max()
+    }
+}
+
+extension AppState {
+    /// Resolves a module's visible status from the same PII-safe endpoint health that
+    /// powers Diagnostics. `staleAfter` is module-specific because activity/faction
+    /// endpoints intentionally poll more slowly than live bars.
+    func presentationState(endpointIDs: [String],
+                           hasContent: Bool,
+                           staleAfter: TimeInterval) -> ModulePresentationState {
+        ModulePresentationState.resolve(
+            health: endpointIDs.compactMap { endpointHealth.latest(for: $0) },
+            hasContent: hasContent,
+            isLoading: isLoading,
+            fallbackError: errorMsg,
+            staleAfter: staleAfter
+        )
     }
 }
 

--- a/MacTorn/MacTorn/Utilities/SentryManager.swift
+++ b/MacTorn/MacTorn/Utilities/SentryManager.swift
@@ -25,12 +25,17 @@ enum SentryManager {
 
     /// Call once at app launch. Starts the SDK only if the user has opted in.
     static func startIfEnabled() {
-        guard isEnabled else { return }
+        guard shouldStart(isEnabled: isEnabled, isUITesting: UITestConfiguration.isActive) else {
+            return
+        }
         start()
     }
 
     /// Apply current toggle state. Call after the user flips the Settings switch.
     static func applyState() {
+        // UI tests use fixture-backed networking and must remain completely hermetic,
+        // including when a test happens to exercise the Settings toggle.
+        guard !UITestConfiguration.isActive else { return }
         if isEnabled {
             start()
         } else if isStarted {
@@ -46,31 +51,41 @@ enum SentryManager {
         let release = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
 
         SentrySDK.start { options in
-            options.dsn = dsn
-            options.releaseName = "mactorn@\(release)"
-            options.environment = Self.environment()
-
-            // Crash + errors only — no perf, no profiling, no replays.
-            options.tracesSampleRate = 0.0
-
-            // PII hygiene: never send IP, device name, etc.
-            options.sendDefaultPii = false
-
-            // Strip API keys from URLs in events + breadcrumbs.
-            options.beforeSend = { event in scrub(event) }
-            options.beforeBreadcrumb = { crumb in scrub(crumb) }
-
-            // Redact URLs Sentry might capture from URLSession swizzling.
-            options.enableNetworkTracking = false
-            options.enableNetworkBreadcrumbs = false
-            // Torn API 5xx are upstream noise, not MacTorn bugs — don't auto-capture them.
-            options.enableCaptureFailedRequests = false
-            // AppHang detection produces only system-frame events for MenuBarExtra apps
-            // (CAFenceHandle, SkyLight display state) which are macOS doing its thing on
-            // wake/animate, not actionable MacTorn bugs. Crashes still captured.
-            options.enableAppHangTracking = false
+            configure(options, release: release, environment: Self.environment())
         }
         logger.info("Sentry started, release \(release)")
+    }
+
+    /// Pure startup policy, separated from `SentrySDK.start` so privacy and transport
+    /// invariants can be pinned without starting the SDK or making a network request.
+    static func configure(_ options: Options, release: String, environment: String) {
+        options.dsn = dsn
+        options.releaseName = "mactorn@\(release)"
+        options.environment = environment
+
+        // Crash + errors only — no perf, no profiling, no replays.
+        options.tracesSampleRate = 0.0
+
+        // PII hygiene: never send IP, device name, etc.
+        options.sendDefaultPii = false
+
+        // Strip API keys from URLs in events + breadcrumbs.
+        options.beforeSend = { event in scrub(event) }
+        options.beforeBreadcrumb = { crumb in scrub(crumb) }
+
+        // Redact URLs Sentry might capture from URLSession swizzling.
+        options.enableNetworkTracking = false
+        options.enableNetworkBreadcrumbs = false
+        // Torn API 5xx are upstream noise, not MacTorn bugs — don't auto-capture them.
+        options.enableCaptureFailedRequests = false
+        // AppHang detection produces only system-frame events for MenuBarExtra apps
+        // (CAFenceHandle, SkyLight display state) which are macOS doing its thing on
+        // wake/animate, not actionable MacTorn bugs. Crashes still captured.
+        options.enableAppHangTracking = false
+    }
+
+    static func shouldStart(isEnabled: Bool, isUITesting: Bool) -> Bool {
+        isEnabled && !isUITesting
     }
 
     private static func environment() -> String {

--- a/MacTorn/MacTorn/Utilities/ShortcutsManager.swift
+++ b/MacTorn/MacTorn/Utilities/ShortcutsManager.swift
@@ -1,5 +1,102 @@
 import Foundation
+import Observation
 import SwiftUI
+
+/// The stable keyboard contract for MacTorn itself. Torn website shortcuts remain
+/// user-customizable below; app navigation intentionally uses fixed, conflict-free
+/// command-number pairs so every module is directly reachable.
+enum MacTornCommand: String, CaseIterable, Identifiable {
+    case refresh
+    case settings
+    case status
+    case travel
+    case attacks
+    case money
+    case faction
+    case watchlist
+    case forums
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .refresh: return "Refresh"
+        case .settings: return "Settings…"
+        case .status: return "Go to Status"
+        case .travel: return "Go to Travel"
+        case .attacks: return "Go to Attacks"
+        case .money: return "Go to Money"
+        case .faction: return "Go to Faction"
+        case .watchlist: return "Go to Watchlist"
+        case .forums: return "Go to Forums"
+        }
+    }
+
+    var keyEquivalent: Character {
+        switch self {
+        case .refresh: return "r"
+        case .settings: return ","
+        case .status: return "1"
+        case .travel: return "2"
+        case .attacks: return "3"
+        case .money: return "4"
+        case .faction: return "5"
+        case .watchlist: return "6"
+        case .forums: return "7"
+        }
+    }
+
+    var tab: AppTab? {
+        switch self {
+        case .status: return .status
+        case .travel: return .travel
+        case .attacks: return .attacks
+        case .money: return .money
+        case .faction: return .faction
+        case .watchlist: return .watchlist
+        case .forums: return .forums
+        case .refresh, .settings: return nil
+        }
+    }
+
+    static var navigation: [MacTornCommand] {
+        allCases.filter { $0.tab != nil }
+    }
+}
+
+/// Shared by the menu-bar popover and the macOS command menu. Keeping selection and
+/// Settings presentation in one observable object prevents keyboard commands and clicks
+/// from drifting into different destinations.
+@Observable
+final class AppNavigationState {
+    private(set) var selectedTab: AppTab
+    private(set) var isShowingSettings: Bool
+
+    init(selectedTab: AppTab = .status, isShowingSettings: Bool = false) {
+        self.selectedTab = selectedTab
+        self.isShowingSettings = isShowingSettings
+    }
+
+    func select(_ tab: AppTab) {
+        selectedTab = tab
+        isShowingSettings = false
+    }
+
+    func showSettings() {
+        isShowingSettings = true
+    }
+
+    func toggleSettings() {
+        isShowingSettings.toggle()
+    }
+
+    @discardableResult
+    func dismissSettings(hasConfiguredAccount: Bool) -> Bool {
+        guard hasConfiguredAccount, isShowingSettings else { return false }
+        isShowingSettings = false
+        return true
+    }
+}
 
 @MainActor
 class ShortcutsManager: ObservableObject {

--- a/MacTorn/MacTorn/ViewModels/AccountSessionStore.swift
+++ b/MacTorn/MacTorn/ViewModels/AccountSessionStore.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Observation
+import Security
+import os.log
+
+private let accountLogger = Logger(
+    subsystem: TornConstants.logSubsystem,
+    category: "AccountSessionStore"
+)
+
+struct AccountIdentity: Equatable, Sendable {
+    let apiKey: String
+    let generation: UInt
+}
+
+enum AccountTaskKind: Hashable, Sendable {
+    case userSnapshot
+    case watchlist
+    case forum
+}
+
+protocol APIKeyStoring: Sendable {
+    func get() -> String?
+    func set(_ value: String)
+}
+
+struct KeychainAPIKeyStore: APIKeyStoring {
+    func get() -> String? { KeychainStore.get() }
+    func set(_ value: String) { KeychainStore.set(value) }
+}
+
+/// Owns authenticated-account identity and task invalidation. Feature state still lives
+/// behind `AppState`, but every account-scoped service shares this generation contract.
+@MainActor
+@Observable
+final class AccountSessionStore {
+    private(set) var apiKey: String
+    private(set) var generation: UInt = 0
+    var isHalted = false
+
+    @ObservationIgnored private let credentialStore: APIKeyStoring
+    @ObservationIgnored private var tasks: [AccountTaskKind: Task<Void, Never>] = [:]
+
+    init(defaults: UserDefaults,
+         credentialStore: APIKeyStoring = KeychainAPIKeyStore()) {
+        self.credentialStore = credentialStore
+
+        if let legacy = defaults.string(forKey: "apiKey"), !legacy.isEmpty {
+            credentialStore.set(legacy)
+            defaults.removeObject(forKey: "apiKey")
+            accountLogger.info("Migrated API key from UserDefaults to Keychain")
+        }
+        self.apiKey = credentialStore.get() ?? ""
+    }
+
+    var identity: AccountIdentity {
+        AccountIdentity(apiKey: apiKey, generation: generation)
+    }
+
+    @discardableResult
+    func updateAPIKey(_ newValue: String) -> Bool {
+        guard newValue != apiKey else { return false }
+        credentialStore.set(newValue)
+        generation &+= 1
+        cancelAllTasks()
+        apiKey = newValue
+        isHalted = false
+        return true
+    }
+
+    func isCurrent(_ identity: AccountIdentity) -> Bool {
+        self.identity == identity
+    }
+
+    func startTask(
+        _ kind: AccountTaskKind,
+        operation: @escaping @MainActor () async -> Void
+    ) {
+        tasks[kind]?.cancel()
+        tasks[kind] = Task { await operation() }
+    }
+
+    func cancelTask(_ kind: AccountTaskKind) {
+        tasks[kind]?.cancel()
+        tasks[kind] = nil
+    }
+
+    func cancelAllTasks() {
+        for task in tasks.values {
+            task.cancel()
+        }
+        tasks.removeAll(keepingCapacity: true)
+    }
+}
+
+// MARK: - Keychain
+
+/// Minimal generic-password Keychain wrapper for the single Torn API key.
+///
+/// Test isolation: XCTest workers use a PID-suffixed service, while the UI-test harness
+/// routes through an in-memory override and never reads a developer's real key.
+enum KeychainStore {
+    static let account = "apiKey"
+
+    static var service: String {
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            return "com.mactorn.app.tests.\(ProcessInfo.processInfo.processIdentifier)"
+        }
+        return "com.mactorn.app"
+    }
+
+    static func get() -> String? {
+        #if DEBUG
+        if UITestConfiguration.isActive {
+            return UITestConfiguration.keychainOverride[account]
+        }
+        #endif
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let string = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return string
+    }
+
+    static func set(_ value: String) {
+        guard !value.isEmpty else {
+            delete()
+            return
+        }
+        #if DEBUG
+        if UITestConfiguration.isActive {
+            UITestConfiguration.keychainOverride[account] = value
+            return
+        }
+        #endif
+        guard let data = value.data(using: .utf8) else { return }
+        let baseQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        let updateAttributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+        ]
+        let updateStatus = SecItemUpdate(
+            baseQuery as CFDictionary,
+            updateAttributes as CFDictionary
+        )
+        if updateStatus == errSecItemNotFound {
+            var addQuery = baseQuery
+            addQuery.merge(updateAttributes) { _, new in new }
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            if addStatus != errSecSuccess {
+                accountLogger.error("Keychain add failed: OSStatus \(addStatus)")
+            }
+        } else if updateStatus != errSecSuccess {
+            accountLogger.error("Keychain update failed: OSStatus \(updateStatus)")
+        }
+    }
+
+    static func delete() {
+        #if DEBUG
+        if UITestConfiguration.isActive {
+            UITestConfiguration.keychainOverride[account] = nil
+            return
+        }
+        #endif
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/MacTorn/MacTorn/ViewModels/AppState+FactionFetch.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState+FactionFetch.swift
@@ -1,0 +1,205 @@
+import Foundation
+
+extension AppState {
+    private static var factionV2MinInterval: TimeInterval { 300 }
+
+    // MARK: - Fetch Faction Data
+
+    func fetchFactionData(apiKey: String, generation: UInt) async {
+        guard let url = TornAPI.factionURL(for: apiKey),
+              reserveRequest("faction.basic") else { return }
+        let startTime = Date()
+
+        do {
+            let result = try await factionService.loadBasic(from: url)
+            guard isCurrentAccount(apiKey, generation: generation) else { return }
+
+            switch result {
+            case .success(let payload, let responseBytes):
+                factionService.publishBasic(payload)
+                logger.info("Faction data fetched")
+                recordHealth("faction.basic", outcome: .ok, since: startTime, bytes: responseBytes)
+
+            case .apiError(let apiError, let responseBytes):
+                recordHealth(
+                    "faction.basic",
+                    outcome: .error,
+                    since: startTime,
+                    bytes: responseBytes,
+                    errorClass: apiError.classification.rawValue
+                )
+                logger.warning("Faction API error class: \(apiError.classification.rawValue)")
+
+            case .httpError(let statusCode, let responseBytes):
+                recordHealth(
+                    "faction.basic",
+                    outcome: .error,
+                    since: startTime,
+                    bytes: responseBytes,
+                    errorClass: "http\(statusCode)"
+                )
+
+            case .malformed(let responseBytes):
+                recordHealth(
+                    "faction.basic",
+                    outcome: .error,
+                    since: startTime,
+                    bytes: responseBytes,
+                    errorClass: "malformedResponse"
+                )
+            }
+        } catch {
+            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
+            recordHealth(
+                "faction.basic",
+                outcome: mapped?.classification == .offline ? .offline : .error,
+                since: startTime,
+                bytes: 0,
+                errorClass: mapped?.classification.rawValue ?? "transport"
+            )
+            logger.warning("Faction fetch error (optional): \(String(describing: type(of: error)))")
+        }
+    }
+
+    // MARK: - Fetch API v2 Faction Data
+
+    func fetchFactionV2Data(apiKey: String, generation: UInt) async {
+        guard !apiKey.isEmpty else { return }
+
+        if let last = lastFactionV2Fetch,
+           Date().timeIntervalSince(last) < Self.factionV2MinInterval {
+            return
+        }
+        var issuedRequest = false
+
+        if let url = TornAPI.factionRankedWarsURL(for: apiKey),
+           reserveRequest("faction.rankedwars") {
+            issuedRequest = true
+            let startTime = Date()
+            do {
+                let result = try await factionService.loadWars(from: url)
+                guard isCurrentAccount(apiKey, generation: generation) else { return }
+
+                switch result {
+                case .success(let wars, let responseBytes):
+                    factionService.publishWars(wars)
+                    recordHealth(
+                        "faction.rankedwars",
+                        outcome: .ok,
+                        since: startTime,
+                        bytes: responseBytes
+                    )
+
+                case .apiError(let apiError, let responseBytes):
+                    recordHealth(
+                        "faction.rankedwars",
+                        outcome: .error,
+                        since: startTime,
+                        bytes: responseBytes,
+                        errorClass: apiError.classification.rawValue
+                    )
+                    logger.warning(
+                        "Faction v2 (rankedwars) API error class: \(apiError.classification.rawValue)"
+                    )
+
+                case .httpError(let statusCode, let responseBytes):
+                    recordHealth(
+                        "faction.rankedwars",
+                        outcome: .error,
+                        since: startTime,
+                        bytes: responseBytes,
+                        errorClass: "http\(statusCode)"
+                    )
+
+                case .malformed(let responseBytes):
+                    recordHealth(
+                        "faction.rankedwars",
+                        outcome: .error,
+                        since: startTime,
+                        bytes: responseBytes,
+                        errorClass: "malformedResponse"
+                    )
+                }
+            } catch {
+                let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
+                recordHealth(
+                    "faction.rankedwars",
+                    outcome: mapped?.classification == .offline ? .offline : .error,
+                    since: startTime,
+                    bytes: 0,
+                    errorClass: mapped?.classification.rawValue ?? "transport"
+                )
+                logger.warning(
+                    "Faction v2 (rankedwars) fetch error (optional): \(String(describing: type(of: error)))"
+                )
+            }
+        }
+
+        if !isRowSourcePaused("faction.news"), let url = TornAPI.factionNewsURL(for: apiKey) {
+            guard reserveRequest("faction.news") else {
+                if issuedRequest { lastFactionV2Fetch = Date() }
+                return
+            }
+            issuedRequest = true
+            let startTime = Date()
+            do {
+                let result = try await factionService.loadNews(from: url)
+                guard isCurrentAccount(apiKey, generation: generation) else { return }
+
+                switch result {
+                case .success(let news, let responseBytes):
+                    factionService.publishNews(news)
+                    recordHealth("faction.news", outcome: .ok, since: startTime, bytes: responseBytes)
+
+                case .apiError(let apiError, let responseBytes):
+                    if apiError.haltsCategoryOnly {
+                        pauseRowSource("faction.news", error: apiError)
+                    }
+                    recordHealth(
+                        "faction.news",
+                        outcome: .error,
+                        since: startTime,
+                        bytes: responseBytes,
+                        errorClass: apiError.classification.rawValue
+                    )
+                    logger.warning(
+                        "Faction v2 (news) API error class: \(apiError.classification.rawValue)"
+                    )
+
+                case .httpError(let statusCode, let responseBytes):
+                    recordHealth(
+                        "faction.news",
+                        outcome: .error,
+                        since: startTime,
+                        bytes: responseBytes,
+                        errorClass: "http\(statusCode)"
+                    )
+
+                case .malformed(let responseBytes):
+                    recordHealth(
+                        "faction.news",
+                        outcome: .error,
+                        since: startTime,
+                        bytes: responseBytes,
+                        errorClass: "malformedResponse"
+                    )
+                }
+            } catch {
+                let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
+                recordHealth(
+                    "faction.news",
+                    outcome: mapped?.classification == .offline ? .offline : .error,
+                    since: startTime,
+                    bytes: 0,
+                    errorClass: mapped?.classification.rawValue ?? "transport"
+                )
+                logger.warning(
+                    "Faction v2 (news) fetch error (optional): \(String(describing: type(of: error)))"
+                )
+            }
+        }
+        if issuedRequest, isCurrentAccount(apiKey, generation: generation) {
+            lastFactionV2Fetch = Date()
+        }
+    }
+}

--- a/MacTorn/MacTorn/ViewModels/AppState+LiveNextAction.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState+LiveNextAction.swift
@@ -1,0 +1,174 @@
+import Foundation
+import Combine
+
+extension AppState {
+    private static var hiddenNextActionKey: String { "hiddenNextActionCategories" }
+
+    // MARK: - Live Timer
+
+    func manageLiveTimer() {
+        tick()
+        if shouldRunLiveTimer {
+            if liveTimerCancellable == nil {
+                startLiveTimer()
+            }
+        } else {
+            stopLiveTimer()
+        }
+    }
+
+    private var shouldRunLiveTimer: Bool {
+        guard let data = data else { return false }
+        if let travel = data.travel, travel.isTraveling { return true }
+        if let status = data.status, status.isInHospital || status.isInJail { return true }
+        if let ends = cooldownEnds, ends.soonestActive() != nil { return true }
+        return false
+    }
+
+    private func startLiveTimer() {
+        liveTimerCancellable?.cancel()
+
+        liveTimerCancellable = Timer.publish(every: 1.0, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                self?.tick()
+            }
+    }
+
+    private func stopLiveTimer() {
+        liveTimerCancellable?.cancel()
+        liveTimerCancellable = nil
+        travelSecondsRemaining = 0
+        menuBarDisplay = computeMenuBarDisplay()
+    }
+
+    private func tick() {
+        updateTravelSecondsRemaining()
+        let next = computeMenuBarDisplay()
+        if next != menuBarDisplay {
+            menuBarDisplay = next
+        }
+    }
+
+    private func updateTravelSecondsRemaining() {
+        let next: Int
+        if let travel = data?.travel, travel.isTraveling {
+            next = travel.remainingSeconds(from: lastFetchTime)
+        } else {
+            next = 0
+        }
+        if next != travelSecondsRemaining {
+            travelSecondsRemaining = next
+        }
+    }
+
+    private func computeMenuBarDisplay() -> MenuBarDisplay {
+        guard let data = data else { return .fallbackIcon }
+
+        if let travel = data.travel, travel.isTraveling {
+            let flag = TornDestination.flag(for: travel.destination ?? "?")
+            return .traveling(flag: flag, seconds: travel.remainingSeconds(from: lastFetchTime))
+        }
+
+        if let status = data.status, status.isInHospital {
+            let secs = status.timeRemaining
+            if let travel = data.travel, travel.isAbroad {
+                let flag = TornDestination.flag(for: travel.destination ?? "?")
+                return .hospitalAbroad(flag: flag, seconds: secs)
+            }
+            return .hospitalAtHome(seconds: secs)
+        }
+
+        if let status = data.status, status.isInJail {
+            return .jail(seconds: status.timeRemaining)
+        }
+
+        if let ends = cooldownEnds,
+           let soonest = ends.soonestActive() {
+            return .cooldown(emoji: soonest.kind.emoji, seconds: soonest.seconds)
+        }
+
+        return .fallbackIcon
+    }
+
+    // MARK: - Next Action
+
+    func loadHiddenNextActionCategories() {
+        guard let raw = defaults.stringArray(forKey: Self.hiddenNextActionKey) else { return }
+        hiddenNextActionCategories = Set(raw.compactMap(NextActionCategory.init(rawValue:)))
+    }
+
+    func saveHiddenNextActionCategories() {
+        defaults.set(hiddenNextActionCategories.map(\.rawValue), forKey: Self.hiddenNextActionKey)
+    }
+
+    func makeNextActionSnapshot(now: Date = Date()) -> NextActionSnapshot {
+        let nowUnix = Int(now.timeIntervalSince1970)
+        var snapshot = NextActionSnapshot(now: nowUnix)
+
+        if let bars = data?.bars {
+            snapshot.energyFullAt = barFullAt(bars.energy, nowUnix: nowUnix)
+            snapshot.nerveFullAt = barFullAt(bars.nerve, nowUnix: nowUnix)
+            snapshot.happyFullAt = barFullAt(bars.happy, nowUnix: nowUnix)
+            snapshot.lifeFullAt = barFullAt(bars.life, nowUnix: nowUnix)
+        }
+        if let cd = cooldownEnds {
+            snapshot.drugReadyAt = cd.drugEndsAt > 0 ? cd.drugEndsAt : nil
+            snapshot.medicalReadyAt = cd.medicalEndsAt > 0 ? cd.medicalEndsAt : nil
+            snapshot.boosterReadyAt = cd.boosterEndsAt > 0 ? cd.boosterEndsAt : nil
+        }
+        if let travel = data?.travel, travel.isTraveling, travelSecondsRemaining > 0 {
+            snapshot.travelArrivalAt = nowUnix + travelSecondsRemaining
+        }
+        if let status = data?.status {
+            if status.isInHospital { snapshot.hospitalReleaseAt = status.until }
+            if status.isInJail { snapshot.jailReleaseAt = status.until }
+        }
+        if let until = education?.current?.until, until > 0 {
+            snapshot.educationEndsAt = until
+        }
+        if let ready = organizedCrime?.readyAt, ready > 0 {
+            snapshot.ocReadyAt = ready
+        }
+        if let chain = data?.chain, chain.isActive, let timeout = chain.timeout, timeout > 0 {
+            snapshot.chainTimeoutAt = timeout
+        }
+        if let refills, !refills.unclaimed.isEmpty {
+            snapshot.refillsAvailable = true
+        }
+        return snapshot
+    }
+
+    private func barFullAt(_ bar: Bar, nowUnix: Int) -> Int? {
+        guard bar.current < bar.maximum, let full = bar.fulltime, full > 0 else { return nil }
+        return nowUnix + full
+    }
+
+    func nextEvents(now: Date = Date()) -> [NextEvent] {
+        NextActionEngine().events(from: makeNextActionSnapshot(now: now), hidden: hiddenNextActionCategories)
+    }
+
+    func makeDiagnosticsReport() async -> DiagnosticsReport {
+        let notif = await NotificationManager.shared.authorizationStatusDescription()
+        var recordsByCategory: [String: Int] = [:]
+        for (category, count) in pollingCoordinator.recordsPerDayByCategory() {
+            recordsByCategory[category.rawValue] = count
+        }
+        return DiagnosticsReport(
+            appVersion: DiagnosticsEnvironment.appVersion,
+            build: DiagnosticsEnvironment.build,
+            osVersion: DiagnosticsEnvironment.osVersion,
+            architecture: DiagnosticsEnvironment.architecture,
+            isOnline: connectivity.isConnected,
+            notificationPermission: notif,
+            lastSuccessfulRefresh: lastUpdated,
+            lastErrorSummary: errorMsg,
+            keyPresent: !apiKey.isEmpty,
+            requiredAccessLevel: TornEndpointRegistry.requiredAccessLevel.label,
+            requestsLastMinute: pollingCoordinator.requestsInLastMinute,
+            requestsLastDay: pollingCoordinator.requestsInLastDay,
+            recordsPerDayByCategory: recordsByCategory,
+            endpoints: endpointHealth.all
+        )
+    }
+}

--- a/MacTorn/MacTorn/ViewModels/AppState+MarketForum.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState+MarketForum.swift
@@ -1,0 +1,346 @@
+import Foundation
+import Combine
+
+extension AppState {
+    // MARK: - Watchlist
+
+    func loadWatchlist() {
+        marketWatchService.load()
+    }
+
+    func saveWatchlist() {
+        marketWatchService.save()
+    }
+
+    func addToWatchlist(itemId: Int, name: String) {
+        guard marketWatchService.add(itemID: itemId, name: name) else {
+            logger.warning("addToWatchlist rejected invalid or duplicate item \(itemId)")
+            return
+        }
+        Task {
+            await fetchItemPrice(itemId: itemId)
+        }
+    }
+
+    func removeFromWatchlist(_ itemId: Int) {
+        marketWatchService.remove(itemID: itemId)
+    }
+
+    func refreshWatchlistPrices() {
+        accountSession.startTask(.watchlist) {
+            await self.fetchWatchlistPrices()
+        }
+    }
+
+    private func fetchWatchlistPrices() async {
+        guard connectivity.isConnected else { return }
+        let requestedKey = apiKey
+        let generation = accountSession.identity.generation
+        guard !requestedKey.isEmpty else { return }
+        let itemIDs = watchlistItems.map(\.id)
+        pendingPriceAlerts.removeAll(keepingCapacity: true)
+        await BoundedTaskQueue.run(itemIDs, limit: 4) { [weak self] itemID in
+            guard let self else { return }
+            await self.fetchItemPrice(
+                itemId: itemID,
+                apiKey: requestedKey,
+                generation: generation,
+                save: false
+            )
+        }
+        guard !Task.isCancelled,
+              isCurrentAccount(requestedKey, generation: generation) else { return }
+        flushPendingPriceAlerts()
+        saveWatchlist()
+    }
+
+    private func flushPendingPriceAlerts() {
+        let alerts = pendingPriceAlerts
+        pendingPriceAlerts.removeAll(keepingCapacity: true)
+        guard !alerts.isEmpty else { return }
+        if alerts.count == 1 {
+            let a = alerts[0]
+            NotificationManager.shared.send(
+                title: "Price Alert: \(a.name)",
+                body: "Lowest price dropped to \(formatAlertPrice(a.price))",
+                type: .priceAlert
+            )
+            return
+        }
+        // Summary notification: list up to 3 names then "+N more".
+        let preview = alerts.prefix(3).map { $0.name }.joined(separator: ", ")
+        let extra = alerts.count > 3 ? " +\(alerts.count - 3) more" : ""
+        NotificationManager.shared.send(
+            title: "\(alerts.count) price alerts",
+            body: "\(preview)\(extra)",
+            type: .priceAlert
+        )
+    }
+
+    private func fetchItemPrice(itemId: Int, save: Bool = true) async {
+        let requestedKey = apiKey
+        let generation = accountSession.identity.generation
+        await fetchItemPrice(
+            itemId: itemId,
+            apiKey: requestedKey,
+            generation: generation,
+            save: save
+        )
+    }
+
+    private func fetchItemPrice(
+        itemId: Int,
+        apiKey requestedKey: String,
+        generation: UInt,
+        save: Bool
+    ) async {
+        guard isCurrentAccount(requestedKey, generation: generation),
+              !requestedKey.isEmpty,
+              let url = TornAPI.marketURL(itemId: itemId, apiKey: requestedKey) else { return }
+        guard reserveRequest("market.item") else {
+            updateItemError(itemId: itemId, error: "Request limit reached", save: save)
+            return
+        }
+
+        logger.info("Fetching price for item \(itemId)")
+
+        do {
+            let result = try await marketWatchService.fetchPrice(from: url)
+            guard !Task.isCancelled,
+                  isCurrentAccount(requestedKey, generation: generation) else { return }
+
+            switch result {
+            case .success(let snapshot, _):
+                updateItemPrice(
+                    itemId: itemId,
+                    lowestPrice: snapshot.lowestPrice,
+                    lowestPriceQuantity: snapshot.lowestPriceQuantity,
+                    secondLowestPrice: snapshot.secondLowestPrice,
+                    save: save
+                )
+            case .apiError(let apiError, _):
+                logger.warning("Item \(itemId) API returned an error envelope")
+                updateItemError(itemId: itemId, error: apiError.userMessage, save: save)
+            case .httpError(let statusCode, _):
+                logger.error("Item \(itemId) HTTP Error: \(statusCode)")
+                updateItemError(itemId: itemId, error: "HTTP \(statusCode)", save: save)
+            case .noListings:
+                updateItemError(itemId: itemId, error: "No listings", save: save)
+            case .malformed:
+                logger.error("Item \(itemId): failed to parse JSON response")
+                updateItemError(itemId: itemId, error: "Parse Error", save: save)
+            }
+        } catch {
+            guard !Task.isCancelled,
+                  isCurrentAccount(requestedKey, generation: generation) else { return }
+            logger.error("Item \(itemId) price fetch error: \(String(describing: type(of: error)))")
+            updateItemError(itemId: itemId, error: "Network Error", save: save)
+        }
+    }
+
+    @MainActor
+    private func updateItemPrice(itemId: Int, lowestPrice: Int, lowestPriceQuantity: Int, secondLowestPrice: Int, save: Bool = true) {
+        let snapshot = MarketPriceSnapshot(
+            lowestPrice: lowestPrice,
+            lowestPriceQuantity: lowestPriceQuantity,
+            secondLowestPrice: secondLowestPrice
+        )
+        if let alert = marketWatchService.apply(snapshot, to: itemId) {
+            if save {
+                NotificationManager.shared.send(
+                    title: "Price Alert: \(alert.name)",
+                    body: "Lowest price dropped to \(formatAlertPrice(alert.price))",
+                    type: .priceAlert
+                )
+            } else {
+                pendingPriceAlerts.append((name: alert.name, price: alert.price))
+            }
+        }
+        if save { marketWatchService.save() }
+    }
+
+    private func formatAlertPrice(_ price: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencySymbol = "$"
+        formatter.maximumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: price)) ?? "$\(price)"
+    }
+
+    @MainActor
+    private func updateItemError(itemId: Int, error: String, save: Bool = true) {
+        marketWatchService.setError(error, for: itemId)
+        if save { marketWatchService.save() }
+    }
+
+    // MARK: - Forum Watch
+
+    func loadForumWatch() {
+        forumWatchService.load()
+    }
+
+    func saveForumWatch() {
+        forumWatchService.save()
+    }
+
+    func parseThreadInput(_ input: String) -> Int? {
+        forumWatchService.parseThreadInput(input)
+    }
+
+    @discardableResult
+    func addWatchedThread(input: String) -> Bool {
+        guard let threadId = forumWatchService.add(input: input) else { return false }
+        Task {
+            await fetchForumThreadMetadata(threadId: threadId)
+        }
+        return true
+    }
+
+    func removeWatchedThread(_ threadId: Int) {
+        forumWatchService.remove(threadID: threadId)
+    }
+
+    func toggleThreadNotifications(_ threadId: Int) {
+        forumWatchService.toggleNotifications(threadID: threadId)
+    }
+
+    func markThreadAsRead(_ threadId: Int) {
+        forumWatchService.markAsRead(threadID: threadId)
+    }
+
+    func startForumPolling() {
+        // Same MenuBarExtra-onAppear churn as startPolling: skip restart if already
+        // running and we polled recently.
+        if forumTimerCancellable != nil,
+           let last = lastForumFetchAt,
+           Date().timeIntervalSince(last) < Double(forumWatchConfig.pollingIntervalSeconds) / 2 {
+            return
+        }
+        forumTimerCancellable?.cancel()
+        guard !apiKey.isEmpty else { return }
+
+        // Initial fetch
+        refreshForumWatch()
+
+        forumTimerCancellable = Timer.publish(every: Double(forumWatchConfig.pollingIntervalSeconds), on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                self?.refreshForumWatch()
+            }
+    }
+
+    func stopForumPolling() {
+        forumTimerCancellable?.cancel()
+        forumTimerCancellable = nil
+    }
+
+    func refreshForumWatch() {
+        accountSession.startTask(.forum) {
+            await self.fetchForumUpdates()
+        }
+    }
+
+    private func fetchForumUpdates() async {
+        guard connectivity.isConnected, !apiKey.isEmpty else { return }
+        let requestedKey = apiKey
+        let generation = accountSession.identity.generation
+        let threadIDs = watchedThreads.map(\.id)
+
+        await BoundedTaskQueue.run(threadIDs, limit: 4) { [weak self] threadID in
+            guard let self else { return }
+            await self.checkThreadForUpdates(
+                threadId: threadID,
+                apiKey: requestedKey,
+                generation: generation
+            )
+        }
+
+        guard !Task.isCancelled,
+              isCurrentAccount(requestedKey, generation: generation) else { return }
+        lastForumFetchAt = Date()
+        saveForumWatch()
+    }
+
+    private func checkThreadForUpdates(
+        threadId: Int,
+        apiKey requestedKey: String,
+        generation: UInt
+    ) async {
+        guard isCurrentAccount(requestedKey, generation: generation),
+              let url = TornAPI.forumThreadURL(threadId: threadId, apiKey: requestedKey) else { return }
+        guard reserveRequest("forum.thread") else {
+            updateThreadError(threadId: threadId, error: "Request limit reached")
+            return
+        }
+
+        do {
+            let result = try await forumWatchService.fetchThread(from: url)
+            guard !Task.isCancelled,
+                  isCurrentAccount(requestedKey, generation: generation) else { return }
+
+            switch result {
+            case .success(let snapshot, _):
+                if let update = forumWatchService.apply(snapshot, to: threadId) {
+                    let threadURL = URL(
+                        string: "https://www.torn.com/forums.php#/p=threads&t=\(threadId)"
+                    )
+                    NotificationManager.shared.send(
+                        title: "Forum: \(update.title)",
+                        body: "\(update.count) new post\(update.count == 1 ? "" : "s")",
+                        type: .forumNewPosts,
+                        customURL: threadURL
+                    )
+                }
+            case .apiError(let apiError, _):
+                updateThreadError(threadId: threadId, error: apiError.userMessage)
+            case .httpError, .malformed:
+                return
+            }
+        } catch {
+            guard !Task.isCancelled,
+                  isCurrentAccount(requestedKey, generation: generation) else { return }
+            updateThreadError(threadId: threadId, error: "Network Error")
+        }
+    }
+
+    @MainActor
+    private func updateThreadError(threadId: Int, error: String) {
+        forumWatchService.setError(error, for: threadId)
+    }
+
+    private func fetchForumThreadMetadata(threadId: Int) async {
+        let requestedKey = apiKey
+        let generation = accountSession.identity.generation
+        guard !requestedKey.isEmpty,
+              let url = TornAPI.forumThreadURL(threadId: threadId, apiKey: requestedKey) else { return }
+        guard reserveRequest("forum.thread") else {
+            updateThreadError(threadId: threadId, error: "Request limit reached")
+            return
+        }
+
+        do {
+            let result = try await forumWatchService.fetchThread(from: url)
+            guard !Task.isCancelled,
+                  isCurrentAccount(requestedKey, generation: generation) else { return }
+
+            switch result {
+            case .success(let snapshot, _):
+                _ = forumWatchService.apply(snapshot, to: threadId)
+            case .apiError(let apiError, _):
+                updateThreadError(threadId: threadId, error: apiError.userMessage)
+            case .httpError:
+                updateThreadError(threadId: threadId, error: "HTTP Error")
+            case .malformed:
+                return
+            }
+        } catch {
+            guard !Task.isCancelled,
+                  isCurrentAccount(requestedKey, generation: generation) else { return }
+            updateThreadError(threadId: threadId, error: "Network Error")
+        }
+
+        if isCurrentAccount(requestedKey, generation: generation) {
+            saveForumWatch()
+        }
+    }
+}

--- a/MacTorn/MacTorn/ViewModels/AppState+NotificationsFeedback.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState+NotificationsFeedback.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+extension AppState {
+    // MARK: - Notifications
+
+    func checkNotifications(newData: TornResponse) {
+        if let prev = previousBars, let current = newData.bars {
+            checkBarNotification(prevBar: prev.energy, currentBar: current.energy, barType: .energy)
+            checkBarNotification(prevBar: prev.nerve, currentBar: current.nerve, barType: .nerve)
+            checkBarNotification(prevBar: prev.happy, currentBar: current.happy, barType: .happy)
+            checkBarNotification(prevBar: prev.life, currentBar: current.life, barType: .life)
+        }
+
+        if let prevCD = previousCooldowns, let currentCD = newData.cooldowns {
+            if prevCD.drug > 0 && currentCD.drug == 0 {
+                NotificationManager.shared.send(title: "Drug Ready! 💊", body: "Drug cooldown has ended", type: .drugReady)
+            }
+            if prevCD.medical > 0 && currentCD.medical == 0 {
+                NotificationManager.shared.send(title: "Medical Ready! 🏥", body: "Medical cooldown has ended", type: .medicalReady)
+            }
+            if prevCD.booster > 0 && currentCD.booster == 0 {
+                NotificationManager.shared.send(title: "Booster Ready! 🚀", body: "Booster cooldown has ended", type: .boosterReady)
+            }
+        }
+
+        if let prevTravel = previousTravel, let currentTravel = newData.travel {
+            // Just landed
+            if prevTravel.isTraveling && !currentTravel.isTraveling {
+                NotificationManager.shared.send(title: "Landed!", body: "You have arrived in \(currentTravel.destination ?? "destination")", type: .landed)
+                NotificationManager.shared.cancelTravelNotifications()
+            }
+            // Just started traveling
+            if !prevTravel.isTraveling && currentTravel.isTraveling {
+                scheduleTravelNotifications(for: currentTravel)
+            }
+        } else if let currentTravel = newData.travel, currentTravel.isTraveling, previousTravel == nil {
+            // First data fetch while traveling
+            scheduleTravelNotifications(for: currentTravel)
+        }
+
+        if chainExpiringShouldFire(newData.chain), let chain = newData.chain {
+            NotificationManager.shared.send(title: "Chain Expiring! ⚠️", body: "Chain timeout in \(chain.timeoutRemaining) seconds!", type: .chainExpiring)
+        }
+
+        if let prevStatus = previousStatus, let currentStatus = newData.status {
+            if (prevStatus.isInHospital || prevStatus.isInJail) && currentStatus.isOkay {
+                NotificationManager.shared.send(title: "Released! 🎉", body: "You are now free", type: .released)
+            }
+        }
+    }
+
+    /// Decides whether the "Chain Expiring!" alert should fire on this poll.
+    ///
+    /// The alert must fire exactly once when the chain enters the danger window
+    /// (0 < timeout < `chainWarningThreshold`), NOT on every poll while it stays there
+    /// (the previous bug). It re-arms once the chain leaves the window — a member hits
+    /// (timeout jumps back up), the chain ends, or the chain drops — so a fresh danger
+    /// window alerts again. The latch is persisted, so a relaunch mid-window is silent.
+    /// `internal` for `@testable` regression coverage.
+    func chainExpiringShouldFire(_ chain: Chain?) -> Bool {
+        let inDanger = (chain?.isActive == true)
+            && chain!.timeoutRemaining > 0
+            && chain!.timeoutRemaining < Self.chainWarningThreshold
+        return notificationCoordinator.shouldFireOnEdge("chain.expiring", active: inDanger)
+    }
+
+    private func checkBarNotification(prevBar: Bar, currentBar: Bar, barType: NotificationRule.BarType) {
+        let prevPct = prevBar.percentage
+        let currentPct = currentBar.percentage
+
+        for rule in notificationRules where rule.enabled && rule.barType == barType {
+            let threshold = Double(rule.threshold)
+
+            if prevPct < threshold && currentPct >= threshold {
+                let title: String
+                let notificationType: NotificationType
+                switch barType {
+                case .energy:
+                    title = "Energy \(rule.threshold)%! ⚡️"
+                    notificationType = .energy
+                case .nerve:
+                    title = "Nerve \(rule.threshold)%! 💪"
+                    notificationType = .nerve
+                case .happy:
+                    title = "Happy \(rule.threshold)%! 😊"
+                    notificationType = .happy
+                case .life:
+                    title = "Life \(rule.threshold)%! ❤️"
+                    notificationType = .life
+                }
+                NotificationManager.shared.send(title: title, body: "\(barType.rawValue) is now at \(currentBar.current)/\(currentBar.maximum)", type: notificationType)
+
+                if let sound = NotificationSound(rawValue: rule.soundName) {
+                    SoundManager.shared.play(sound)
+                }
+            }
+        }
+    }
+
+    // MARK: - Updates
+
+    func checkForAppUpdates() {
+        guard let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return }
+
+        Task {
+            if let release = await updateManager.checkForUpdates(currentVersion: currentVersion) {
+                await MainActor.run {
+                    self.updateAvailable = release
+                }
+            }
+        }
+    }
+
+    // MARK: - Feedback Prompt
+
+    func loadFeedbackState() {
+        if let data = defaults.data(forKey: "appFeedbackState"),
+           let state = try? JSONDecoder().decode(AppFeedbackState.self, from: data) {
+            feedbackState = state
+        } else {
+            feedbackState = AppFeedbackState(
+                firstLaunchDate: Date(),
+                hasResponded: false,
+                dismissCount: 0,
+                lastDismissedDate: nil
+            )
+            saveFeedbackState()
+        }
+    }
+
+    func saveFeedbackState() {
+        guard let state = feedbackState,
+              let data = try? JSONEncoder().encode(state) else { return }
+        defaults.set(data, forKey: "appFeedbackState")
+    }
+
+    func checkFeedbackPrompt() {
+        guard let state = feedbackState else { return }
+        guard !state.hasResponded else { return }
+        guard state.dismissCount < Self.feedbackThresholds.count else { return }
+
+        // 5-minute cooldown after last dismissal
+        if let lastDismissed = state.lastDismissedDate,
+           Date().timeIntervalSince(lastDismissed) < 300 {
+            return
+        }
+
+        let elapsed = Date().timeIntervalSince(state.firstLaunchDate)
+        let requiredTime = Self.feedbackThresholds[state.dismissCount]
+
+        if elapsed >= requiredTime {
+            showFeedbackPrompt = true
+        }
+    }
+
+    private static var isRunningUnderXCTest: Bool {
+        NSClassFromString("XCTestCase") != nil
+    }
+
+    func feedbackRespondedPositive() {
+        feedbackState?.hasResponded = true
+        showFeedbackPrompt = false
+        saveFeedbackState()
+        // Guard prevents tests from spamming the user's browser/mail client.
+        guard !Self.isRunningUnderXCTest else { return }
+        if let url = URL(string: "https://www.torn.com/forums.php#/p=threads&f=67&t=16532308") {
+            BrowserManager.shared.open(url)
+        }
+    }
+
+    func feedbackRespondedNegative() {
+        feedbackState?.hasResponded = true
+        showFeedbackPrompt = false
+        saveFeedbackState()
+        guard !Self.isRunningUnderXCTest else { return }
+        if let url = URL(string: "mailto:pawel@orzech.lol?subject=MacTorn%20Feedback") {
+            BrowserManager.shared.open(url)
+        }
+    }
+
+    func feedbackDismissed() {
+        feedbackState?.dismissCount += 1
+        feedbackState?.lastDismissedDate = Date()
+        showFeedbackPrompt = false
+        saveFeedbackState()
+    }
+}

--- a/MacTorn/MacTorn/ViewModels/AppState+PersistenceStocks.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState+PersistenceStocks.swift
@@ -1,0 +1,179 @@
+import Foundation
+import os.log
+
+extension AppState {
+    private static var stocksMetadataCacheKey: String { "stocksMetadataCache" }
+    private static var stocksBackoffLadder: [TimeInterval] { [60, 300, 1800] }
+
+    // MARK: - Stocks Metadata
+
+    func loadStocksMetadataFromCache() {
+        guard let data = defaults.data(forKey: Self.stocksMetadataCacheKey),
+              let cached = try? JSONDecoder().decode([Int: StockMetadata].self, from: data) else {
+            return
+        }
+        stocksMetadata = cached
+    }
+
+    func fetchStocksMetadata() async {
+        guard !apiKey.isEmpty, let url = TornAPI.tornStocksURL(for: apiKey) else { return }
+        guard reserveRequest("torn.stocks") else { return }
+        let startTime = Date()
+        do {
+            var request = URLRequest(url: url)
+            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+            let (data, _) = try await session.data(for: request)
+            let parsed = AppState.parseStocksMetadata(from: data, logger: logger)
+            guard !parsed.isEmpty else {
+                await MainActor.run {
+                    self.recordStocksMetadataFailure()
+                    self.recordHealth("torn.stocks", outcome: .error, since: startTime, bytes: data.count, errorClass: "malformedResponse")
+                }
+                return
+            }
+            await MainActor.run {
+                self.stocksMetadata = parsed
+                if let encoded = try? JSONEncoder().encode(parsed) {
+                    defaults.set(encoded, forKey: Self.stocksMetadataCacheKey)
+                }
+                self.stocksFailureCount = 0
+                self.stocksNextRetryAfter = nil
+                self.recordHealth("torn.stocks", outcome: .ok, since: startTime, bytes: data.count)
+                self.logger.info("Stocks metadata loaded: \(parsed.count) stocks")
+            }
+        } catch {
+            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
+            await MainActor.run {
+                self.recordStocksMetadataFailure()
+                self.recordHealth(
+                    "torn.stocks",
+                    outcome: mapped?.classification == .offline ? .offline : .error,
+                    since: startTime,
+                    bytes: 0,
+                    errorClass: mapped?.classification.rawValue ?? "transport"
+                )
+            }
+            logger.error("Failed to fetch stocks metadata: \(String(describing: type(of: error)))")
+        }
+    }
+
+    @MainActor
+    func recordStocksMetadataFailure() {
+        stocksFailureCount += 1
+        let idx = min(stocksFailureCount - 1, Self.stocksBackoffLadder.count - 1)
+        let delay = Self.stocksBackoffLadder[idx]
+        stocksNextRetryAfter = Date().addingTimeInterval(delay)
+    }
+
+    nonisolated static func parseStocksMetadata(from data: Data, logger: Logger) -> [Int: StockMetadata] {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            logger.error("Stocks metadata: failed to parse JSON")
+            return [:]
+        }
+        if tornAPIErrorMessage(in: json) != nil {
+            logger.error("Stocks metadata API returned an error envelope")
+            return [:]
+        }
+        guard let stocksDict = json["stocks"] as? [String: [String: Any]] else {
+            logger.warning("Stocks metadata: no 'stocks' key in response")
+            return [:]
+        }
+        var result: [Int: StockMetadata] = [:]
+        for (key, stockData) in stocksDict {
+            guard let id = Int(key) else { continue }
+            let name = stockData["name"] as? String ?? ""
+            let acronym = stockData["acronym"] as? String ?? ""
+            let price: Double
+            if let n = stockData["current_price"] as? NSNumber {
+                price = n.doubleValue
+            } else if let s = stockData["current_price"] as? String, let d = Double(s) {
+                price = d
+            } else {
+                price = 0
+            }
+            result[id] = StockMetadata(id: id, name: name, acronym: acronym, currentPrice: price)
+        }
+        return result
+    }
+
+    // MARK: - Notification Rules
+
+    func loadNotificationRules() {
+        if let data = defaults.data(forKey: "notificationRules"),
+           let rules = try? JSONDecoder().decode([NotificationRule].self, from: data) {
+            notificationRules = rules
+        } else {
+            notificationRules = NotificationRule.defaults
+            saveNotificationRules()
+        }
+    }
+
+    func saveNotificationRules() {
+        if let data = try? JSONEncoder().encode(notificationRules) {
+            defaults.set(data, forKey: "notificationRules")
+        }
+    }
+
+    func updateRule(_ rule: NotificationRule) {
+        if let index = notificationRules.firstIndex(where: { $0.id == rule.id }) {
+            notificationRules[index] = rule
+            saveNotificationRules()
+        }
+    }
+
+    // MARK: - Travel Notification Settings
+
+    func loadTravelNotificationSettings() {
+        if let data = defaults.data(forKey: "travelNotificationSettings"),
+           let settings = try? JSONDecoder().decode([TravelNotificationSetting].self, from: data) {
+            travelNotificationSettings = settings
+        } else {
+            travelNotificationSettings = TravelNotificationSetting.defaults
+            saveTravelNotificationSettings()
+        }
+    }
+
+    func saveTravelNotificationSettings() {
+        if let data = try? JSONEncoder().encode(travelNotificationSettings) {
+            defaults.set(data, forKey: "travelNotificationSettings")
+        }
+    }
+
+    func updateTravelNotificationSetting(_ setting: TravelNotificationSetting) {
+        if let index = travelNotificationSettings.firstIndex(where: { $0.id == setting.id }) {
+            travelNotificationSettings[index] = setting
+            saveTravelNotificationSettings()
+            if let travel = data?.travel, travel.isTraveling {
+                scheduleTravelNotifications(for: travel)
+            }
+        }
+    }
+
+    func scheduleTravelNotifications(for travel: Travel) {
+        NotificationManager.shared.cancelTravelNotifications()
+
+        guard let arrivalDate = travel.arrivalDate else { return }
+
+        for setting in travelNotificationSettings where setting.enabled {
+            let notificationDate = arrivalDate.addingTimeInterval(-Double(setting.secondsBefore))
+
+            if notificationDate > Date() {
+                let identifier = "\(setting.id)_alert"
+                let timeText: String
+                if setting.secondsBefore >= 60 {
+                    timeText = "\(setting.secondsBefore / 60) minute\(setting.secondsBefore >= 120 ? "s" : "")"
+                } else {
+                    timeText = "\(setting.secondsBefore) seconds"
+                }
+
+                NotificationManager.shared.scheduleNotification(
+                    title: "Landing Soon!",
+                    body: "You will arrive in \(travel.destination ?? "your destination") in \(timeText)",
+                    type: .travelApproaching,
+                    at: notificationDate,
+                    identifier: identifier
+                )
+            }
+        }
+    }
+}

--- a/MacTorn/MacTorn/ViewModels/AppState+PollingUserFetch.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState+PollingUserFetch.swift
@@ -1,0 +1,549 @@
+import Foundation
+import Combine
+
+extension AppState {
+    private static var activityMinInterval: TimeInterval { 300 }
+    private static var dailyRowLimitPause: TimeInterval { 3600 }
+
+    // MARK: - Polling
+
+    func startPolling(force: Bool = false) {
+        guard !keyHalted else {
+            logger.warning("startPolling skipped: polling halted on a permanent key error")
+            return
+        }
+        if !force,
+           timerCancellable != nil,
+           Date().timeIntervalSince(lastFetchTime) < Double(refreshInterval) / 2 {
+            return
+        }
+        timerCancellable?.cancel()
+        fetchData()
+        triggerStocksMetadataFetchIfNeeded()
+        timerCancellable = Timer.publish(every: Double(refreshInterval), on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                self?.fetchData()
+                self?.triggerStocksMetadataFetchIfNeeded()
+            }
+    }
+
+    private func triggerStocksMetadataFetchIfNeeded() {
+        guard stocksMetadata.isEmpty, !apiKey.isEmpty else { return }
+        if let nextRetry = stocksNextRetryAfter, Date() < nextRetry { return }
+        Task { await self.fetchStocksMetadata() }
+    }
+
+    func stopPolling() {
+        timerCancellable?.cancel()
+        timerCancellable = nil
+    }
+
+    func refreshNow() {
+        startPolling(force: true)
+    }
+
+    func isRowSourcePaused(_ endpointID: String) -> Bool {
+        guard let until = rowSourcePausedUntil[endpointID] else { return false }
+        if time.now >= until {
+            rowSourcePausedUntil[endpointID] = nil
+            return false
+        }
+        return true
+    }
+
+    func pauseRowSource(_ endpointID: String, error: TornAPIError) {
+        rowSourcePausedUntil[endpointID] = time.now.addingTimeInterval(Self.dailyRowLimitPause)
+        logger.warning("Paused row source \(endpointID) for \(Int(Self.dailyRowLimitPause))s after daily read limit (code \(error.tornCode ?? 14))")
+    }
+
+    @discardableResult
+    func reserveRequest(_ endpointID: String) -> Bool {
+        guard let endpoint = TornEndpointRegistry.endpoint(id: endpointID),
+              pollingCoordinator.canMakeRequest() else {
+            logger.warning("Request skipped for \(endpointID): per-minute budget reached")
+            return false
+        }
+        pollingCoordinator.record(endpoint)
+        return true
+    }
+
+    func handlePermanentKeyError(_ error: TornAPIError) {
+        resetAccountScopedState()
+        keyHalted = true
+        keyInfo = nil
+        keyValidation = .failure(error.userMessage)
+        errorMsg = error.userMessage
+        stopPolling()
+        logger.error("Polling halted on permanent key/permission error (code \(error.tornCode ?? -1))")
+    }
+
+    func validateKey(_ keyOverride: String? = nil) async {
+        let trimmed = (keyOverride ?? apiKey).trimmingCharacters(in: .whitespacesAndNewlines)
+        let validationIdentity = accountSession.identity
+        guard !trimmed.isEmpty else {
+            keyValidation = .failure("Enter your Torn API key first.")
+            return
+        }
+        guard connectivity.isConnected else {
+            keyValidation = .failure(TornAPIError.offline.userMessage)
+            return
+        }
+        guard let url = TornAPI.keyInfoURL(for: trimmed) else {
+            keyValidation = .failure("Could not build the key-info request.")
+            return
+        }
+
+        keyValidation = .validating
+        guard reserveRequest("key.info") else {
+            keyValidation = .failure("Request limit reached. Please try again shortly.")
+            return
+        }
+        let startTime = Date()
+        logger.info("Validating key via key-info: \(tornRedactedURL(url))")
+
+        do {
+            var request = URLRequest(url: url)
+            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+            let (data, response) = try await session.data(for: request)
+            guard accountSession.isCurrent(validationIdentity) else { return }
+
+            guard let http = response as? HTTPURLResponse else { throw APIError.invalidResponse }
+
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let apiError = tornAPIError(in: json) {
+                recordHealth(
+                    "key.info",
+                    outcome: .error,
+                    since: startTime,
+                    bytes: data.count,
+                    errorClass: apiError.classification.rawValue
+                )
+                keyValidation = .failure(apiError.userMessage)
+                return
+            }
+
+            guard http.statusCode == 200 else {
+                recordHealth(
+                    "key.info",
+                    outcome: .error,
+                    since: startTime,
+                    bytes: data.count,
+                    errorClass: "temporaryBackend"
+                )
+                keyValidation = .failure("Torn returned HTTP \(http.statusCode). Please try again.")
+                return
+            }
+
+            let decoded = try JSONDecoder().decode(TornKeyInfo.Response.self, from: data)
+            self.keyInfo = decoded.info
+            self.keyValidation = .success(KeyValidator.validate(decoded.info))
+            recordHealth("key.info", outcome: .ok, since: startTime, bytes: data.count)
+            logger.info("Key validated: access level \(decoded.info.access.level)")
+        } catch {
+            if Task.isCancelled {
+                recordHealth("key.info", outcome: .cancelled, since: startTime, bytes: 0)
+                return
+            }
+            guard accountSession.isCurrent(validationIdentity) else { return }
+            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
+            let message = mapped?.userMessage
+                ?? "Couldn't read Torn's response. Please try again."
+            keyValidation = .failure(message)
+            recordHealth(
+                "key.info",
+                outcome: mapped?.classification == .offline ? .offline : .error,
+                since: startTime,
+                bytes: 0,
+                errorClass: mapped?.classification.rawValue ?? "malformedResponse"
+            )
+            logger.error("Key validation failed: \(String(describing: type(of: error)))")
+        }
+    }
+
+    func recordHealth(
+        _ endpointID: String,
+        outcome: EndpointOutcome,
+        since start: Date,
+        bytes: Int,
+        errorClass: String? = nil
+    ) {
+        endpointHealth.record(
+            endpointID: endpointID,
+            outcome: outcome,
+            latencyMs: Int(Date().timeIntervalSince(start) * 1000),
+            responseBytes: bytes,
+            errorClass: errorClass
+        )
+    }
+
+    // MARK: - Fetch Data
+
+    func fetchData() {
+        guard connectivity.isConnected else {
+            if errorMsg != "No internet connection" {
+                errorMsg = "No internet connection"
+                logger.warning("Fetch aborted: No internet connection")
+            }
+            return
+        }
+
+        let requestedKey = apiKey
+        guard !requestedKey.isEmpty else {
+            errorMsg = "API Key required"
+            logger.warning("Fetch aborted: API Key required")
+            return
+        }
+
+        guard let url = TornAPI.url(for: requestedKey) else {
+            errorMsg = "Invalid URL"
+            logger.error("Fetch aborted: Invalid URL")
+            return
+        }
+
+        guard reserveRequest("user.fast") else { return }
+
+        isLoading = true
+        errorMsg = nil
+        let generation = accountSession.identity.generation
+
+        logger.info("Starting data fetch from: \(tornRedactedURL(url))")
+
+        accountSession.startTask(.userSnapshot) {
+            let startTime = Date()
+
+            defer {
+                Task { @MainActor in
+                    let elapsed = Date().timeIntervalSince(startTime)
+                    if elapsed < 0.5 {
+                        try? await Task.sleep(nanoseconds: UInt64((0.5 - elapsed) * 1_000_000_000))
+                    }
+                    if self.isCurrentAccount(requestedKey, generation: generation) {
+                        self.isLoading = false
+                    }
+                }
+            }
+
+            do {
+                let response = try await self.userSnapshotService.load(url)
+                let data = response.data
+                guard self.isCurrentAccount(requestedKey, generation: generation) else {
+                    self.recordHealth("user.fast", outcome: .cancelled, since: startTime, bytes: 0)
+                    return
+                }
+
+                self.logger.info("HTTP response: \(response.statusCode)")
+
+                switch response.statusCode {
+                case 200:
+                    if let topLevel = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                        if let apiError = tornAPIError(in: topLevel) {
+                            self.recordHealth(
+                                "user.fast",
+                                outcome: .error,
+                                since: startTime,
+                                bytes: data.count,
+                                errorClass: apiError.classification.rawValue
+                            )
+                            if apiError.haltsAllRequests {
+                                self.handlePermanentKeyError(apiError)
+                            } else {
+                                self.errorMsg = apiError.userMessage
+                                self.logger.warning("User API error class: \(apiError.classification.rawValue)")
+                            }
+                            return
+                        }
+                        let keys = topLevel.keys.sorted().joined(separator: ",")
+                        self.logger.debug("API response: \(data.count) bytes, keys=[\(keys)]")
+                    } else {
+                        self.logger.debug("API response: \(data.count) bytes (non-JSON or unparseable)")
+                    }
+
+                    async let factionResult: Void = self.fetchFactionData(apiKey: requestedKey, generation: generation)
+                    async let userV2Result: Void = self.fetchUserV2Data(apiKey: requestedKey, generation: generation)
+                    async let factionV2Result: Void = self.fetchFactionV2Data(apiKey: requestedKey, generation: generation)
+                    async let activityResult: Void = self.fetchActivityData(apiKey: requestedKey, generation: generation)
+                    let parsed = await self.parseDataInBackground(
+                        data: data,
+                        apiKey: requestedKey,
+                        generation: generation
+                    )
+                    await factionResult
+                    await userV2Result
+                    await factionV2Result
+                    await activityResult
+
+                    guard self.isCurrentAccount(requestedKey, generation: generation) else { return }
+                    if parsed {
+                        self.logger.info("Data fetch completed successfully")
+                        self.recordHealth("user.fast", outcome: .ok, since: startTime, bytes: data.count)
+                    } else {
+                        self.recordHealth(
+                            "user.fast",
+                            outcome: .error,
+                            since: startTime,
+                            bytes: data.count,
+                            errorClass: "malformedResponse"
+                        )
+                    }
+
+                case 403, 404:
+                    await MainActor.run {
+                        guard self.isCurrentAccount(requestedKey, generation: generation) else { return }
+                        self.errorMsg = "Invalid API Key"
+                        self.data = nil
+                    }
+                    self.logger.error("HTTP \(response.statusCode): Invalid API Key")
+                    self.recordHealth(
+                        "user.fast",
+                        outcome: .error,
+                        since: startTime,
+                        bytes: data.count,
+                        errorClass: "permanentKey"
+                    )
+                default:
+                    await MainActor.run {
+                        guard self.isCurrentAccount(requestedKey, generation: generation) else { return }
+                        self.errorMsg = "HTTP Error: \(response.statusCode)"
+                    }
+                    self.logger.error("HTTP Error: \(response.statusCode)")
+                    self.recordHealth(
+                        "user.fast",
+                        outcome: .error,
+                        since: startTime,
+                        bytes: data.count,
+                        errorClass: "temporaryBackend"
+                    )
+                }
+            } catch {
+                if Task.isCancelled {
+                    self.recordHealth("user.fast", outcome: .cancelled, since: startTime, bytes: 0)
+                    return
+                }
+                let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
+                await MainActor.run {
+                    guard self.isCurrentAccount(requestedKey, generation: generation) else { return }
+                    self.errorMsg = mapped?.userMessage ?? "Network request failed. Please try again."
+                }
+                self.logger.error("Network error: \(String(describing: type(of: error)))")
+                self.recordHealth(
+                    "user.fast",
+                    outcome: mapped?.classification == .offline ? .offline : .error,
+                    since: startTime,
+                    bytes: 0,
+                    errorClass: mapped?.classification.rawValue ?? "transport"
+                )
+            }
+        }
+    }
+
+    private func parseDataInBackground(data: Data, apiKey: String, generation: UInt) async -> Bool {
+        let requestedSelections =
+            TornEndpointRegistry.endpoint(id: "user.fast")?.selections ?? []
+        let grantedSelections = keyInfo?.selections.user
+        let result = await userSnapshotService.parseSnapshot(
+            data: data,
+            requestedSelections: requestedSelections,
+            grantedSelections: grantedSelections
+        )
+
+        guard isCurrentAccount(apiKey, generation: generation) else { return false }
+        let payload: UserSnapshotPayload
+        switch result {
+        case .success(let value, _):
+            payload = value
+        case .apiError(let apiError, _):
+            errorMsg = apiError.userMessage
+            return false
+        case .malformed:
+            errorMsg = "Failed to decode user data"
+            logger.error("Data error: Failed to decode user data")
+            return false
+        }
+
+        let decoded = payload.snapshot
+        logger.info("Parsed authenticated user data successfully")
+
+        checkNotifications(newData: decoded)
+        self.data = decoded
+
+        if let cooldowns = decoded.cooldowns {
+            let anchor = decoded.anchorTimestamp ?? Int(Date().timeIntervalSince1970)
+            let fresh = CooldownEnds.from(cooldowns: cooldowns, anchor: anchor)
+            cooldownEnds = cooldownEnds?.merged(with: fresh) ?? fresh
+        } else {
+            cooldownEnds = nil
+        }
+
+        previousBars = decoded.bars
+        previousCooldowns = decoded.cooldowns
+        previousTravel = decoded.travel
+        previousChain = decoded.chain
+        previousStatus = decoded.status
+
+        moneyData = payload.money
+        battleStats = payload.battleStats
+        if let attacks = payload.recentAttacks { recentAttacks = attacks }
+        if let properties = payload.properties { propertiesData = properties }
+        stocksData = payload.stocks
+
+        lastUpdated = Date()
+        lastFetchTime = Date()
+        errorMsg = nil
+
+        manageLiveTimer()
+        checkFeedbackPrompt()
+
+        logger.info("Data updated, lastUpdated: \(self.lastUpdated?.description ?? "nil")")
+        return true
+    }
+
+    // MARK: - Fetch Row-Based Activity Data
+
+    private func fetchActivityData(apiKey: String, generation: UInt) async {
+        guard !apiKey.isEmpty, let url = TornAPI.activityURL(for: apiKey) else { return }
+        guard !isRowSourcePaused("user.activity") else { return }
+
+        if let last = lastActivityFetch,
+           Date().timeIntervalSince(last) < Self.activityMinInterval {
+            return
+        }
+        guard reserveRequest("user.activity") else { return }
+        lastActivityFetch = Date()
+        let startTime = Date()
+
+        do {
+            let result = try await userSnapshotService.loadActivity(url)
+            guard isCurrentAccount(apiKey, generation: generation) else { return }
+
+            switch result {
+            case .success(let payload, let responseBytes):
+                if let events = payload.events { activityEvents = events }
+                if let unread = payload.unreadMessages { unreadMessages = unread }
+                if let attacks = payload.recentAttacks { recentAttacks = attacks }
+                recordHealth("user.activity", outcome: .ok, since: startTime, bytes: responseBytes)
+
+            case .apiError(let apiError, let responseBytes):
+                if apiError.haltsCategoryOnly {
+                    pauseRowSource("user.activity", error: apiError)
+                }
+                recordHealth(
+                    "user.activity",
+                    outcome: .error,
+                    since: startTime,
+                    bytes: responseBytes,
+                    errorClass: apiError.classification.rawValue
+                )
+                logger.warning("Activity API error class: \(apiError.classification.rawValue)")
+
+            case .malformed(let responseBytes):
+                recordHealth(
+                    "user.activity",
+                    outcome: .error,
+                    since: startTime,
+                    bytes: responseBytes,
+                    errorClass: "malformedResponse"
+                )
+            }
+        } catch {
+            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
+            recordHealth(
+                "user.activity",
+                outcome: mapped?.classification == .offline ? .offline : .error,
+                since: startTime,
+                bytes: 0,
+                errorClass: mapped?.classification.rawValue ?? "transport"
+            )
+            logger.warning("Activity fetch error (optional): \(String(describing: type(of: error)))")
+        }
+    }
+
+    // MARK: - Fetch API v2 User Data
+
+    private func fetchUserV2Data(apiKey: String, generation: UInt) async {
+        guard !apiKey.isEmpty, let url = TornAPI.userV2URL(for: apiKey),
+              reserveRequest("user.v2") else { return }
+        let startTime = Date()
+
+        do {
+            let result = try await userSnapshotService.loadUserV2(url)
+            guard isCurrentAccount(apiKey, generation: generation) else { return }
+
+            switch result {
+            case .success(let payload, let responseBytes):
+                organizedCrime = payload.organizedCrime
+                if let refills = payload.refills { self.refills = refills }
+                if let education = payload.education { self.education = education }
+                bountiesOnMe = payload.bounties
+
+                if shouldNotifyOCReady(payload.organizedCrime),
+                   let organizedCrime = payload.organizedCrime {
+                    NotificationManager.shared.send(
+                        title: "OC Ready! 💼",
+                        body: "\(organizedCrime.name) is ready to execute",
+                        type: .ocReady
+                    )
+                }
+
+                notifyBountiesOnMe()
+                logger.info("User v2 data fetched")
+                recordHealth("user.v2", outcome: .ok, since: startTime, bytes: responseBytes)
+
+            case .apiError(let apiError, let responseBytes):
+                recordHealth(
+                    "user.v2",
+                    outcome: .error,
+                    since: startTime,
+                    bytes: responseBytes,
+                    errorClass: apiError.classification.rawValue
+                )
+                logger.warning("User v2 API error class: \(apiError.classification.rawValue)")
+
+            case .malformed(let responseBytes):
+                recordHealth(
+                    "user.v2",
+                    outcome: .error,
+                    since: startTime,
+                    bytes: responseBytes,
+                    errorClass: "malformedResponse"
+                )
+            }
+        } catch {
+            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
+            recordHealth(
+                "user.v2",
+                outcome: mapped?.classification == .offline ? .offline : .error,
+                since: startTime,
+                bytes: 0,
+                errorClass: mapped?.classification.rawValue ?? "transport"
+            )
+            logger.warning("User v2 fetch error (optional): \(String(describing: type(of: error)))")
+        }
+    }
+
+    func shouldNotifyOCReady(_ oc: OrganizedCrime2?) -> Bool {
+        guard let oc, oc.isReady else { return false }
+        return notificationCoordinator.shouldFireOnce("oc.ready", epoch: "\(oc.id)")
+    }
+
+    private func notifyBountiesOnMe() {
+        let currentKeys = Set(bountiesOnMe.map(\.id))
+        for bounty in bountiesOnMe where !notifiedBountyKeys.contains(bounty.id) {
+            let amount = Self.decimalFormatter.string(from: NSNumber(value: bounty.reward)) ?? "\(bounty.reward)"
+            let who: String
+            if bounty.isAnonymous == true {
+                who = " (anonymous)"
+            } else if let name = bounty.listerName {
+                who = " from \(name)"
+            } else {
+                who = ""
+            }
+            NotificationManager.shared.send(
+                title: "⚠️ Bounty on you",
+                body: "$\(amount)\(who)",
+                type: .bountyOnMe
+            )
+        }
+        notifiedBountyKeys = currentKeys
+    }
+}

--- a/MacTorn/MacTorn/ViewModels/AppState.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState.swift
@@ -1,110 +1,44 @@
 import Foundation
 import Combine
-import Security
 import SwiftUI
 import Observation
 import os.log
 
-private let logger = Logger(subsystem: TornConstants.logSubsystem, category: "AppState")
+/// Runs an async operation over a snapshot of inputs without ever having more than
+/// `limit` child tasks in flight. Cancellation prevents queued inputs from starting and
+/// is also propagated to the currently-running children.
+enum BoundedTaskQueue {
+    static func run<Element: Sendable>(
+        _ elements: [Element],
+        limit: Int,
+        operation: @escaping @Sendable (Element) async -> Void
+    ) async {
+        precondition(limit > 0)
+        guard !elements.isEmpty, !Task.isCancelled else { return }
 
-// MARK: - KeychainStore (F-01: replaces @AppStorage for the Torn API key)
+        await withTaskGroup(of: Void.self) { group in
+            var iterator = elements.makeIterator()
 
-/// Minimal generic-password Keychain wrapper for the single Torn API key.
-/// Lives here as a file-private enum to avoid touching the .pbxproj — the surface
-/// is so small (one item) that a separate file would be over-architected.
-///
-/// Storage attributes:
-/// - `kSecClassGenericPassword` (one item, scoped to this app)
-/// - `kSecAttrAccessibleAfterFirstUnlock` (available across reboots once the user
-///    has logged in once; matches a menu-bar app's expected runtime)
-///
-/// Test isolation: when running under XCTest we use a `.tests` service name so
-/// the test suite cannot read or overwrite a real production API key.
-enum KeychainStore {
-    static let account = "apiKey"
-
-    static var service: String {
-        // Under XCTest, xcodebuild may spawn multiple parallel xctest worker processes.
-        // They share the user's login keychain, so a fixed test-service name causes
-        // races: one worker's `set` overwrites another's mid-test. PID-suffix isolates
-        // them. Orphan entries are bounded (tearDown deletes them).
-        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
-            return "com.mactorn.app.tests.\(ProcessInfo.processInfo.processIdentifier)"
-        }
-        return "com.mactorn.app"
-    }
-
-    static func get() -> String? {
-        #if DEBUG
-        // Under the UI-test harness, the app runs as a separate process without the
-        // XCTest env var, so the real login Keychain would be hit. Route through an
-        // in-memory store instead so a UI test never reads a developer's real key.
-        if UITestConfiguration.isActive { return UITestConfiguration.keychainOverride[account] }
-        #endif
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-        var item: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
-        guard status == errSecSuccess,
-              let data = item as? Data,
-              let str = String(data: data, encoding: .utf8) else {
-            return nil
-        }
-        return str
-    }
-
-    static func set(_ value: String) {
-        guard !value.isEmpty else {
-            delete()
-            return
-        }
-        #if DEBUG
-        if UITestConfiguration.isActive {
-            UITestConfiguration.keychainOverride[account] = value
-            return
-        }
-        #endif
-        guard let data = value.data(using: .utf8) else { return }
-        let baseQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-        ]
-        let updateAttrs: [String: Any] = [
-            kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
-        ]
-        let updateStatus = SecItemUpdate(baseQuery as CFDictionary, updateAttrs as CFDictionary)
-        if updateStatus == errSecItemNotFound {
-            var addQuery = baseQuery
-            addQuery.merge(updateAttrs) { _, new in new }
-            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-            if addStatus != errSecSuccess {
-                logger.error("KeychainStore add failed: OSStatus \(addStatus)")
+            for _ in 0..<min(limit, elements.count) {
+                guard !Task.isCancelled, let element = iterator.next() else { break }
+                group.addTask {
+                    guard !Task.isCancelled else { return }
+                    await operation(element)
+                }
             }
-        } else if updateStatus != errSecSuccess {
-            logger.error("KeychainStore update failed: OSStatus \(updateStatus)")
-        }
-    }
 
-    static func delete() {
-        #if DEBUG
-        if UITestConfiguration.isActive {
-            UITestConfiguration.keychainOverride[account] = nil
-            return
+            while await group.next() != nil {
+                guard !Task.isCancelled else {
+                    group.cancelAll()
+                    break
+                }
+                guard let element = iterator.next() else { continue }
+                group.addTask {
+                    guard !Task.isCancelled else { return }
+                    await operation(element)
+                }
+            }
         }
-        #endif
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-        ]
-        SecItemDelete(query as CFDictionary)
     }
 }
 
@@ -126,20 +60,19 @@ enum AppearanceMode: String, CaseIterable {
 @MainActor
 @Observable
 class AppState {
+    private static let appLogger = Logger(subsystem: TornConstants.logSubsystem, category: "AppState")
+    var logger: Logger { Self.appLogger }
+
     // MARK: - Persisted
-    /// Torn API key. Stored in the macOS Keychain (see `KeychainStore` above).
-    /// Was previously `@AppStorage("apiKey")` which writes plaintext to
-    /// `~/Library/Preferences/com.mactorn.app.plist` — an unprivileged read.
-    var apiKey: String = "" {
-        didSet {
-            // Skip the redundant write that the migration assignment in init would
-            // otherwise trigger, and avoid Keychain churn on no-op assignments from
-            // SwiftUI's binding lifecycle.
-            guard apiKey != oldValue else { return }
-            KeychainStore.set(apiKey)
-            // A new key clears any permanent-key halt so polling can resume (Etap B).
-            keyHalted = false
-            // A new key invalidates any prior validation result (Etap C).
+    var apiKey: String {
+        get { accountSession.apiKey }
+        set {
+            guard accountSession.updateAPIKey(newValue) else { return }
+            resetAccountScopedState()
+            if newValue.isEmpty {
+                stopPolling()
+                stopForumPolling()
+            }
             keyValidation = .idle
             keyInfo = nil
         }
@@ -148,7 +81,10 @@ class AppState {
     /// True after a permanent key/permission error (Torn codes 2/16/18) halted polling.
     /// Blocks auto-restart (e.g. on MenuBarExtra open) until the user changes the key.
     /// `internal` for `@testable`.
-    var keyHalted: Bool = false
+    var keyHalted: Bool {
+        get { accountSession.isHalted }
+        set { accountSession.isHalted = newValue }
+    }
 
     // MARK: - Key validation (Etap C, ISC-16)
     /// Onboarding "Test Connection" state. Drives the SettingsView result panel.
@@ -163,6 +99,10 @@ class AppState {
     var refreshInterval: Int = 30 {
         didSet {
             guard refreshInterval != oldValue else { return }
+            guard Self.allowedRefreshIntervals.contains(refreshInterval) else {
+                refreshInterval = 30
+                return
+            }
             defaults.set(refreshInterval, forKey: "refreshInterval")
         }
     }
@@ -190,21 +130,36 @@ class AppState {
     // requests events/messages — never clobbers them.
     var activityEvents: [TornEvent] = []
     var unreadMessages: Int = 0
-    var factionData: FactionData?
+    var factionData: FactionData? {
+        factionService.basic
+    }
     var propertiesData: [PropertyInfo]?
     var stocksData: [StockHolding] = []
     var stocksMetadata: [Int: StockMetadata] = [:]
-    var watchlistItems: [WatchlistItem] = []
+    var watchlistItems: [WatchlistItem] {
+        get { marketWatchService.items }
+        set { marketWatchService.items = newValue }
+    }
     // MARK: - API v2 user state (organized crime, refills, education, bounties)
     var organizedCrime: OrganizedCrime2?
     var refills: Refills?
     var education: EducationStatus?
     var bountiesOnMe: [Bounty] = []
     // MARK: - Faction v2 state (ranked wars, news)
-    var rankedWars: [RankedWar] = []
-    var factionNews: [FactionNews] = []
-    var watchedThreads: [WatchedThread] = []
-    var forumWatchConfig: ForumWatchConfig = ForumWatchConfig()
+    var rankedWars: [RankedWar] {
+        factionService.wars
+    }
+    var factionNews: [FactionNews] {
+        factionService.news
+    }
+    var watchedThreads: [WatchedThread] {
+        get { forumWatchService.threads }
+        set { forumWatchService.threads = newValue }
+    }
+    var forumWatchConfig: ForumWatchConfig {
+        get { forumWatchService.config }
+        set { forumWatchService.config = newValue }
+    }
 
     // MARK: - Update State
     var updateAvailable: GitHubRelease?
@@ -234,7 +189,7 @@ class AppState {
     // MARK: - Live Travel Countdown
     var travelSecondsRemaining: Int = 0
     var menuBarDisplay: MenuBarDisplay = .fallbackIcon
-    @ObservationIgnored private var liveTimerCancellable: AnyCancellable?
+    @ObservationIgnored var liveTimerCancellable: AnyCancellable?
 
     // MARK: - Managers
     @ObservationIgnored let launchAtLogin = LaunchAtLoginManager()
@@ -242,43 +197,39 @@ class AppState {
     @ObservationIgnored let updateManager = UpdateManager.shared
 
     // MARK: - Networking (Dependency Injection for Testing)
-    @ObservationIgnored private let session: NetworkSession
-    @ObservationIgnored private let connectivity: NetworkConnectivity
+    @ObservationIgnored let session: NetworkSession
+    @ObservationIgnored let connectivity: NetworkConnectivity
+    @ObservationIgnored let accountSession: AccountSessionStore
+    @ObservationIgnored let userSnapshotService: UserSnapshotServicing
+    @ObservationIgnored let factionService: FactionServicing
+    @ObservationIgnored let marketWatchService: MarketWatchServicing
+    @ObservationIgnored let forumWatchService: ForumWatchServicing
 
     // MARK: - State Comparison
-    @ObservationIgnored private var previousBars: Bars?
-    @ObservationIgnored private var previousCooldowns: Cooldowns?
-    @ObservationIgnored private var previousTravel: Travel?
-    @ObservationIgnored private var previousChain: Chain?
-    @ObservationIgnored private var previousStatus: Status?
-    @ObservationIgnored private var notifiedBountyKeys: Set<String> = []
+    @ObservationIgnored var previousBars: Bars?
+    @ObservationIgnored var previousCooldowns: Cooldowns?
+    @ObservationIgnored var previousTravel: Travel?
+    @ObservationIgnored var previousChain: Chain?
+    @ObservationIgnored var previousStatus: Status?
+    @ObservationIgnored var notifiedBountyKeys: Set<String> = []
     /// Throttle for the heavy, slow-changing faction v2 overlays (ranked wars + news).
     /// `news` is a row-based cloud category, so this doubles as its rate control:
     /// 5 min → ≤288 calls/day × 25-row limit ≈ 7,200 rows/day, well under the 50k cap.
-    @ObservationIgnored private var lastFactionV2Fetch: Date?
-    private static let factionV2MinInterval: TimeInterval = 300
+    @ObservationIgnored var lastFactionV2Fetch: Date?
 
     /// Throttle for the row-based user activity call (events + messages + attacks).
     /// Same 50k-rows/day-per-category budget as faction news — keep the cadence slow.
-    @ObservationIgnored private var lastActivityFetch: Date?
-    private static let activityMinInterval: TimeInterval = 300
-
-    // MARK: - Task Handles (for deduplication)
-    @ObservationIgnored private var fetchTask: Task<Void, Never>?
-    @ObservationIgnored private var watchlistTask: Task<Void, Never>?
-    @ObservationIgnored private var forumFetchTask: Task<Void, Never>?
+    @ObservationIgnored var lastActivityFetch: Date?
 
     // MARK: - Timer
-    @ObservationIgnored private var timerCancellable: AnyCancellable?
-    @ObservationIgnored private var forumTimerCancellable: AnyCancellable?
-    @ObservationIgnored private var lastForumFetchAt: Date?
-
-    private static let stocksMetadataCacheKey = "stocksMetadataCache"
+    @ObservationIgnored var timerCancellable: AnyCancellable?
+    @ObservationIgnored var forumTimerCancellable: AnyCancellable?
+    @ObservationIgnored var lastForumFetchAt: Date?
+    @ObservationIgnored var pendingPriceAlerts: [(name: String, price: Int)] = []
 
     // Stocks metadata backoff: ladder of seconds applied between retries after failures.
     // Last value is the cap and is used for any further failure beyond the ladder length.
     // Reset to 0 (= no backoff active) on success or when metadata is freshly cached.
-    private static let stocksBackoffLadder: [TimeInterval] = [60, 300, 1800]
     // `internal` (default) so @testable can read these in performance tests.
     var stocksFailureCount = 0
     var stocksNextRetryAfter: Date?
@@ -287,7 +238,7 @@ class AppState {
     /// `UserDefaults` suite instead of the process-wide `.standard`, which under
     /// parallel testing races across test classes on shared keys (e.g. "watchlist").
     /// Production always passes `.standard`. See audit finding G-01.
-    @ObservationIgnored private let defaults: UserDefaults
+    @ObservationIgnored let defaults: UserDefaults
 
     /// Persistent notification de-duplication (Etap E). Built from the same injected
     /// `defaults`, so tests get isolated dedup state alongside isolated persistence.
@@ -301,7 +252,7 @@ class AppState {
     @ObservationIgnored let endpointHealth: EndpointHealthTracker
 
     /// Shared clock (injected). Used for the daily-row-limit pause windows below.
-    @ObservationIgnored private let time: TimeSource
+    @ObservationIgnored let time: TimeSource
 
     /// Row-based sources paused after a Torn "daily read limit" hit (error code 14),
     /// keyed by endpoint id → re-arm instant (ISC-15.1). Keyed by endpoint (NOT budget
@@ -309,41 +260,43 @@ class AppState {
     /// the row-based `news` can trip code 14 — pausing it must never stop the point-in-time
     /// `faction.basic` chain data that drives the chain alert. Point-in-time endpoints never
     /// land here, so the live bars/countdowns keep running while a row source is paused.
-    @ObservationIgnored private var rowSourcePausedUntil: [String: Date] = [:]
+    @ObservationIgnored var rowSourcePausedUntil: [String: Date] = [:]
 
     /// How long a row source stays paused after a code-14 hit before it is retried. The cap
     /// is a rolling 24 h window, so a conservative 1 h pause backs off without giving up.
-    private static let dailyRowLimitPause: TimeInterval = 3600
-
     /// Chain timeout (seconds remaining) below which the "Chain Expiring!" alert arms.
     static let chainWarningThreshold = 60
 
     init(session: NetworkSession = URLSession.shared,
          connectivity: NetworkConnectivity? = nil,
          defaults: UserDefaults = .standard,
-         time: TimeSource = SystemTimeSource()) {
+         time: TimeSource = SystemTimeSource(),
+         pollingCoordinator: PollingCoordinator? = nil,
+         accountSession: AccountSessionStore? = nil,
+         userSnapshotService: UserSnapshotServicing? = nil,
+         factionService: FactionServicing? = nil,
+         marketWatchService: MarketWatchServicing? = nil,
+         forumWatchService: ForumWatchServicing? = nil) {
         self.session = session
         self.connectivity = connectivity ?? NetworkMonitor.shared
         self.defaults = defaults
         self.time = time
+        self.accountSession = accountSession ?? AccountSessionStore(defaults: defaults)
+        self.userSnapshotService = userSnapshotService ?? UserSnapshotService(session: session)
+        self.factionService = factionService ?? FactionService(session: session)
+        self.marketWatchService =
+            marketWatchService ?? MarketWatchService(defaults: defaults, session: session)
+        self.forumWatchService =
+            forumWatchService ?? ForumWatchService(defaults: defaults, session: session)
         self.notificationCoordinator = NotificationCoordinator(defaults: defaults)
-        self.pollingCoordinator = PollingCoordinator(time: time)
+        self.pollingCoordinator = pollingCoordinator ?? PollingCoordinator(time: time)
         self.endpointHealth = EndpointHealthTracker(time: time)
-
-        // F-01 migration: lift any pre-existing plaintext key out of UserDefaults
-        // into the Keychain on first launch of the new build, then clear the
-        // UserDefaults entry. Safe to run every launch (idempotent).
-        if let legacy = defaults.string(forKey: "apiKey"), !legacy.isEmpty {
-            KeychainStore.set(legacy)
-            defaults.removeObject(forKey: "apiKey")
-            logger.info("Migrated API key from UserDefaults to Keychain")
-        }
-        self.apiKey = KeychainStore.get() ?? ""
 
         // Was provided by @AppStorage; now manual seed from UserDefaults so the
         // values survive across launches. Note: didSet does NOT fire on init,
         // so this assignment doesn't loop-write back into UserDefaults.
-        if let stored = defaults.object(forKey: "refreshInterval") as? Int {
+        if let stored = defaults.object(forKey: "refreshInterval") as? Int,
+           Self.allowedRefreshIntervals.contains(stored) {
             self.refreshInterval = stored
         }
         if let stored = defaults.string(forKey: "appearanceMode") {
@@ -368,1501 +321,45 @@ class AppState {
         // Polling and permissions moved to onAppear in UI
     }
 
-    // MARK: - Stocks Metadata (global lookup from torn/?selections=stocks)
-    func loadStocksMetadataFromCache() {
-        guard let data = defaults.data(forKey: Self.stocksMetadataCacheKey),
-              let cached = try? JSONDecoder().decode([Int: StockMetadata].self, from: data) else {
-            return
-        }
-        stocksMetadata = cached
-    }
+    private static let allowedRefreshIntervals: Set<Int> = [15, 30, 60, 120]
 
-    func fetchStocksMetadata() async {
-        guard !apiKey.isEmpty, let url = TornAPI.tornStocksURL(for: apiKey) else { return }
-        recordRequest("torn.stocks")
-        let startTime = Date()
-        do {
-            var request = URLRequest(url: url)
-            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-            let (data, _) = try await session.data(for: request)
-            let parsed = AppState.parseStocksMetadata(from: data, logger: logger)
-            guard !parsed.isEmpty else {
-                await MainActor.run {
-                    self.recordStocksMetadataFailure()
-                    self.recordHealth("torn.stocks", outcome: .error, since: startTime, bytes: data.count, errorClass: "malformedResponse")
-                }
-                return
-            }
-            await MainActor.run {
-                self.stocksMetadata = parsed
-                if let encoded = try? JSONEncoder().encode(parsed) {
-                    defaults.set(encoded, forKey: Self.stocksMetadataCacheKey)
-                }
-                self.stocksFailureCount = 0
-                self.stocksNextRetryAfter = nil
-                self.recordHealth("torn.stocks", outcome: .ok, since: startTime, bytes: data.count)
-                logger.info("Stocks metadata loaded: \(parsed.count) stocks")
-            }
-        } catch {
-            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
-            await MainActor.run {
-                self.recordStocksMetadataFailure()
-                self.recordHealth("torn.stocks",
-                                  outcome: mapped?.classification == .offline ? .offline : .error,
-                                  since: startTime, bytes: 0,
-                                  errorClass: mapped?.classification.rawValue ?? "transport")
-            }
-            logger.error("Failed to fetch stocks metadata: \(error.localizedDescription)")
-        }
-    }
-
-    /// Bumps failure count and computes the next allowable retry instant from the backoff ladder.
-    /// `internal` so unit tests can drive it without going through a fake URL session.
-    @MainActor
-    func recordStocksMetadataFailure() {
-        stocksFailureCount += 1
-        let idx = min(stocksFailureCount - 1, Self.stocksBackoffLadder.count - 1)
-        let delay = Self.stocksBackoffLadder[idx]
-        stocksNextRetryAfter = Date().addingTimeInterval(delay)
-    }
-
-    /// Parses the `torn/?selections=stocks` response using JSONSerialization (resilient to extra fields).
-    /// Exposed as a static func so tests can drive it without a network round-trip.
-    nonisolated static func parseStocksMetadata(from data: Data, logger: Logger) -> [Int: StockMetadata] {
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            logger.error("Stocks metadata: failed to parse JSON")
-            return [:]
-        }
-        if let msg = tornAPIErrorMessage(in: json) {
-            logger.error("Stocks metadata API error: \(msg)")
-            return [:]
-        }
-        guard let stocksDict = json["stocks"] as? [String: [String: Any]] else {
-            logger.warning("Stocks metadata: no 'stocks' key in response")
-            return [:]
-        }
-        var result: [Int: StockMetadata] = [:]
-        for (key, stockData) in stocksDict {
-            guard let id = Int(key) else { continue }
-            let name = stockData["name"] as? String ?? ""
-            let acronym = stockData["acronym"] as? String ?? ""
-            let price: Double
-            if let n = stockData["current_price"] as? NSNumber {
-                price = n.doubleValue
-            } else if let s = stockData["current_price"] as? String, let d = Double(s) {
-                price = d
-            } else {
-                price = 0
-            }
-            result[id] = StockMetadata(id: id, name: name, acronym: acronym, currentPrice: price)
-        }
-        return result
-    }
-    
-    // MARK: - Notification Rules
-    func loadNotificationRules() {
-        if let data = defaults.data(forKey: "notificationRules"),
-           let rules = try? JSONDecoder().decode([NotificationRule].self, from: data) {
-            notificationRules = rules
-        } else {
-            notificationRules = NotificationRule.defaults
-            saveNotificationRules()
-        }
-    }
-    
-    func saveNotificationRules() {
-        if let data = try? JSONEncoder().encode(notificationRules) {
-            defaults.set(data, forKey: "notificationRules")
-        }
-    }
-    
-    func updateRule(_ rule: NotificationRule) {
-        if let index = notificationRules.firstIndex(where: { $0.id == rule.id }) {
-            notificationRules[index] = rule
-            saveNotificationRules()
-        }
-    }
-
-    // MARK: - Travel Notification Settings
-    func loadTravelNotificationSettings() {
-        if let data = defaults.data(forKey: "travelNotificationSettings"),
-           let settings = try? JSONDecoder().decode([TravelNotificationSetting].self, from: data) {
-            travelNotificationSettings = settings
-        } else {
-            travelNotificationSettings = TravelNotificationSetting.defaults
-            saveTravelNotificationSettings()
-        }
-    }
-
-    func saveTravelNotificationSettings() {
-        if let data = try? JSONEncoder().encode(travelNotificationSettings) {
-            defaults.set(data, forKey: "travelNotificationSettings")
-        }
-    }
-
-    func updateTravelNotificationSetting(_ setting: TravelNotificationSetting) {
-        if let index = travelNotificationSettings.firstIndex(where: { $0.id == setting.id }) {
-            travelNotificationSettings[index] = setting
-            saveTravelNotificationSettings()
-            // Reschedule notifications if currently traveling
-            if let travel = data?.travel, travel.isTraveling {
-                scheduleTravelNotifications(for: travel)
-            }
-        }
-    }
-
-    func scheduleTravelNotifications(for travel: Travel) {
-        // Cancel any existing travel notifications first
-        NotificationManager.shared.cancelTravelNotifications()
-
-        guard let arrivalDate = travel.arrivalDate else { return }
-
-        for setting in travelNotificationSettings where setting.enabled {
-            let notificationDate = arrivalDate.addingTimeInterval(-Double(setting.secondsBefore))
-
-            // Only schedule if the notification time is in the future
-            if notificationDate > Date() {
-                let identifier = "\(setting.id)_alert"
-                let timeText: String
-                if setting.secondsBefore >= 60 {
-                    timeText = "\(setting.secondsBefore / 60) minute\(setting.secondsBefore >= 120 ? "s" : "")"
-                } else {
-                    timeText = "\(setting.secondsBefore) seconds"
-                }
-
-                NotificationManager.shared.scheduleNotification(
-                    title: "Landing Soon!",
-                    body: "You will arrive in \(travel.destination ?? "your destination") in \(timeText)",
-                    type: .travelApproaching,
-                    at: notificationDate,
-                    identifier: identifier
-                )
-            }
-        }
-    }
-
-    // MARK: - Live Timer (drives travel countdown + menu bar display)
-    func manageLiveTimer() {
-        tick()
-        if shouldRunLiveTimer {
-            if liveTimerCancellable == nil {
-                startLiveTimer()
-            }
-        } else {
-            stopLiveTimer()
-        }
-    }
-
-    private var shouldRunLiveTimer: Bool {
-        guard let data = data else { return false }
-        if let travel = data.travel, travel.isTraveling { return true }
-        if let status = data.status, status.isInHospital || status.isInJail { return true }
-        if let ends = cooldownEnds, ends.soonestActive() != nil { return true }
-        return false
-    }
-
-    private func startLiveTimer() {
-        liveTimerCancellable?.cancel()
-
-        liveTimerCancellable = Timer.publish(every: 1.0, on: .main, in: .common)
-            .autoconnect()
-            .sink { [weak self] _ in
-                self?.tick()
-            }
-    }
-
-    private func stopLiveTimer() {
+    /// Removes data that belongs to the previously authenticated Torn account. Local
+    /// preferences (watchlist, watched threads, appearance) intentionally remain.
+    func resetAccountScopedState() {
+        data = nil
+        lastUpdated = nil
+        errorMsg = nil
+        isLoading = false
+        moneyData = nil
+        battleStats = nil
+        recentAttacks = nil
+        activityEvents = []
+        unreadMessages = 0
+        factionService.reset()
+        propertiesData = nil
+        stocksData = []
+        organizedCrime = nil
+        refills = nil
+        education = nil
+        bountiesOnMe = []
+        cooldownEnds = nil
+        travelSecondsRemaining = 0
+        menuBarDisplay = .fallbackIcon
+        previousBars = nil
+        previousCooldowns = nil
+        previousTravel = nil
+        previousChain = nil
+        previousStatus = nil
+        notifiedBountyKeys = []
+        lastFactionV2Fetch = nil
+        lastActivityFetch = nil
+        rowSourcePausedUntil = [:]
         liveTimerCancellable?.cancel()
         liveTimerCancellable = nil
-        travelSecondsRemaining = 0
-        menuBarDisplay = computeMenuBarDisplay()
     }
 
-    private func tick() {
-        updateTravelSecondsRemaining()
-        // Skip @Published write if computed value is unchanged: avoids SwiftUI
-        // invalidating MenuBarLabel + every observer once per second when the
-        // displayed string hasn't actually changed (cooldowns shown as `Hh Mm`
-        // tick the underlying seconds but render the same label for ~60s).
-        let next = computeMenuBarDisplay()
-        if next != menuBarDisplay {
-            menuBarDisplay = next
-        }
-    }
-
-    private func updateTravelSecondsRemaining() {
-        let next: Int
-        if let travel = data?.travel, travel.isTraveling {
-            next = travel.remainingSeconds(from: lastFetchTime)
-        } else {
-            next = 0
-        }
-        if next != travelSecondsRemaining {
-            travelSecondsRemaining = next
-        }
-    }
-
-    private func computeMenuBarDisplay() -> MenuBarDisplay {
-        guard let data = data else { return .fallbackIcon }
-
-        if let travel = data.travel, travel.isTraveling {
-            let flag = TornDestination.flag(for: travel.destination ?? "?")
-            return .traveling(flag: flag, seconds: travel.remainingSeconds(from: lastFetchTime))
-        }
-
-        if let status = data.status, status.isInHospital {
-            let secs = status.timeRemaining
-            if let travel = data.travel, travel.isAbroad {
-                let flag = TornDestination.flag(for: travel.destination ?? "?")
-                return .hospitalAbroad(flag: flag, seconds: secs)
-            }
-            return .hospitalAtHome(seconds: secs)
-        }
-
-        if let status = data.status, status.isInJail {
-            return .jail(seconds: status.timeRemaining)
-        }
-
-        if let ends = cooldownEnds,
-           let soonest = ends.soonestActive() {
-            return .cooldown(emoji: soonest.kind.emoji, seconds: soonest.seconds)
-        }
-
-        return .fallbackIcon
-    }
-
-    // MARK: - Watchlist
-    func loadWatchlist() {
-        if let data = defaults.data(forKey: "watchlist"),
-           let items = try? JSONDecoder().decode([WatchlistItem].self, from: data) {
-            watchlistItems = items
-        }
-    }
-    
-    func saveWatchlist() {
-        if let data = try? JSONEncoder().encode(watchlistItems) {
-            defaults.set(data, forKey: "watchlist")
-        }
-    }
-    
-    func addToWatchlist(itemId: Int, name: String) {
-        // Clamp inputs at the trust boundary. itemId flows directly into a request URL path
-        // and `name` flows into UNNotificationContent.body, so reject obviously bogus values
-        // rather than persisting them. Torn item IDs are positive and currently <100k.
-        guard itemId > 0, itemId < 100_000 else {
-            logger.warning("addToWatchlist rejected itemId out of range: \(itemId)")
-            return
-        }
-        let trimmed = String(name.trimmingCharacters(in: .whitespacesAndNewlines).prefix(64))
-        let item = WatchlistItem(id: itemId, name: trimmed, lowestPrice: 0, lowestPriceQuantity: 0, secondLowestPrice: 0, lastUpdated: nil, error: nil)
-        if !watchlistItems.contains(where: { $0.id == itemId }) {
-            watchlistItems.append(item)
-            saveWatchlist()
-            // Fetch price immediately
-            Task {
-                await fetchItemPrice(itemId: itemId)
-            }
-        }
-    }
-    
-    func removeFromWatchlist(_ itemId: Int) {
-        watchlistItems.removeAll { $0.id == itemId }
-        saveWatchlist()
-    }
-    
-    func refreshWatchlistPrices() {
-        watchlistTask?.cancel()
-        watchlistTask = Task {
-            await fetchWatchlistPrices()
-        }
-    }
-    
-    /// Accumulated alerts during a batch refresh; flushed (single or summary) at the end.
-    private var pendingPriceAlerts: [(name: String, price: Int)] = []
-
-    private func fetchWatchlistPrices() async {
-        guard connectivity.isConnected else { return }
-        pendingPriceAlerts.removeAll(keepingCapacity: true)
-        await withTaskGroup(of: Void.self) { group in
-            for item in watchlistItems {
-                group.addTask { await self.fetchItemPrice(itemId: item.id, save: false) }
-            }
-        }
-        flushPendingPriceAlerts()
-        saveWatchlist()
-    }
-
-    private func flushPendingPriceAlerts() {
-        let alerts = pendingPriceAlerts
-        pendingPriceAlerts.removeAll(keepingCapacity: true)
-        guard !alerts.isEmpty else { return }
-        if alerts.count == 1 {
-            let a = alerts[0]
-            NotificationManager.shared.send(
-                title: "Price Alert: \(a.name)",
-                body: "Lowest price dropped to \(formatAlertPrice(a.price))",
-                type: .priceAlert
-            )
-            return
-        }
-        // Summary notification: list up to 3 names then "+N more".
-        let preview = alerts.prefix(3).map { $0.name }.joined(separator: ", ")
-        let extra = alerts.count > 3 ? " +\(alerts.count - 3) more" : ""
-        NotificationManager.shared.send(
-            title: "\(alerts.count) price alerts",
-            body: "\(preview)\(extra)",
-            type: .priceAlert
-        )
-    }
-    
-    private func fetchItemPrice(itemId: Int, save: Bool = true) async {
-        guard !apiKey.isEmpty,
-              let url = TornAPI.marketURL(itemId: itemId, apiKey: apiKey) else { return }
-        recordRequest("market.item")
-
-        logger.info("Fetching price for item \(itemId)")
-
-        do {
-            var request = URLRequest(url: url)
-            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-            let (data, response) = try await session.data(for: request)
-
-            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
-                logger.error("Item \(itemId) HTTP Error: \(httpResponse.statusCode)")
-                updateItemError(itemId: itemId, error: "HTTP \(httpResponse.statusCode)", save: save)
-                return
-            }
-
-            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-
-                // Check if API returned error
-                if let errorText = tornAPIErrorMessage(in: json) {
-                    logger.warning("Item \(itemId) API error: \(errorText)")
-                    updateItemError(itemId: itemId, error: errorText, save: save)
-                    return
-                }
-
-                var allListings: [(price: Int, amount: Int)] = []
-
-                // Check itemmarket v2 structure
-                if let itemmarket = json["itemmarket"] as? [String: Any],
-                   let listings = itemmarket["listings"] as? [[String: Any]] {
-                     let mapped = listings.compactMap { dict -> (Int, Int)? in
-                        guard let p = dict["price"] as? Int else { return nil }
-                        return (p, dict["amount"] as? Int ?? 1)
-                     }
-                     allListings.append(contentsOf: mapped)
-                }
-                // Fallback for v1
-                else if let itemmarketArr = json["itemmarket"] as? [[String: Any]] {
-                     let mapped = itemmarketArr.compactMap { dict -> (Int, Int)? in
-                        guard let p = dict["cost"] as? Int else { return nil }
-                        return (p, dict["quantity"] as? Int ?? 1)
-                     }
-                     allListings.append(contentsOf: mapped)
-                }
-
-                // Check bazaar
-                if let bazaarArr = json["bazaar"] as? [[String: Any]] {
-                    let mapped = bazaarArr.compactMap { dict -> (Int, Int)? in
-                        guard let p = dict["cost"] as? Int else { return nil }
-                        return (p, dict["quantity"] as? Int ?? 1)
-                    }
-                    allListings.append(contentsOf: mapped)
-                }
-
-                let sortedListings = allListings.sorted { $0.price < $1.price }
-                logger.debug("Item \(itemId): found \(sortedListings.count) listings, lowest: \(sortedListings.first?.price ?? 0)")
-
-                if let best = sortedListings.first {
-                    let secondPrice = sortedListings.count > 1 ? sortedListings[1].price : 0
-                    updateItemPrice(itemId: itemId, lowestPrice: best.price, lowestPriceQuantity: best.amount, secondLowestPrice: secondPrice, save: save)
-                } else {
-                    updateItemError(itemId: itemId, error: "No listings", save: save)
-                }
-            } else {
-                logger.error("Item \(itemId): failed to parse JSON response")
-                updateItemError(itemId: itemId, error: "Parse Error", save: save)
-            }
-        } catch {
-            if Task.isCancelled { return }
-            logger.error("Item \(itemId) price fetch error: \(error.localizedDescription)")
-            updateItemError(itemId: itemId, error: "Network Error", save: save)
-        }
-    }
-    
-    @MainActor
-    private func updateItemPrice(itemId: Int, lowestPrice: Int, lowestPriceQuantity: Int, secondLowestPrice: Int, save: Bool = true) {
-        if let index = watchlistItems.firstIndex(where: { $0.id == itemId }) {
-            var item = watchlistItems[index]
-            item.lowestPrice = lowestPrice
-            item.lowestPriceQuantity = lowestPriceQuantity
-            item.secondLowestPrice = secondLowestPrice
-            item.lastUpdated = Date()
-            item.error = nil
-            watchlistItems[index] = item
-            if watchlistItems[index].shouldFirePriceAlert {
-                if save {
-                    // Single-item path (e.g. addToWatchlist): fire immediately.
-                    NotificationManager.shared.send(
-                        title: "Price Alert: \(item.name)",
-                        body: "Lowest price dropped to \(formatAlertPrice(lowestPrice))",
-                        type: .priceAlert
-                    )
-                } else {
-                    // Batch path (refreshWatchlistPrices): buffer and emit one summary
-                    // notification at end of fetchWatchlistPrices via flushPendingPriceAlerts().
-                    pendingPriceAlerts.append((name: item.name, price: lowestPrice))
-                }
-                watchlistItems[index].lastAlertedPrice = lowestPrice
-            }
-            if save { saveWatchlist() }
-        }
-    }
-
-    private func formatAlertPrice(_ price: Int) -> String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .currency
-        formatter.currencySymbol = "$"
-        formatter.maximumFractionDigits = 0
-        return formatter.string(from: NSNumber(value: price)) ?? "$\(price)"
-    }
-
-    @MainActor
-    private func updateItemError(itemId: Int, error: String, save: Bool = true) {
-        if let index = watchlistItems.firstIndex(where: { $0.id == itemId }) {
-            var item = watchlistItems[index]
-            item.error = error
-            watchlistItems[index] = item
-            if save { saveWatchlist() }
-        }
-    }
-    
-    // MARK: - Forum Watch
-    func loadForumWatch() {
-        if let data = defaults.data(forKey: "forumWatchedThreads"),
-           let threads = try? JSONDecoder().decode([WatchedThread].self, from: data) {
-            watchedThreads = threads
-        }
-        if let data = defaults.data(forKey: "forumWatchConfig"),
-           let config = try? JSONDecoder().decode(ForumWatchConfig.self, from: data) {
-            forumWatchConfig = config
-        }
-    }
-
-    func saveForumWatch() {
-        if let data = try? JSONEncoder().encode(watchedThreads) {
-            defaults.set(data, forKey: "forumWatchedThreads")
-        }
-        if let data = try? JSONEncoder().encode(forumWatchConfig) {
-            defaults.set(data, forKey: "forumWatchConfig")
-        }
-    }
-
-    func parseThreadInput(_ input: String) -> Int? {
-        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
-        // Try bare integer
-        if let id = Int(trimmed) {
-            return id
-        }
-        // Try URL pattern: forums.php...t=12345
-        if let range = trimmed.range(of: #"[?&#]t=(\d+)"#, options: .regularExpression) {
-            let match = trimmed[range]
-            let digits = match.drop(while: { !$0.isNumber })
-            return Int(digits)
-        }
-        return nil
-    }
-
-    func addWatchedThread(input: String) {
-        guard let threadId = parseThreadInput(input) else { return }
-        guard !watchedThreads.contains(where: { $0.id == threadId }) else { return }
-
-        let thread = WatchedThread(id: threadId, title: "Loading...", lastKnownPostCount: 0)
-        watchedThreads.append(thread)
-        saveForumWatch()
-
-        Task {
-            await fetchForumThreadMetadata(threadId: threadId)
-        }
-    }
-
-    func removeWatchedThread(_ threadId: Int) {
-        watchedThreads.removeAll { $0.id == threadId }
-        saveForumWatch()
-    }
-
-    func toggleThreadNotifications(_ threadId: Int) {
-        if let index = watchedThreads.firstIndex(where: { $0.id == threadId }) {
-            watchedThreads[index].notificationsEnabled.toggle()
-            saveForumWatch()
-        }
-    }
-
-    func markThreadAsRead(_ threadId: Int) {
-        if let index = watchedThreads.firstIndex(where: { $0.id == threadId }) {
-            // We don't know the "current" post count from here, so the view should pass it
-            // or we just flag it. The fetchForumUpdates will set the correct count next poll.
-            watchedThreads[index].error = nil
-            saveForumWatch()
-        }
-    }
-
-    func startForumPolling() {
-        // Same MenuBarExtra-onAppear churn as startPolling: skip restart if already
-        // running and we polled recently.
-        if forumTimerCancellable != nil,
-           let last = lastForumFetchAt,
-           Date().timeIntervalSince(last) < Double(forumWatchConfig.pollingIntervalSeconds) / 2 {
-            return
-        }
-        forumTimerCancellable?.cancel()
-        guard !apiKey.isEmpty else { return }
-
-        // Initial fetch
-        refreshForumWatch()
-
-        forumTimerCancellable = Timer.publish(every: Double(forumWatchConfig.pollingIntervalSeconds), on: .main, in: .common)
-            .autoconnect()
-            .sink { [weak self] _ in
-                self?.refreshForumWatch()
-            }
-    }
-
-    func stopForumPolling() {
-        forumTimerCancellable?.cancel()
-        forumTimerCancellable = nil
-    }
-
-    func refreshForumWatch() {
-        forumFetchTask?.cancel()
-        forumFetchTask = Task {
-            await fetchForumUpdates()
-        }
-    }
-
-    private func fetchForumUpdates() async {
-        guard connectivity.isConnected, !apiKey.isEmpty else { return }
-
-        // Fetch all watched threads in parallel
-        await withTaskGroup(of: Void.self) { group in
-            for thread in watchedThreads {
-                group.addTask { await self.checkThreadForUpdates(threadId: thread.id) }
-            }
-        }
-
-        lastForumFetchAt = Date()
-        saveForumWatch()
-    }
-
-    private func checkThreadForUpdates(threadId: Int) async {
-        guard let url = TornAPI.forumThreadURL(threadId: threadId, apiKey: apiKey) else { return }
-        recordRequest("forum.thread")
-
-        do {
-            var request = URLRequest(url: url)
-            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-            let (data, response) = try await session.data(for: request)
-
-            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else { return }
-
-            // v2 API wraps the thread in a top-level object
-            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                // Check for API error
-                if let errorText = tornAPIErrorMessage(in: json) {
-                    await updateThreadError(threadId: threadId, error: errorText)
-                    return
-                }
-
-                // Parse thread data - v2 may return directly or nested
-                let threadData: [String: Any]? = json["thread"] as? [String: Any] ?? json
-                guard let threadInfo = threadData else { return }
-
-                let title = threadInfo["title"] as? String ?? "Unknown"
-                let currentPostCount = threadInfo["posts"] as? Int ?? 0
-
-                await MainActor.run {
-                    if let index = self.watchedThreads.firstIndex(where: { $0.id == threadId }) {
-                        let previousCount = self.watchedThreads[index].lastKnownPostCount
-
-                        // Always-set: title (may have changed) + lastChecked. Only set error
-                        // if it was non-nil (avoid spurious @Published write on no-op).
-                        if self.watchedThreads[index].title != title {
-                            self.watchedThreads[index].title = title
-                        }
-                        self.watchedThreads[index].lastChecked = Date()
-                        if self.watchedThreads[index].error != nil {
-                            self.watchedThreads[index].error = nil
-                        }
-
-                        // Short-circuit: if post count is unchanged, skip the
-                        // notification check + post-count write entirely.
-                        guard currentPostCount != previousCount else { return }
-
-                        if previousCount > 0 && currentPostCount > previousCount {
-                            let newPosts = currentPostCount - previousCount
-                            if self.watchedThreads[index].notificationsEnabled {
-                                let threadURL = URL(string: "https://www.torn.com/forums.php#/p=threads&t=\(threadId)")
-                                NotificationManager.shared.send(
-                                    title: "Forum: \(title)",
-                                    body: "\(newPosts) new post\(newPosts == 1 ? "" : "s")",
-                                    type: .forumNewPosts,
-                                    customURL: threadURL
-                                )
-                            }
-                        }
-                        self.watchedThreads[index].lastKnownPostCount = currentPostCount
-                    }
-                }
-            }
-        } catch {
-            if Task.isCancelled { return }
-            await updateThreadError(threadId: threadId, error: "Network Error")
-        }
-    }
-
-    @MainActor
-    private func updateThreadError(threadId: Int, error: String) {
-        if let index = watchedThreads.firstIndex(where: { $0.id == threadId }) {
-            watchedThreads[index].error = error
-        }
-    }
-
-    private func fetchForumThreadMetadata(threadId: Int) async {
-        guard let url = TornAPI.forumThreadURL(threadId: threadId, apiKey: apiKey) else { return }
-        recordRequest("forum.thread")
-
-        do {
-            var request = URLRequest(url: url)
-            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-            let (data, response) = try await session.data(for: request)
-
-            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-                await updateThreadError(threadId: threadId, error: "HTTP Error")
-                return
-            }
-
-            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                if let errorText = tornAPIErrorMessage(in: json) {
-                    await updateThreadError(threadId: threadId, error: errorText)
-                    return
-                }
-
-                let threadData: [String: Any]? = json["thread"] as? [String: Any] ?? json
-                guard let threadInfo = threadData else { return }
-
-                let title = threadInfo["title"] as? String ?? "Unknown"
-                let postCount = threadInfo["posts"] as? Int ?? 0
-
-                await MainActor.run {
-                    if let index = self.watchedThreads.firstIndex(where: { $0.id == threadId }) {
-                        self.watchedThreads[index].title = title
-                        self.watchedThreads[index].lastKnownPostCount = postCount
-                        self.watchedThreads[index].lastChecked = Date()
-                        self.watchedThreads[index].error = nil
-                    }
-                }
-            }
-        } catch {
-            if Task.isCancelled { return }
-            await updateThreadError(threadId: threadId, error: "Network Error")
-        }
-
-        saveForumWatch()
-    }
-
-    // MARK: - Polling
-    func startPolling(force: Bool = false) {
-        // A permanently-bad key won't work no matter how often we retry — don't restart
-        // the loop (Etap B). Changing the key clears `keyHalted` and lets polling resume.
-        guard !keyHalted else {
-            logger.warning("startPolling skipped: polling halted on a permanent key error")
-            return
-        }
-        // MenuBarExtra fires onAppear on every menu open, so this is called repeatedly.
-        // If the timer is already running and we fetched recently (< refreshInterval/2 ago),
-        // skip the restart + immediate refetch — it just burns API quota.
-        // `force: true` (refreshNow) bypasses the guard for an explicit user-initiated refresh.
-        if !force,
-           timerCancellable != nil,
-           Date().timeIntervalSince(lastFetchTime) < Double(refreshInterval) / 2 {
-            return
-        }
-        timerCancellable?.cancel()
-        fetchData()
-        // Idempotent: only fetch if we don't already have metadata. This survives the
-        // "startPolling fires before apiKey loaded" race because we'll retry next tick.
-        triggerStocksMetadataFetchIfNeeded()
-        timerCancellable = Timer.publish(every: Double(refreshInterval), on: .main, in: .common)
-            .autoconnect()
-            .sink { [weak self] _ in
-                self?.fetchData()
-                self?.triggerStocksMetadataFetchIfNeeded()
-            }
-    }
-
-    private func triggerStocksMetadataFetchIfNeeded() {
-        guard stocksMetadata.isEmpty, !apiKey.isEmpty else { return }
-        // Respect exponential backoff so a persistent endpoint failure doesn't
-        // burn API quota on every 30s poll cycle.
-        if let nextRetry = stocksNextRetryAfter, Date() < nextRetry { return }
-        Task { await self.fetchStocksMetadata() }
-    }
-    
-    func stopPolling() {
-        timerCancellable?.cancel()
-        timerCancellable = nil
-    }
-    
-    func refreshNow() {
-        startPolling(force: true)
-    }
-
-    /// True while a row-based source is paused after a daily-row-limit (code 14) hit.
-    /// Auto-clears (and reports false) once the pause window elapses. `internal` for tests.
-    func isRowSourcePaused(_ endpointID: String) -> Bool {
-        guard let until = rowSourcePausedUntil[endpointID] else { return false }
-        if time.now >= until {
-            rowSourcePausedUntil[endpointID] = nil
-            return false
-        }
-        return true
-    }
-
-    /// Pause a single row-based source after Torn returns a daily-row-limit error (ISC-15.1),
-    /// so only that category backs off while everything point-in-time keeps polling.
-    private func pauseRowSource(_ endpointID: String, error: TornAPIError) {
-        rowSourcePausedUntil[endpointID] = time.now.addingTimeInterval(Self.dailyRowLimitPause)
-        logger.warning("Paused row source \(endpointID) for \(Int(Self.dailyRowLimitPause))s after daily read limit (code \(error.tornCode ?? 14))")
-    }
-
-    /// Record an issued request against the API budget (Etap D). Defensive no-op if the
-    /// id isn't in the registry.
-    private func recordRequest(_ endpointID: String) {
-        if let endpoint = TornEndpointRegistry.endpoint(id: endpointID) {
-            pollingCoordinator.record(endpoint)
-        }
-    }
-
-    /// Handle a permanent key/permission error (Etap B): stop the loop, show the user a
-    /// clear message, and latch `keyHalted` so it won't auto-restart until the key changes.
-    func handlePermanentKeyError(_ error: TornAPIError) {
-        keyHalted = true
-        errorMsg = error.userMessage
-        data = nil
-        stopPolling()
-        logger.error("Polling halted on permanent key/permission error (code \(error.tornCode ?? -1))")
-    }
-
-    /// Validate the current API key against the official `/key/info` endpoint (Etap C).
-    /// On success, publishes the real access level/type, the owner's id, and per-endpoint
-    /// availability so onboarding can show exactly what the key unlocks and disable the
-    /// modules it can't serve. All error paths surface a sanitized, PII-free message.
-    /// - Parameter keyOverride: validate this key instead of the saved `apiKey` (used by
-    ///   onboarding's Test Connection, so it can check a just-typed key without persisting
-    ///   it — persisting would flip the view off the Settings screen before the result shows).
-    func validateKey(_ keyOverride: String? = nil) async {
-        let trimmed = (keyOverride ?? apiKey).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            keyValidation = .failure("Enter your Torn API key first.")
-            return
-        }
-        guard connectivity.isConnected else {
-            keyValidation = .failure(TornAPIError.offline.userMessage)
-            return
-        }
-        guard let url = TornAPI.keyInfoURL(for: trimmed) else {
-            keyValidation = .failure("Could not build the key-info request.")
-            return
-        }
-
-        keyValidation = .validating
-        recordRequest("key.info")
-        let startTime = Date()
-        logger.info("Validating key via key-info: \(tornRedactedURL(url))")
-
-        do {
-            var request = URLRequest(url: url)
-            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-            let (data, response) = try await session.data(for: request)
-
-            guard let http = response as? HTTPURLResponse else { throw APIError.invalidResponse }
-
-            // Torn returns HTTP 200 even on errors — check the envelope before decoding.
-            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let apiError = tornAPIError(in: json) {
-                recordHealth("key.info", outcome: .error, since: startTime, bytes: data.count,
-                             errorClass: apiError.classification.rawValue)
-                keyValidation = .failure(apiError.userMessage)
-                return
-            }
-
-            guard http.statusCode == 200 else {
-                recordHealth("key.info", outcome: .error, since: startTime, bytes: data.count,
-                             errorClass: "temporaryBackend")
-                keyValidation = .failure("Torn returned HTTP \(http.statusCode). Please try again.")
-                return
-            }
-
-            let decoded = try JSONDecoder().decode(TornKeyInfo.Response.self, from: data)
-            self.keyInfo = decoded.info
-            self.keyValidation = .success(KeyValidator.validate(decoded.info))
-            recordHealth("key.info", outcome: .ok, since: startTime, bytes: data.count)
-            logger.info("Key validated: access level \(decoded.info.access.level)")
-        } catch {
-            if Task.isCancelled {
-                recordHealth("key.info", outcome: .cancelled, since: startTime, bytes: 0)
-                return
-            }
-            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
-            let message = mapped?.userMessage
-                ?? "Couldn't read Torn's response. Please try again."
-            keyValidation = .failure(message)
-            recordHealth("key.info",
-                         outcome: mapped?.classification == .offline ? .offline : .error,
-                         since: startTime, bytes: 0,
-                         errorClass: mapped?.classification.rawValue ?? "malformedResponse")
-            logger.error("Key validation failed: \(String(describing: type(of: error)))")
-        }
-    }
-
-    /// Record the outcome of a request for the Diagnostics screen (Etap F).
-    private func recordHealth(_ endpointID: String, outcome: EndpointOutcome, since start: Date, bytes: Int, errorClass: String? = nil) {
-        endpointHealth.record(endpointID: endpointID,
-                              outcome: outcome,
-                              latencyMs: Int(Date().timeIntervalSince(start) * 1000),
-                              responseBytes: bytes,
-                              errorClass: errorClass)
-    }
-
-    // MARK: - Next Action (Etap J)
-
-    private static let hiddenNextActionKey = "hiddenNextActionCategories"
-
-    private func loadHiddenNextActionCategories() {
-        guard let raw = defaults.stringArray(forKey: Self.hiddenNextActionKey) else { return }
-        hiddenNextActionCategories = Set(raw.compactMap(NextActionCategory.init(rawValue:)))
-    }
-
-    private func saveHiddenNextActionCategories() {
-        defaults.set(hiddenNextActionCategories.map(\.rawValue), forKey: Self.hiddenNextActionKey)
-    }
-
-    /// Builds the decoupled snapshot the Next Action engine consumes, mapping each live
-    /// model to an absolute Unix timestamp. Cooldowns/status/OC/education/chain already
-    /// carry absolute epochs; bars use `fulltime` (seconds-to-full) and travel uses the
-    /// live `travelSecondsRemaining`.
-    func makeNextActionSnapshot(now: Date = Date()) -> NextActionSnapshot {
-        let nowUnix = Int(now.timeIntervalSince1970)
-        var s = NextActionSnapshot(now: nowUnix)
-
-        if let bars = data?.bars {
-            s.energyFullAt = barFullAt(bars.energy, nowUnix: nowUnix)
-            s.nerveFullAt = barFullAt(bars.nerve, nowUnix: nowUnix)
-            s.happyFullAt = barFullAt(bars.happy, nowUnix: nowUnix)
-            s.lifeFullAt = barFullAt(bars.life, nowUnix: nowUnix)
-        }
-        if let cd = cooldownEnds {
-            s.drugReadyAt = cd.drugEndsAt > 0 ? cd.drugEndsAt : nil
-            s.medicalReadyAt = cd.medicalEndsAt > 0 ? cd.medicalEndsAt : nil
-            s.boosterReadyAt = cd.boosterEndsAt > 0 ? cd.boosterEndsAt : nil
-        }
-        if let travel = data?.travel, travel.isTraveling, travelSecondsRemaining > 0 {
-            s.travelArrivalAt = nowUnix + travelSecondsRemaining
-        }
-        if let status = data?.status {
-            if status.isInHospital { s.hospitalReleaseAt = status.until }
-            if status.isInJail { s.jailReleaseAt = status.until }
-        }
-        if let until = education?.current?.until, until > 0 {
-            s.educationEndsAt = until
-        }
-        if let ready = organizedCrime?.readyAt, ready > 0 {
-            s.ocReadyAt = ready
-        }
-        if let chain = data?.chain, chain.isActive, let timeout = chain.timeout, timeout > 0 {
-            s.chainTimeoutAt = timeout
-        }
-        if let refills, !refills.unclaimed.isEmpty {
-            s.refillsAvailable = true
-        }
-        return s
-    }
-
-    private func barFullAt(_ bar: Bar, nowUnix: Int) -> Int? {
-        guard bar.current < bar.maximum, let full = bar.fulltime, full > 0 else { return nil }
-        return nowUnix + full
-    }
-
-    /// The full upcoming timeline (soonest first), minus hidden categories.
-    func nextEvents(now: Date = Date()) -> [NextEvent] {
-        NextActionEngine().events(from: makeNextActionSnapshot(now: now), hidden: hiddenNextActionCategories)
-    }
-
-    /// Assemble a PII-safe diagnostics snapshot (Etap F). Async because the notification
-    /// authorization state is read from the system.
-    func makeDiagnosticsReport() async -> DiagnosticsReport {
-        let notif = await NotificationManager.shared.authorizationStatusDescription()
-        var recordsByCategory: [String: Int] = [:]
-        for (category, count) in pollingCoordinator.recordsPerDayByCategory() {
-            recordsByCategory[category.rawValue] = count
-        }
-        return DiagnosticsReport(
-            appVersion: DiagnosticsEnvironment.appVersion,
-            build: DiagnosticsEnvironment.build,
-            osVersion: DiagnosticsEnvironment.osVersion,
-            architecture: DiagnosticsEnvironment.architecture,
-            isOnline: connectivity.isConnected,
-            notificationPermission: notif,
-            lastSuccessfulRefresh: lastUpdated,
-            lastErrorSummary: errorMsg,
-            keyPresent: !apiKey.isEmpty,
-            requiredAccessLevel: TornEndpointRegistry.requiredAccessLevel.label,
-            requestsLastMinute: pollingCoordinator.requestsInLastMinute,
-            requestsLastDay: pollingCoordinator.requestsInLastDay,
-            recordsPerDayByCategory: recordsByCategory,
-            endpoints: endpointHealth.all
-        )
-    }
-
-    // MARK: - Fetch Data
-    func fetchData() {
-        guard connectivity.isConnected else {
-            if errorMsg != "No internet connection" {
-                errorMsg = "No internet connection"
-                logger.warning("Fetch aborted: No internet connection")
-            }
-            return
-        }
-
-        guard !apiKey.isEmpty else {
-            errorMsg = "API Key required"
-            logger.warning("Fetch aborted: API Key required")
-            return
-        }
-
-        guard let url = TornAPI.url(for: apiKey) else {
-            errorMsg = "Invalid URL"
-            logger.error("Fetch aborted: Invalid URL")
-            return
-        }
-
-        // Etap D: the request-budget hard cap that no path may bypass. At normal cadence
-        // (~3 requests / 30s) this never trips; it only guards against a pathological
-        // burst (e.g. rapid manual refresh) exceeding the per-minute ceiling.
-        guard pollingCoordinator.canMakeRequest() else {
-            logger.warning("Fetch skipped: per-minute request budget reached")
-            return
-        }
-        recordRequest("user.fast")
-
-        isLoading = true
-        errorMsg = nil
-
-        logger.info("Starting data fetch from: \(tornRedactedURL(url))")
-
-        fetchTask?.cancel()
-        fetchTask = Task {
-            let startTime = Date()
-
-            // Ensure minimum loading time for UX, then set isLoading = false
-            defer {
-                Task { @MainActor in
-                    let elapsed = Date().timeIntervalSince(startTime)
-                    if elapsed < 0.5 {
-                        try? await Task.sleep(nanoseconds: UInt64((0.5 - elapsed) * 1_000_000_000))
-                    }
-                    self.isLoading = false
-                }
-            }
-
-            do {
-                // Create request with no-cache policy to ensure fresh data
-                var request = URLRequest(url: url)
-                request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-
-                let (data, response) = try await session.data(for: request)
-
-                guard let httpResponse = response as? HTTPURLResponse else {
-                    throw APIError.invalidResponse
-                }
-
-                logger.info("HTTP response: \(httpResponse.statusCode)")
-
-                switch httpResponse.statusCode {
-                case 200:
-                    // Diagnostics only: payload size + top-level keys. Never log raw response —
-                    // it contains player name, money, stats, attacks, and other PII (and the
-                    // request URL with the API key already passed through redacted logging).
-                    if let topLevel = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                        // Etap B: Torn returns key/permission errors with HTTP 200 in an
-                        // envelope. A permanent one (codes 2/16/18) must halt polling —
-                        // retrying a dead/paused/under-privileged key forever is pointless.
-                        if let apiError = tornAPIError(in: topLevel), apiError.haltsAllRequests {
-                            self.recordHealth("user.fast", outcome: .error, since: startTime, bytes: data.count, errorClass: apiError.classification.rawValue)
-                            await MainActor.run { self.handlePermanentKeyError(apiError) }
-                            return
-                        }
-                        let keys = topLevel.keys.sorted().joined(separator: ",")
-                        logger.debug("API response: \(data.count) bytes, keys=[\(keys)]")
-                    } else {
-                        logger.debug("API response: \(data.count) bytes (non-JSON or unparseable)")
-                    }
-
-                    // Parse user data and fetch faction + v2 data in parallel
-                    async let factionResult: Void = self.fetchFactionData()
-                    async let userV2Result: Void = self.fetchUserV2Data()
-                    async let factionV2Result: Void = self.fetchFactionV2Data()
-                    async let activityResult: Void = self.fetchActivityData()
-                    try await parseDataInBackground(data: data)
-                    await factionResult
-                    await userV2Result
-                    await factionV2Result
-                    await activityResult
-
-                    logger.info("Data fetch completed successfully")
-                    self.recordHealth("user.fast", outcome: .ok, since: startTime, bytes: data.count)
-
-                case 403, 404:
-                    await MainActor.run {
-                        self.errorMsg = "Invalid API Key"
-                        self.data = nil
-                    }
-                    logger.error("HTTP \(httpResponse.statusCode): Invalid API Key")
-                    self.recordHealth("user.fast", outcome: .error, since: startTime, bytes: data.count, errorClass: "permanentKey")
-                default:
-                    await MainActor.run {
-                        self.errorMsg = "HTTP Error: \(httpResponse.statusCode)"
-                    }
-                    logger.error("HTTP Error: \(httpResponse.statusCode)")
-                    self.recordHealth("user.fast", outcome: .error, since: startTime, bytes: data.count, errorClass: "temporaryBackend")
-                }
-            } catch {
-                if Task.isCancelled {
-                    self.recordHealth("user.fast", outcome: .cancelled, since: startTime, bytes: 0)
-                    return
-                }
-                let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
-                await MainActor.run {
-                    self.errorMsg = "Network error: \(error.localizedDescription)"
-                }
-                logger.error("Network error: \(error.localizedDescription)")
-                self.recordHealth("user.fast",
-                                  outcome: mapped?.classification == .offline ? .offline : .error,
-                                  since: startTime, bytes: 0,
-                                  errorClass: mapped?.classification.rawValue ?? "transport")
-            }
-        }
-    }
-
-    // Move parsing logic here and mark as non-isolated or detached
-    private func parseDataInBackground(data: Data) async throws {
-        // Run CPU-heavy parsing detached from MainActor
-        let result = await Task.detached(priority: .userInitiated) { () -> (TornResponse?, MoneyData?, BattleStats?, [AttackResult]?, [PropertyInfo]?, [StockHolding], String?) in
-            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                return (nil, nil, nil, nil, nil, [], "Failed to parse response")
-            }
-
-            // Check for Torn API error (API returns HTTP 200 even on errors like rate limiting)
-            if let errorMessage = tornAPIErrorMessage(in: json) {
-                return (nil, nil, nil, nil, nil, [], "API Error: \(errorMessage)")
-            }
-
-            // Attempt to decode TornResponse first. Surface the decode failure class
-            // (without dumping payload contents — that's PII) so silent decode failures
-            // become diagnosable instead of vanishing into a "no data" state.
-            let decodedTornResponse: TornResponse?
-            do {
-                decodedTornResponse = try JSONDecoder().decode(TornResponse.self, from: data)
-            } catch let DecodingError.keyNotFound(key, ctx) {
-                logger.error("TornResponse decode: missing key '\(key.stringValue)' at \(ctx.codingPath.map(\.stringValue).joined(separator: "."))")
-                decodedTornResponse = nil
-            } catch let DecodingError.typeMismatch(_, ctx) {
-                logger.error("TornResponse decode: type mismatch at \(ctx.codingPath.map(\.stringValue).joined(separator: "."))")
-                decodedTornResponse = nil
-            } catch let DecodingError.valueNotFound(_, ctx) {
-                logger.error("TornResponse decode: value not found at \(ctx.codingPath.map(\.stringValue).joined(separator: "."))")
-                decodedTornResponse = nil
-            } catch {
-                logger.error("TornResponse decode failed: \(String(describing: type(of: error)))")
-                decodedTornResponse = nil
-            }
-            
-            // --- EXTENDED DATA ---
-            
-             // Money
-            let cash = json["money_onhand"] as? Int ?? 0
-            var vault = 0
-            if let v = json["vault_amount"] as? Int { vault = v }
-            else if let v = json["property_vault"] as? Int { vault = v }
-            else if let moneyDict = json["money"] as? [String: Any] { vault = moneyDict["vault"] as? Int ?? 0 }
-            
-            let points = json["points"] as? Int ?? 0
-            let tokens = json["donator"] as? Int ?? 0
-            let cayman = json["cayman_bank"] as? Int ?? 0
-            let moneyData = MoneyData(cash: cash, vault: vault, points: points, tokens: tokens, cayman: cayman)
-            
-            // Battle Stats
-            let strength = json["strength"] as? Int ?? 0
-            let defense = json["defense"] as? Int ?? 0
-            let speed = json["speed"] as? Int ?? 0
-            let dexterity = json["dexterity"] as? Int ?? 0
-            let battleStats = BattleStats(strength: strength, defense: defense, speed: speed, dexterity: dexterity)
-            
-            // Attacks
-            var attacksList: [AttackResult]?
-            if let attacks = json["attacks"] as? [String: [String: Any]] {
-                attacksList = attacks.values.compactMap { attackDict -> AttackResult? in
-                    guard let code = attackDict["code"] as? String else { return nil }
-                    return AttackResult(
-                        code: code,
-                        timestampStarted: attackDict["timestamp_started"] as? Int,
-                        timestampEnded: attackDict["timestamp_ended"] as? Int,
-                        attackerId: attackDict["attacker_id"] as? Int,
-                        attackerName: attackDict["attacker_name"] as? String,
-                        defenderId: attackDict["defender_id"] as? Int,
-                        defenderName: attackDict["defender_name"] as? String,
-                        result: attackDict["result"] as? String,
-                        respect: attackDict["respect"] as? Double
-                    )
-                }.sorted(by: { ($0.timestampEnded ?? 0) > ($1.timestampEnded ?? 0) })
-            }
-            
-            // Properties — Torn API: `rented` is null OR {user_id, days_left, cost_per_day}
-            // `status` indicates residency ("Owned by them" = owned, not residing).
-            // `upkeep`/`staff_cost` are per-day rates that only apply when residing — we don't surface them.
-            var propertiesList: [PropertyInfo]?
-            if let properties = json["properties"] as? [String: [String: Any]] {
-                propertiesList = properties.values.compactMap { propDict -> PropertyInfo? in
-                    let rentedDict = propDict["rented"] as? [String: Any]
-                    return PropertyInfo(
-                        id: propDict["property_id"] as? Int ?? 0,
-                        propertyType: propDict["property"] as? String ?? "",
-                        status: propDict["status"] as? String ?? "",
-                        cost: propDict["cost"] as? Int ?? 0,
-                        marketprice: propDict["marketprice"] as? Int ?? 0,
-                        happy: propDict["happy"] as? Int ?? 0,
-                        rented: rentedDict != nil,
-                        rentDaysLeft: rentedDict?["days_left"] as? Int
-                    )
-                }
-            }
-            // Stocks
-            var stocksList: [StockHolding] = []
-            if let stocks = json["stocks"] as? [String: [String: Any]] {
-                for (_, stockData) in stocks {
-                    if let stockJSON = try? JSONSerialization.data(withJSONObject: stockData),
-                       let stock = try? JSONDecoder().decode(StockHolding.self, from: stockJSON) {
-                        stocksList.append(stock)
-                    }
-                }
-            }
-
-            // If we couldn't decode TornResponse, report error but continue with extended data
-            let parseError: String? = (decodedTornResponse == nil) ? "Failed to decode user data" : nil
-
-            return (decodedTornResponse, moneyData, battleStats, attacksList, propertiesList, stocksList, parseError)
-        }.value
-
-        await MainActor.run {
-            // Check for parse errors
-            if let parseError = result.6, result.0 == nil {
-                self.errorMsg = parseError
-                logger.error("Data error: \(parseError)")
-                self.lastUpdated = Date() // Still update timestamp on error
-                return
-            }
-
-            if let decoded = result.0 {
-                // Don't log player name (identifying PII). State + life are non-identifying diagnostics.
-                logger.info("Parsed data — Life: \(decoded.life?.current ?? -1)/\(decoded.life?.maximum ?? -1), State: \(decoded.status?.state ?? "nil")")
-                if let events = decoded.events {
-                    logger.info("Events count: \(events.count)")
-                }
-
-                self.checkNotifications(newData: decoded)
-                self.data = decoded
-
-                // Convert relative cooldown durations into absolute end-timestamps,
-                // anchored on the server's response time so countdowns match torn.com
-                // even if the Mac clock is skewed vs the Torn server.
-                if let cooldowns = decoded.cooldowns {
-                    let anchor = decoded.anchorTimestamp ?? Int(Date().timeIntervalSince1970)
-                    let fresh = CooldownEnds.from(cooldowns: cooldowns, anchor: anchor)
-                    // Pin previous end-timestamps when the freshly computed values
-                    // wobble by ≤3 s — that wobble is API/latency jitter, not a real
-                    // change in expiry, and replacing endsAt would visibly jump the
-                    // menu bar countdown on every poll.
-                    self.cooldownEnds = self.cooldownEnds?.merged(with: fresh) ?? fresh
-                } else {
-                    self.cooldownEnds = nil
-                }
-
-                self.previousBars = decoded.bars
-                self.previousCooldowns = decoded.cooldowns
-                self.previousTravel = decoded.travel
-                self.previousChain = decoded.chain
-                self.previousStatus = decoded.status
-            } else {
-                logger.warning("TornResponse decoded as nil but no parse error reported")
-            }
-
-            if let m = result.1 { self.moneyData = m }
-            if let b = result.2 { self.battleStats = b }
-            if let a = result.3 { self.recentAttacks = a }
-            if let p = result.4 { self.propertiesData = p }
-            self.stocksData = result.5
-
-            self.lastUpdated = Date()
-            self.lastFetchTime = Date()
-            self.errorMsg = nil
-
-            // Manage live timer (travel + hospital + jail + cooldowns) after data is set
-            self.manageLiveTimer()
-
-            // Check if feedback prompt should be shown
-            self.checkFeedbackPrompt()
-
-            logger.info("Data updated, lastUpdated: \(self.lastUpdated?.description ?? "nil")")
-        }
-    }
-    
-    // MARK: - Fetch Faction Data
-    private func fetchFactionData() async {
-        guard let url = TornAPI.factionURL(for: apiKey) else { return }
-        recordRequest("faction.basic")
-        let startTime = Date()
-
-        do {
-            var request = URLRequest(url: url)
-            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-            let (data, _) = try await session.data(for: request)
-
-            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                // Check for Torn API error first
-                if let apiError = tornAPIError(in: json) {
-                    recordHealth("faction.basic", outcome: .error, since: startTime, bytes: data.count, errorClass: apiError.classification.rawValue)
-                    logger.warning("Faction API error: \(apiError.userMessage)")
-                    return
-                }
-
-                let name = json["name"] as? String ?? ""
-                let factionId = json["ID"] as? Int ?? 0
-                let respect = json["respect"] as? Int ?? 0
-
-                var chain = FactionChain()
-                if let chainDict = json["chain"] as? [String: Any] {
-                    chain = FactionChain(
-                        current: chainDict["current"] as? Int ?? 0,
-                        max: chainDict["max"] as? Int ?? 0,
-                        timeout: chainDict["timeout"] as? Int ?? 0,
-                        cooldown: chainDict["cooldown"] as? Int ?? 0
-                    )
-                }
-
-                // Organized crime moved to `fetchUserV2Data` (own OC 2.0). The v1
-                // `crimes` selection is dead (frozen OC-1.0 history only).
-
-                self.factionData = FactionData(name: name, factionId: factionId, respect: respect, chain: chain)
-                logger.info("Faction data fetched: \(name)")
-                recordHealth("faction.basic", outcome: .ok, since: startTime, bytes: data.count)
-            } else {
-                recordHealth("faction.basic", outcome: .error, since: startTime, bytes: data.count, errorClass: "malformedResponse")
-            }
-        } catch {
-            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
-            recordHealth("faction.basic",
-                         outcome: mapped?.classification == .offline ? .offline : .error,
-                         since: startTime, bytes: 0,
-                         errorClass: mapped?.classification.rawValue ?? "transport")
-            logger.warning("Faction fetch error (optional): \(error.localizedDescription)")
-            // Faction data is optional, ignore errors
-        }
-    }
-
-    // MARK: - Fetch Row-Based Activity Data (events, messages, attacks)
-    //
-    // These are cloud/row-based categories subject to Torn's 50,000-rows/day-per-category
-    // limit (error code 14 "Daily read limit reached"), which is SEPARATE from the
-    // 100-requests/minute rate limit. They are display-only — no notifications derive
-    // from them — so a slow cadence plus a small `limit` keeps us far under the cap while
-    // the fast poll handles the live bars/cooldowns/travel data.
-    private func fetchActivityData() async {
-        guard !apiKey.isEmpty, let url = TornAPI.activityURL(for: apiKey) else { return }
-        // Skip while this row source is paused after a daily-row-limit hit (ISC-15.1).
-        guard !isRowSourcePaused("user.activity") else { return }
-        // (recorded below, after the throttle guard, so a throttled skip isn't counted)
-
-        // Self-throttle: always runs on the first poll (lastActivityFetch == nil), then
-        // at most once per activityMinInterval regardless of how fast the main poll ticks.
-        // Set upfront (not reset on error) so an error-state retry can't exceed the cap.
-        if let last = lastActivityFetch,
-           Date().timeIntervalSince(last) < Self.activityMinInterval {
-            return
-        }
-        lastActivityFetch = Date()
-        recordRequest("user.activity")
-        let startTime = Date()
-
-        do {
-            var request = URLRequest(url: url)
-            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-            let (data, _) = try await session.data(for: request)
-
-            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                recordHealth("user.activity", outcome: .error, since: startTime, bytes: data.count, errorClass: "malformedResponse")
-                return
-            }
-            if let apiError = tornAPIError(in: json) {
-                // A daily-row-limit (code 14) pauses only this row source (ISC-15.1).
-                if apiError.haltsCategoryOnly { pauseRowSource("user.activity", error: apiError) }
-                recordHealth("user.activity", outcome: .error, since: startTime, bytes: data.count, errorClass: apiError.classification.rawValue)
-                logger.warning("Activity API error: \(apiError.userMessage)")
-                return
-            }
-
-            // events + messages via the TornResponse Codable shape (both optional fields).
-            if let decoded = try? JSONDecoder().decode(TornResponse.self, from: data) {
-                self.activityEvents = decoded.recentEvents
-                self.unreadMessages = decoded.unreadMessagesCount
-            }
-
-            // attacks via JSONSerialization (same mapping as the legacy combined parse).
-            if let attacks = json["attacks"] as? [String: [String: Any]] {
-                self.recentAttacks = attacks.values.compactMap { attackDict -> AttackResult? in
-                    guard let code = attackDict["code"] as? String else { return nil }
-                    return AttackResult(
-                        code: code,
-                        timestampStarted: attackDict["timestamp_started"] as? Int,
-                        timestampEnded: attackDict["timestamp_ended"] as? Int,
-                        attackerId: attackDict["attacker_id"] as? Int,
-                        attackerName: attackDict["attacker_name"] as? String,
-                        defenderId: attackDict["defender_id"] as? Int,
-                        defenderName: attackDict["defender_name"] as? String,
-                        result: attackDict["result"] as? String,
-                        respect: attackDict["respect"] as? Double
-                    )
-                }.sorted(by: { ($0.timestampEnded ?? 0) > ($1.timestampEnded ?? 0) })
-            }
-            recordHealth("user.activity", outcome: .ok, since: startTime, bytes: data.count)
-        } catch {
-            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
-            recordHealth("user.activity",
-                         outcome: mapped?.classification == .offline ? .offline : .error,
-                         since: startTime, bytes: 0,
-                         errorClass: mapped?.classification.rawValue ?? "transport")
-            logger.warning("Activity fetch error (optional): \(error.localizedDescription)")
-        }
-    }
-
-    // MARK: - Fetch API v2 User Data (organized crime, refills, education, bounties)
-    //
-    // One combined v2 call (v2 accepts multiple selections). Each section is decoded
-    // independently so a malformed/absent one never drops the others. Payload is small
-    // (~2 KB), so decoding on the main actor is fine — same pattern as fetchFactionData.
-    private func fetchUserV2Data() async {
-        guard !apiKey.isEmpty, let url = TornAPI.userV2URL(for: apiKey) else { return }
-        recordRequest("user.v2")
-        let startTime = Date()
-
-        do {
-            var request = URLRequest(url: url)
-            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-            let (data, _) = try await session.data(for: request)
-
-            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                recordHealth("user.v2", outcome: .error, since: startTime, bytes: data.count, errorClass: "malformedResponse")
-                return
-            }
-            if let apiError = tornAPIError(in: json) {
-                recordHealth("user.v2", outcome: .error, since: startTime, bytes: data.count, errorClass: apiError.classification.rawValue)
-                logger.warning("User v2 API error: \(apiError.userMessage)")
-                return
-            }
-
-            let decoder = JSONDecoder()
-
-            // Organized crime — `organizedCrime` is oneOf(object | error | null).
-            // Only a well-formed object carrying an Int `id` is a real active OC.
-            var oc: OrganizedCrime2?
-            if let ocDict = json["organizedCrime"] as? [String: Any], ocDict["id"] is Int,
-               let ocData = try? JSONSerialization.data(withJSONObject: ocDict) {
-                oc = try? decoder.decode(OrganizedCrime2.self, from: ocData)
-            }
-            self.organizedCrime = oc
-
-            if let rDict = json["refills"] as? [String: Any],
-               let rData = try? JSONSerialization.data(withJSONObject: rDict) {
-                self.refills = try? decoder.decode(Refills.self, from: rData)
-            }
-
-            if let eDict = json["education"] as? [String: Any],
-               let eData = try? JSONSerialization.data(withJSONObject: eDict) {
-                self.education = try? decoder.decode(EducationStatus.self, from: eData)
-            }
-
-            // `/user?selections=bounties` is scoped to the authenticated player, so
-            // every returned bounty is a bounty ON Paweł.
-            if let bArr = json["bounties"] as? [[String: Any]],
-               let bData = try? JSONSerialization.data(withJSONObject: bArr) {
-                self.bountiesOnMe = (try? decoder.decode([Bounty].self, from: bData)) ?? []
-            } else {
-                self.bountiesOnMe = []
-            }
-
-            // OC-ready notification: fire once per distinct OC id (see shouldNotifyOCReady).
-            if shouldNotifyOCReady(oc), let oc {
-                NotificationManager.shared.send(
-                    title: "OC Ready! 💼",
-                    body: "\(oc.name) is ready to execute",
-                    type: .ocReady
-                )
-            }
-
-            notifyBountiesOnMe()
-
-            logger.info("User v2 data fetched (OC: \(oc?.name ?? "none"), bounties: \(self.bountiesOnMe.count))")
-            recordHealth("user.v2", outcome: .ok, since: startTime, bytes: data.count)
-        } catch {
-            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
-            recordHealth("user.v2",
-                         outcome: mapped?.classification == .offline ? .offline : .error,
-                         since: startTime, bytes: 0,
-                         errorClass: mapped?.classification.rawValue ?? "transport")
-            logger.warning("User v2 fetch error (optional): \(error.localizedDescription)")
-        }
-    }
-
-    /// Whether an OC-ready alert should fire now: true once per distinct OC id, deduped
-    /// **persistently** via the NotificationCoordinator (Etap E / ISC-18), so relaunching
-    /// while the same OC is still ready doesn't re-alert (the old in-memory `previousOCReadyId`
-    /// did). A new OC (new id) re-arms naturally. `internal` for tests.
-    func shouldNotifyOCReady(_ oc: OrganizedCrime2?) -> Bool {
-        guard let oc, oc.isReady else { return false }
-        return notificationCoordinator.shouldFireOnce("oc.ready", epoch: "\(oc.id)")
-    }
-
-    /// Alerts once per distinct bounty placed on Paweł (safety signal). Re-remembers
-    /// only the bounties still active, so a bounty that's cleared and re-listed alerts again.
-    private func notifyBountiesOnMe() {
-        let currentKeys = Set(bountiesOnMe.map(\.id))
-        for bounty in bountiesOnMe where !notifiedBountyKeys.contains(bounty.id) {
-            let amount = Self.decimalFormatter.string(from: NSNumber(value: bounty.reward)) ?? "\(bounty.reward)"
-            let who: String
-            if bounty.isAnonymous == true {
-                who = " (anonymous)"
-            } else if let name = bounty.listerName {
-                who = " from \(name)"
-            } else {
-                who = ""
-            }
-            NotificationManager.shared.send(
-                title: "⚠️ Bounty on you",
-                body: "$\(amount)\(who)",
-                type: .bountyOnMe
-            )
-        }
-        notifiedBountyKeys = currentKeys
+    func isCurrentAccount(_ key: String, generation: UInt) -> Bool {
+        accountSession.isCurrent(AccountIdentity(apiKey: key, generation: generation))
     }
 
     static let decimalFormatter: NumberFormatter = {
@@ -1871,255 +368,6 @@ class AppState {
         return f
     }()
 
-    // MARK: - Fetch API v2 Faction Data (ranked wars, news)
-    //
-    // Dedicated v2 paths: the combined `?selections=rankedwars,news` call fails with
-    // code 21 because `news` needs a `cat` parameter. Both are optional overlays.
-    private func fetchFactionV2Data() async {
-        guard !apiKey.isEmpty else { return }
-
-        // Ranked wars (~15 KB) + news (~23 KB) change slowly and are the heaviest
-        // calls in a poll. Fetch at most once per minute regardless of the poll
-        // interval (which can be as low as 15s) — always runs on the first poll.
-        if let last = lastFactionV2Fetch,
-           Date().timeIntervalSince(last) < Self.factionV2MinInterval {
-            return
-        }
-        lastFactionV2Fetch = Date()
-
-        if let url = TornAPI.factionRankedWarsURL(for: apiKey) {
-            recordRequest("faction.rankedwars")
-            if let wars: [RankedWar] = await fetchV2Array(url: url, key: "rankedwars", endpointID: "faction.rankedwars") {
-                self.rankedWars = wars
-            }
-        }
-
-        // News is the only row-based faction call — skip while it is paused after a
-        // daily-row-limit hit (ISC-15.1). Ranked wars (point-in-time) keeps running.
-        if !isRowSourcePaused("faction.news"), let url = TornAPI.factionNewsURL(for: apiKey) {
-            recordRequest("faction.news")
-            if let news: [FactionNews] = await fetchV2Array(url: url, key: "news", endpointID: "faction.news") {
-                self.factionNews = news
-            }
-        }
-    }
-
-    /// Fetches a v2 endpoint whose payload is `{ "<key>": [ … ] }` and decodes the
-    /// array. Returns nil on network/API error so the caller keeps its prior value.
-    /// Records endpoint health (Etap F) and, on a daily-row-limit error, pauses the source
-    /// (ISC-15.1) — only meaningful for the row-based `news` call.
-    private func fetchV2Array<T: Decodable>(url: URL, key: String, endpointID: String) async -> [T]? {
-        let startTime = Date()
-        do {
-            var request = URLRequest(url: url)
-            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-            let (data, _) = try await session.data(for: request)
-            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                recordHealth(endpointID, outcome: .error, since: startTime, bytes: data.count, errorClass: "malformedResponse")
-                return nil
-            }
-            if let apiError = tornAPIError(in: json) {
-                if apiError.haltsCategoryOnly { pauseRowSource(endpointID, error: apiError) }
-                recordHealth(endpointID, outcome: .error, since: startTime, bytes: data.count, errorClass: apiError.classification.rawValue)
-                logger.warning("Faction v2 (\(key)) API error: \(apiError.userMessage)")
-                return nil
-            }
-            recordHealth(endpointID, outcome: .ok, since: startTime, bytes: data.count)
-            guard let arr = json[key] as? [[String: Any]],
-                  let arrData = try? JSONSerialization.data(withJSONObject: arr) else { return nil }
-            return try? JSONDecoder().decode([T].self, from: arrData)
-        } catch {
-            let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
-            recordHealth(endpointID,
-                         outcome: mapped?.classification == .offline ? .offline : .error,
-                         since: startTime, bytes: 0,
-                         errorClass: mapped?.classification.rawValue ?? "transport")
-            logger.warning("Faction v2 (\(key)) fetch error (optional): \(error.localizedDescription)")
-            return nil
-        }
-    }
-
-    // MARK: - Notifications
-    private func checkNotifications(newData: TornResponse) {
-        if let prev = previousBars, let current = newData.bars {
-            checkBarNotification(prevBar: prev.energy, currentBar: current.energy, barType: .energy)
-            checkBarNotification(prevBar: prev.nerve, currentBar: current.nerve, barType: .nerve)
-            checkBarNotification(prevBar: prev.happy, currentBar: current.happy, barType: .happy)
-            checkBarNotification(prevBar: prev.life, currentBar: current.life, barType: .life)
-        }
-        
-        if let prevCD = previousCooldowns, let currentCD = newData.cooldowns {
-            if prevCD.drug > 0 && currentCD.drug == 0 {
-                NotificationManager.shared.send(title: "Drug Ready! 💊", body: "Drug cooldown has ended", type: .drugReady)
-            }
-            if prevCD.medical > 0 && currentCD.medical == 0 {
-                NotificationManager.shared.send(title: "Medical Ready! 🏥", body: "Medical cooldown has ended", type: .medicalReady)
-            }
-            if prevCD.booster > 0 && currentCD.booster == 0 {
-                NotificationManager.shared.send(title: "Booster Ready! 🚀", body: "Booster cooldown has ended", type: .boosterReady)
-            }
-        }
-        
-        if let prevTravel = previousTravel, let currentTravel = newData.travel {
-            // Just landed
-            if prevTravel.isTraveling && !currentTravel.isTraveling {
-                NotificationManager.shared.send(title: "Landed!", body: "You have arrived in \(currentTravel.destination ?? "destination")", type: .landed)
-                NotificationManager.shared.cancelTravelNotifications()
-            }
-            // Just started traveling
-            if !prevTravel.isTraveling && currentTravel.isTraveling {
-                scheduleTravelNotifications(for: currentTravel)
-            }
-        } else if let currentTravel = newData.travel, currentTravel.isTraveling, previousTravel == nil {
-            // First data fetch while traveling
-            scheduleTravelNotifications(for: currentTravel)
-        }
-        
-        if chainExpiringShouldFire(newData.chain), let chain = newData.chain {
-            NotificationManager.shared.send(title: "Chain Expiring! ⚠️", body: "Chain timeout in \(chain.timeoutRemaining) seconds!", type: .chainExpiring)
-        }
-        
-        if let prevStatus = previousStatus, let currentStatus = newData.status {
-            if (prevStatus.isInHospital || prevStatus.isInJail) && currentStatus.isOkay {
-                NotificationManager.shared.send(title: "Released! 🎉", body: "You are now free", type: .released)
-            }
-        }
-    }
-    
-    /// Decides whether the "Chain Expiring!" alert should fire on this poll.
-    ///
-    /// The alert must fire exactly once when the chain enters the danger window
-    /// (0 < timeout < `chainWarningThreshold`), NOT on every poll while it stays there
-    /// (the previous bug). It re-arms once the chain leaves the window — a member hits
-    /// (timeout jumps back up), the chain ends, or the chain drops — so a fresh danger
-    /// window alerts again. The latch is persisted, so a relaunch mid-window is silent.
-    /// `internal` for `@testable` regression coverage.
-    func chainExpiringShouldFire(_ chain: Chain?) -> Bool {
-        let inDanger = (chain?.isActive == true)
-            && chain!.timeoutRemaining > 0
-            && chain!.timeoutRemaining < Self.chainWarningThreshold
-        return notificationCoordinator.shouldFireOnEdge("chain.expiring", active: inDanger)
-    }
-
-    private func checkBarNotification(prevBar: Bar, currentBar: Bar, barType: NotificationRule.BarType) {
-        let prevPct = prevBar.percentage
-        let currentPct = currentBar.percentage
-
-        for rule in notificationRules where rule.enabled && rule.barType == barType {
-            let threshold = Double(rule.threshold)
-
-            if prevPct < threshold && currentPct >= threshold {
-                let title: String
-                let notificationType: NotificationType
-                switch barType {
-                case .energy:
-                    title = "Energy \(rule.threshold)%! ⚡️"
-                    notificationType = .energy
-                case .nerve:
-                    title = "Nerve \(rule.threshold)%! 💪"
-                    notificationType = .nerve
-                case .happy:
-                    title = "Happy \(rule.threshold)%! 😊"
-                    notificationType = .happy
-                case .life:
-                    title = "Life \(rule.threshold)%! ❤️"
-                    notificationType = .life
-                }
-                NotificationManager.shared.send(title: title, body: "\(barType.rawValue) is now at \(currentBar.current)/\(currentBar.maximum)", type: notificationType)
-
-                if let sound = NotificationSound(rawValue: rule.soundName) {
-                    SoundManager.shared.play(sound)
-                }
-            }
-        }
-    }
-    
-    // MARK: - Updates
-    func checkForAppUpdates() {
-        guard let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return }
-
-        Task {
-            if let release = await updateManager.checkForUpdates(currentVersion: currentVersion) {
-                await MainActor.run {
-                    self.updateAvailable = release
-                }
-            }
-        }
-    }
-
-    // MARK: - Feedback Prompt
-
-    func loadFeedbackState() {
-        if let data = defaults.data(forKey: "appFeedbackState"),
-           let state = try? JSONDecoder().decode(AppFeedbackState.self, from: data) {
-            feedbackState = state
-        } else {
-            feedbackState = AppFeedbackState(
-                firstLaunchDate: Date(),
-                hasResponded: false,
-                dismissCount: 0,
-                lastDismissedDate: nil
-            )
-            saveFeedbackState()
-        }
-    }
-
-    func saveFeedbackState() {
-        guard let state = feedbackState,
-              let data = try? JSONEncoder().encode(state) else { return }
-        defaults.set(data, forKey: "appFeedbackState")
-    }
-
-    func checkFeedbackPrompt() {
-        guard let state = feedbackState else { return }
-        guard !state.hasResponded else { return }
-        guard state.dismissCount < Self.feedbackThresholds.count else { return }
-
-        // 5-minute cooldown after last dismissal
-        if let lastDismissed = state.lastDismissedDate,
-           Date().timeIntervalSince(lastDismissed) < 300 {
-            return
-        }
-
-        let elapsed = Date().timeIntervalSince(state.firstLaunchDate)
-        let requiredTime = Self.feedbackThresholds[state.dismissCount]
-
-        if elapsed >= requiredTime {
-            showFeedbackPrompt = true
-        }
-    }
-
-    private static var isRunningUnderXCTest: Bool {
-        NSClassFromString("XCTestCase") != nil
-    }
-
-    func feedbackRespondedPositive() {
-        feedbackState?.hasResponded = true
-        showFeedbackPrompt = false
-        saveFeedbackState()
-        // Guard prevents tests from spamming the user's browser/mail client.
-        guard !Self.isRunningUnderXCTest else { return }
-        if let url = URL(string: "https://www.torn.com/forums.php#/p=threads&f=67&t=16532308") {
-            BrowserManager.shared.open(url)
-        }
-    }
-
-    func feedbackRespondedNegative() {
-        feedbackState?.hasResponded = true
-        showFeedbackPrompt = false
-        saveFeedbackState()
-        guard !Self.isRunningUnderXCTest else { return }
-        if let url = URL(string: "mailto:pawel@orzech.lol?subject=MacTorn%20Feedback") {
-            BrowserManager.shared.open(url)
-        }
-    }
-
-    func feedbackDismissed() {
-        feedbackState?.dismissCount += 1
-        feedbackState?.lastDismissedDate = Date()
-        showFeedbackPrompt = false
-        saveFeedbackState()
-    }
 }
 
 // MARK: - Errors

--- a/MacTorn/MacTorn/ViewModels/FactionService.swift
+++ b/MacTorn/MacTorn/ViewModels/FactionService.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Observation
+
+enum FactionServiceResult<Value> {
+    case success(Value, responseBytes: Int)
+    case apiError(TornAPIError, responseBytes: Int)
+    case httpError(statusCode: Int, responseBytes: Int)
+    case malformed(responseBytes: Int)
+}
+
+@MainActor
+protocol FactionServicing: AnyObject {
+    var basic: FactionData? { get }
+    var wars: [RankedWar] { get }
+    var news: [FactionNews] { get }
+
+    func loadBasic(from url: URL) async throws -> FactionServiceResult<FactionData>
+    func loadWars(from url: URL) async throws -> FactionServiceResult<[RankedWar]>
+    func loadNews(from url: URL) async throws -> FactionServiceResult<[FactionNews]>
+
+    /// Called by the facade only after its account-generation check succeeds.
+    func publishBasic(_ value: FactionData)
+    func publishWars(_ value: [RankedWar])
+    func publishNews(_ value: [FactionNews])
+    func reset()
+}
+
+/// Owns faction state plus transport/decoding for the three faction sources.
+///
+/// Request budgets, endpoint health, throttling, row-source pauses and account
+/// generation checks deliberately remain facade policy. Loads therefore return typed
+/// results without publishing them; `AppState` publishes only after validating that
+/// the response still belongs to the current account generation.
+@MainActor
+@Observable
+final class FactionService: FactionServicing {
+    private(set) var basic: FactionData?
+    private(set) var wars: [RankedWar] = []
+    private(set) var news: [FactionNews] = []
+
+    @ObservationIgnored private let session: NetworkSession
+
+    init(session: NetworkSession) {
+        self.session = session
+    }
+
+    func loadBasic(from url: URL) async throws -> FactionServiceResult<FactionData> {
+        let response = try await load(url)
+        guard case .success(let data) = response else {
+            return mapTransportFailure(response)
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .malformed(responseBytes: data.count)
+        }
+        if let apiError = tornAPIError(in: json) {
+            return .apiError(apiError, responseBytes: data.count)
+        }
+
+        // FactionData's decoder is intentionally forgiving for UI compatibility.
+        // The service boundary must be stricter so `{}` never publishes a plausible
+        // empty faction or silently erases a valid chain.
+        guard json["name"] is String,
+              json["ID"] is Int,
+              json["respect"] is Int,
+              let chain = json["chain"] as? [String: Any],
+              chain["current"] is Int,
+              chain["max"] is Int,
+              chain["timeout"] is Int,
+              chain["cooldown"] is Int,
+              let decoded = try? JSONDecoder().decode(FactionData.self, from: data) else {
+            return .malformed(responseBytes: data.count)
+        }
+        return .success(decoded, responseBytes: data.count)
+    }
+
+    func loadWars(from url: URL) async throws -> FactionServiceResult<[RankedWar]> {
+        try await loadArray(from: url, key: "rankedwars")
+    }
+
+    func loadNews(from url: URL) async throws -> FactionServiceResult<[FactionNews]> {
+        try await loadArray(from: url, key: "news")
+    }
+
+    func publishBasic(_ value: FactionData) {
+        basic = value
+    }
+
+    func publishWars(_ value: [RankedWar]) {
+        wars = value
+    }
+
+    func publishNews(_ value: [FactionNews]) {
+        news = value
+    }
+
+    func reset() {
+        basic = nil
+        wars = []
+        news = []
+    }
+
+    private enum TransportResponse {
+        case success(Data)
+        case httpError(statusCode: Int, data: Data)
+    }
+
+    private func load(_ url: URL) async throws -> TransportResponse {
+        var request = URLRequest(url: url)
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            return .httpError(
+                statusCode: (response as? HTTPURLResponse)?.statusCode ?? 0,
+                data: data
+            )
+        }
+        return .success(data)
+    }
+
+    private func loadArray<Value: Decodable>(
+        from url: URL,
+        key: String
+    ) async throws -> FactionServiceResult<[Value]> {
+        let response = try await load(url)
+        guard case .success(let data) = response else {
+            return mapTransportFailure(response)
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .malformed(responseBytes: data.count)
+        }
+        if let apiError = tornAPIError(in: json) {
+            return .apiError(apiError, responseBytes: data.count)
+        }
+        guard let array = json[key] as? [Any],
+              let encoded = try? JSONSerialization.data(withJSONObject: array),
+              let decoded = try? JSONDecoder().decode([Value].self, from: encoded) else {
+            return .malformed(responseBytes: data.count)
+        }
+        return .success(decoded, responseBytes: data.count)
+    }
+
+    private func mapTransportFailure<Value>(
+        _ response: TransportResponse
+    ) -> FactionServiceResult<Value> {
+        switch response {
+        case .success(let data):
+            return .malformed(responseBytes: data.count)
+        case .httpError(let statusCode, let data):
+            return .httpError(statusCode: statusCode, responseBytes: data.count)
+        }
+    }
+}

--- a/MacTorn/MacTorn/ViewModels/ForumWatchService.swift
+++ b/MacTorn/MacTorn/ViewModels/ForumWatchService.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Observation
+
+struct ForumThreadSnapshot: Equatable {
+    let title: String
+    let postCount: Int
+}
+
+enum ForumThreadResult {
+    case success(ForumThreadSnapshot, responseBytes: Int)
+    case apiError(TornAPIError, responseBytes: Int)
+    case httpError(statusCode: Int, responseBytes: Int)
+    case malformed(responseBytes: Int)
+}
+
+struct ForumNewPosts: Equatable {
+    let threadID: Int
+    let title: String
+    let count: Int
+}
+
+@MainActor
+protocol ForumWatchServicing: AnyObject {
+    var threads: [WatchedThread] { get set }
+    var config: ForumWatchConfig { get set }
+
+    func load()
+    func save()
+    func parseThreadInput(_ input: String) -> Int?
+    func add(input: String) -> Int?
+    func remove(threadID: Int)
+    func restore(_ thread: WatchedThread, at originalIndex: Int) -> Bool
+    func toggleNotifications(threadID: Int)
+    func markAsRead(threadID: Int)
+    func apply(_ snapshot: ForumThreadSnapshot, to threadID: Int) -> ForumNewPosts?
+    func setError(_ error: String, for threadID: Int)
+    func fetchThread(from url: URL) async throws -> ForumThreadResult
+}
+
+/// Owns forum-watch state, config, persistence and response decoding. Poll timers,
+/// bounded fan-out, account cancellation, budgets and notifications stay in AppState.
+@MainActor
+@Observable
+final class ForumWatchService: ForumWatchServicing {
+    var threads: [WatchedThread] = []
+    var config = ForumWatchConfig()
+
+    @ObservationIgnored private let defaults: UserDefaults
+    @ObservationIgnored private let session: NetworkSession
+
+    init(defaults: UserDefaults, session: NetworkSession) {
+        self.defaults = defaults
+        self.session = session
+    }
+
+    func load() {
+        if let data = defaults.data(forKey: "forumWatchedThreads"),
+           let decoded = try? JSONDecoder().decode([WatchedThread].self, from: data) {
+            threads = decoded
+        }
+        if let data = defaults.data(forKey: "forumWatchConfig"),
+           let decoded = try? JSONDecoder().decode(ForumWatchConfig.self, from: data) {
+            config = decoded
+            if ![120, 180, 300].contains(config.pollingIntervalSeconds) {
+                config.pollingIntervalSeconds = 180
+            }
+        }
+    }
+
+    func save() {
+        if let data = try? JSONEncoder().encode(threads) {
+            defaults.set(data, forKey: "forumWatchedThreads")
+        }
+        if let data = try? JSONEncoder().encode(config) {
+            defaults.set(data, forKey: "forumWatchConfig")
+        }
+    }
+
+    func parseThreadInput(_ input: String) -> Int? {
+        func valid(_ id: Int?) -> Int? {
+            guard let id, id > 0 else { return nil }
+            return id
+        }
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let id = Int(trimmed) {
+            return valid(id)
+        }
+        guard let range = trimmed.range(
+            of: #"[?&#]t=(\d+)"#,
+            options: .regularExpression
+        ) else {
+            return nil
+        }
+        let match = trimmed[range]
+        return valid(Int(match.drop(while: { !$0.isNumber })))
+    }
+
+    func add(input: String) -> Int? {
+        guard let threadID = parseThreadInput(input),
+              !threads.contains(where: { $0.id == threadID }) else {
+            return nil
+        }
+        threads.append(
+            WatchedThread(
+                id: threadID,
+                title: "Loading...",
+                lastKnownPostCount: 0
+            )
+        )
+        save()
+        return threadID
+    }
+
+    func remove(threadID: Int) {
+        threads.removeAll { $0.id == threadID }
+        save()
+    }
+
+    func restore(_ thread: WatchedThread, at originalIndex: Int) -> Bool {
+        guard !threads.contains(where: { $0.id == thread.id }) else { return false }
+        let insertionIndex = min(max(originalIndex, 0), threads.count)
+        threads.insert(thread, at: insertionIndex)
+        save()
+        return true
+    }
+
+    func toggleNotifications(threadID: Int) {
+        guard let index = threads.firstIndex(where: { $0.id == threadID }) else { return }
+        threads[index].notificationsEnabled.toggle()
+        save()
+    }
+
+    func markAsRead(threadID: Int) {
+        guard let index = threads.firstIndex(where: { $0.id == threadID }) else { return }
+        threads[index].error = nil
+        save()
+    }
+
+    func apply(_ snapshot: ForumThreadSnapshot, to threadID: Int) -> ForumNewPosts? {
+        guard let index = threads.firstIndex(where: { $0.id == threadID }) else { return nil }
+        let previousCount = threads[index].lastKnownPostCount
+        threads[index].title = snapshot.title
+        threads[index].lastChecked = Date()
+        threads[index].error = nil
+        threads[index].lastKnownPostCount = snapshot.postCount
+
+        guard previousCount > 0,
+              snapshot.postCount > previousCount,
+              threads[index].notificationsEnabled else {
+            return nil
+        }
+        return ForumNewPosts(
+            threadID: threadID,
+            title: snapshot.title,
+            count: snapshot.postCount - previousCount
+        )
+    }
+
+    func setError(_ error: String, for threadID: Int) {
+        guard let index = threads.firstIndex(where: { $0.id == threadID }) else { return }
+        threads[index].error = error
+    }
+
+    func fetchThread(from url: URL) async throws -> ForumThreadResult {
+        var request = URLRequest(url: url)
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        let (data, response) = try await session.data(for: request)
+
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            return .httpError(
+                statusCode: (response as? HTTPURLResponse)?.statusCode ?? 0,
+                responseBytes: data.count
+            )
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .malformed(responseBytes: data.count)
+        }
+        if let apiError = tornAPIError(in: json) {
+            return .apiError(apiError, responseBytes: data.count)
+        }
+        let thread = json["thread"] as? [String: Any] ?? json
+        guard thread["title"] != nil || thread["posts"] != nil else {
+            return .malformed(responseBytes: data.count)
+        }
+        return .success(
+            ForumThreadSnapshot(
+                title: thread["title"] as? String ?? "Unknown",
+                postCount: thread["posts"] as? Int ?? 0
+            ),
+            responseBytes: data.count
+        )
+    }
+}

--- a/MacTorn/MacTorn/ViewModels/MarketWatchService.swift
+++ b/MacTorn/MacTorn/ViewModels/MarketWatchService.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Observation
+
+struct MarketPriceSnapshot: Equatable {
+    let lowestPrice: Int
+    let lowestPriceQuantity: Int
+    let secondLowestPrice: Int
+}
+
+enum MarketPriceResult {
+    case success(MarketPriceSnapshot, responseBytes: Int)
+    case apiError(TornAPIError, responseBytes: Int)
+    case httpError(statusCode: Int, responseBytes: Int)
+    case noListings(responseBytes: Int)
+    case malformed(responseBytes: Int)
+}
+
+struct MarketPriceAlert: Equatable {
+    let name: String
+    let price: Int
+}
+
+@MainActor
+protocol MarketWatchServicing: AnyObject {
+    var items: [WatchlistItem] { get set }
+
+    func load()
+    func save()
+    func add(itemID: Int, name: String) -> Bool
+    func remove(itemID: Int)
+    func restore(_ item: WatchlistItem, at originalIndex: Int) -> Bool
+    func apply(_ snapshot: MarketPriceSnapshot, to itemID: Int) -> MarketPriceAlert?
+    func setError(_ error: String, for itemID: Int)
+    func fetchPrice(from url: URL) async throws -> MarketPriceResult
+}
+
+/// Owns watchlist state, persistence and market-response decoding. Request budgets,
+/// account identity, bounded fan-out and notification delivery remain AppState policy.
+@MainActor
+@Observable
+final class MarketWatchService: MarketWatchServicing {
+    var items: [WatchlistItem] = []
+
+    @ObservationIgnored private let defaults: UserDefaults
+    @ObservationIgnored private let session: NetworkSession
+
+    init(defaults: UserDefaults, session: NetworkSession) {
+        self.defaults = defaults
+        self.session = session
+    }
+
+    func load() {
+        guard let data = defaults.data(forKey: "watchlist"),
+              let decoded = try? JSONDecoder().decode([WatchlistItem].self, from: data) else {
+            return
+        }
+        items = decoded
+    }
+
+    func save() {
+        guard let data = try? JSONEncoder().encode(items) else { return }
+        defaults.set(data, forKey: "watchlist")
+    }
+
+    func add(itemID: Int, name: String) -> Bool {
+        guard itemID > 0, itemID < 100_000 else { return false }
+        let trimmed = String(
+            name.trimmingCharacters(in: .whitespacesAndNewlines).prefix(64)
+        )
+        guard !trimmed.isEmpty,
+              !items.contains(where: { $0.id == itemID }) else {
+            return false
+        }
+        items.append(
+            WatchlistItem(
+                id: itemID,
+                name: trimmed,
+                lowestPrice: 0,
+                lowestPriceQuantity: 0,
+                secondLowestPrice: 0,
+                lastUpdated: nil,
+                error: nil
+            )
+        )
+        save()
+        return true
+    }
+
+    func remove(itemID: Int) {
+        items.removeAll { $0.id == itemID }
+        save()
+    }
+
+    func restore(_ item: WatchlistItem, at originalIndex: Int) -> Bool {
+        guard !items.contains(where: { $0.id == item.id }) else { return false }
+        let insertionIndex = min(max(originalIndex, 0), items.count)
+        items.insert(item, at: insertionIndex)
+        save()
+        return true
+    }
+
+    func apply(_ snapshot: MarketPriceSnapshot, to itemID: Int) -> MarketPriceAlert? {
+        guard let index = items.firstIndex(where: { $0.id == itemID }) else { return nil }
+        var item = items[index]
+        item.lowestPrice = snapshot.lowestPrice
+        item.lowestPriceQuantity = snapshot.lowestPriceQuantity
+        item.secondLowestPrice = snapshot.secondLowestPrice
+        item.lastUpdated = Date()
+        item.error = nil
+        items[index] = item
+
+        guard items[index].shouldFirePriceAlert else { return nil }
+        items[index].lastAlertedPrice = snapshot.lowestPrice
+        return MarketPriceAlert(name: item.name, price: snapshot.lowestPrice)
+    }
+
+    func setError(_ error: String, for itemID: Int) {
+        guard let index = items.firstIndex(where: { $0.id == itemID }) else { return }
+        items[index].error = error
+    }
+
+    func fetchPrice(from url: URL) async throws -> MarketPriceResult {
+        var request = URLRequest(url: url)
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        let (data, response) = try await session.data(for: request)
+
+        if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+            return .httpError(statusCode: http.statusCode, responseBytes: data.count)
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .malformed(responseBytes: data.count)
+        }
+        if let apiError = tornAPIError(in: json) {
+            return .apiError(apiError, responseBytes: data.count)
+        }
+
+        var listings: [(price: Int, amount: Int)] = []
+        if let itemMarket = json["itemmarket"] as? [String: Any],
+           let array = itemMarket["listings"] as? [[String: Any]] {
+            listings += array.compactMap {
+                guard let price = $0["price"] as? Int else { return nil }
+                return (price, $0["amount"] as? Int ?? 1)
+            }
+        } else if let array = json["itemmarket"] as? [[String: Any]] {
+            listings += array.compactMap {
+                guard let price = $0["cost"] as? Int else { return nil }
+                return (price, $0["quantity"] as? Int ?? 1)
+            }
+        }
+        if let array = json["bazaar"] as? [[String: Any]] {
+            listings += array.compactMap {
+                guard let price = $0["cost"] as? Int else { return nil }
+                return (price, $0["quantity"] as? Int ?? 1)
+            }
+        }
+
+        let sorted = listings.sorted { $0.price < $1.price }
+        guard let best = sorted.first else {
+            return .noListings(responseBytes: data.count)
+        }
+        return .success(
+            MarketPriceSnapshot(
+                lowestPrice: best.price,
+                lowestPriceQuantity: best.amount,
+                secondLowestPrice: sorted.count > 1 ? sorted[1].price : 0
+            ),
+            responseBytes: data.count
+        )
+    }
+}

--- a/MacTorn/MacTorn/ViewModels/UserSnapshotService.swift
+++ b/MacTorn/MacTorn/ViewModels/UserSnapshotService.swift
@@ -1,0 +1,313 @@
+import Foundation
+import os.log
+
+private let userSnapshotLogger = Logger(
+    subsystem: TornConstants.logSubsystem,
+    category: "UserSnapshotService"
+)
+
+struct UserHTTPResponse {
+    let data: Data
+    let statusCode: Int
+}
+
+enum UserServiceResult<Value> {
+    case success(Value, responseBytes: Int)
+    case apiError(TornAPIError, responseBytes: Int)
+    case malformed(responseBytes: Int)
+}
+
+struct UserSnapshotPayload {
+    let snapshot: TornResponse
+    let money: MoneyData
+    let battleStats: BattleStats
+    let recentAttacks: [AttackResult]?
+    let properties: [PropertyInfo]?
+    let stocks: [StockHolding]
+}
+
+struct UserActivityPayload {
+    let events: [TornEvent]?
+    let unreadMessages: Int?
+    let recentAttacks: [AttackResult]?
+}
+
+struct UserV2Payload {
+    let organizedCrime: OrganizedCrime2?
+    let refills: Refills?
+    let education: EducationStatus?
+    let bounties: [Bounty]
+}
+
+protocol UserSnapshotServicing: Sendable {
+    func load(_ url: URL) async throws -> UserHTTPResponse
+    func parseSnapshot(
+        data: Data,
+        requestedSelections: [String],
+        grantedSelections: [String]?
+    ) async -> UserServiceResult<UserSnapshotPayload>
+    func loadActivity(_ url: URL) async throws -> UserServiceResult<UserActivityPayload>
+    func loadUserV2(_ url: URL) async throws -> UserServiceResult<UserV2Payload>
+}
+
+/// Transport and decoding boundary for user-owned Torn endpoints. It does not know
+/// `AppState`, budgets, endpoint health, notifications or account publication rules.
+final class UserSnapshotService: UserSnapshotServicing, @unchecked Sendable {
+    private let session: NetworkSession
+
+    init(session: NetworkSession) {
+        self.session = session
+    }
+
+    func load(_ url: URL) async throws -> UserHTTPResponse {
+        var request = URLRequest(url: url)
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+        return UserHTTPResponse(data: data, statusCode: http.statusCode)
+    }
+
+    func parseSnapshot(
+        data: Data,
+        requestedSelections: [String],
+        grantedSelections: [String]?
+    ) async -> UserServiceResult<UserSnapshotPayload> {
+        await Task.detached(priority: .userInitiated) {
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return .malformed(responseBytes: data.count)
+            }
+            if let apiError = tornAPIError(in: json) {
+                return .apiError(apiError, responseBytes: data.count)
+            }
+            guard UserSnapshotContract.isSatisfied(
+                by: json,
+                requestedSelections: requestedSelections,
+                grantedSelections: grantedSelections
+            ) else {
+                return .malformed(responseBytes: data.count)
+            }
+
+            let snapshot: TornResponse
+            do {
+                snapshot = try JSONDecoder().decode(TornResponse.self, from: data)
+            } catch let DecodingError.keyNotFound(key, context) {
+                userSnapshotLogger.error(
+                    "TornResponse decode: missing key '\(key.stringValue)' at \(context.codingPath.map(\.stringValue).joined(separator: "."))"
+                )
+                return .malformed(responseBytes: data.count)
+            } catch let DecodingError.typeMismatch(_, context) {
+                userSnapshotLogger.error(
+                    "TornResponse decode: type mismatch at \(context.codingPath.map(\.stringValue).joined(separator: "."))"
+                )
+                return .malformed(responseBytes: data.count)
+            } catch {
+                userSnapshotLogger.error(
+                    "TornResponse decode failed: \(String(describing: type(of: error)))"
+                )
+                return .malformed(responseBytes: data.count)
+            }
+
+            let money = Self.parseMoney(json)
+            let battleStats = Self.parseBattleStats(json)
+            let attacks = Self.parseAttacks(json)
+            let properties = Self.parseProperties(json)
+            let stocks = Self.parseStocks(json)
+
+            return .success(
+                UserSnapshotPayload(
+                    snapshot: snapshot,
+                    money: money,
+                    battleStats: battleStats,
+                    recentAttacks: attacks,
+                    properties: properties,
+                    stocks: stocks
+                ),
+                responseBytes: data.count
+            )
+        }.value
+    }
+
+    func loadActivity(_ url: URL) async throws -> UserServiceResult<UserActivityPayload> {
+        let response = try await load(url)
+        let data = response.data
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .malformed(responseBytes: data.count)
+        }
+        if let apiError = tornAPIError(in: json) {
+            return .apiError(apiError, responseBytes: data.count)
+        }
+
+        let decoded = try? JSONDecoder().decode(TornResponse.self, from: data)
+        return .success(
+            UserActivityPayload(
+                events: decoded?.recentEvents,
+                unreadMessages: decoded?.unreadMessagesCount,
+                recentAttacks: Self.parseAttacks(json)
+            ),
+            responseBytes: data.count
+        )
+    }
+
+    func loadUserV2(_ url: URL) async throws -> UserServiceResult<UserV2Payload> {
+        let response = try await load(url)
+        let data = response.data
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .malformed(responseBytes: data.count)
+        }
+        if let apiError = tornAPIError(in: json) {
+            return .apiError(apiError, responseBytes: data.count)
+        }
+
+        let decoder = JSONDecoder()
+        var organizedCrime: OrganizedCrime2?
+        if let dictionary = json["organizedCrime"] as? [String: Any],
+           dictionary["id"] is Int,
+           let encoded = try? JSONSerialization.data(withJSONObject: dictionary) {
+            organizedCrime = try? decoder.decode(OrganizedCrime2.self, from: encoded)
+        }
+
+        var refills: Refills?
+        if let dictionary = json["refills"] as? [String: Any],
+           let encoded = try? JSONSerialization.data(withJSONObject: dictionary) {
+            refills = try? decoder.decode(Refills.self, from: encoded)
+        }
+
+        var education: EducationStatus?
+        if let dictionary = json["education"] as? [String: Any],
+           let encoded = try? JSONSerialization.data(withJSONObject: dictionary) {
+            education = try? decoder.decode(EducationStatus.self, from: encoded)
+        }
+
+        var bounties: [Bounty] = []
+        if let array = json["bounties"] as? [[String: Any]],
+           let encoded = try? JSONSerialization.data(withJSONObject: array) {
+            bounties = (try? decoder.decode([Bounty].self, from: encoded)) ?? []
+        }
+
+        return .success(
+            UserV2Payload(
+                organizedCrime: organizedCrime,
+                refills: refills,
+                education: education,
+                bounties: bounties
+            ),
+            responseBytes: data.count
+        )
+    }
+
+    private static func parseMoney(_ json: [String: Any]) -> MoneyData {
+        let cash = json["money_onhand"] as? Int ?? 0
+        let vault: Int
+        if let value = json["vault_amount"] as? Int {
+            vault = value
+        } else if let value = json["property_vault"] as? Int {
+            vault = value
+        } else if let money = json["money"] as? [String: Any] {
+            vault = money["vault"] as? Int ?? 0
+        } else {
+            vault = 0
+        }
+        return MoneyData(
+            cash: cash,
+            vault: vault,
+            points: json["points"] as? Int ?? 0,
+            tokens: json["donator"] as? Int ?? 0,
+            cayman: json["cayman_bank"] as? Int ?? 0
+        )
+    }
+
+    private static func parseBattleStats(_ json: [String: Any]) -> BattleStats {
+        BattleStats(
+            strength: json["strength"] as? Int ?? 0,
+            defense: json["defense"] as? Int ?? 0,
+            speed: json["speed"] as? Int ?? 0,
+            dexterity: json["dexterity"] as? Int ?? 0
+        )
+    }
+
+    private static func parseAttacks(_ json: [String: Any]) -> [AttackResult]? {
+        guard let attacks = json["attacks"] as? [String: [String: Any]] else { return nil }
+        return attacks.values.compactMap { attack in
+            guard let code = attack["code"] as? String else { return nil }
+            return AttackResult(
+                code: code,
+                timestampStarted: attack["timestamp_started"] as? Int,
+                timestampEnded: attack["timestamp_ended"] as? Int,
+                attackerId: attack["attacker_id"] as? Int,
+                attackerName: attack["attacker_name"] as? String,
+                defenderId: attack["defender_id"] as? Int,
+                defenderName: attack["defender_name"] as? String,
+                result: attack["result"] as? String,
+                respect: attack["respect"] as? Double
+            )
+        }.sorted { ($0.timestampEnded ?? 0) > ($1.timestampEnded ?? 0) }
+    }
+
+    private static func parseProperties(_ json: [String: Any]) -> [PropertyInfo]? {
+        guard let properties = json["properties"] as? [String: [String: Any]] else {
+            return nil
+        }
+        return properties.values.map { property in
+            let rented = property["rented"] as? [String: Any]
+            return PropertyInfo(
+                id: property["property_id"] as? Int ?? 0,
+                propertyType: property["property"] as? String ?? "",
+                status: property["status"] as? String ?? "",
+                cost: property["cost"] as? Int ?? 0,
+                marketprice: property["marketprice"] as? Int ?? 0,
+                happy: property["happy"] as? Int ?? 0,
+                rented: rented != nil,
+                rentDaysLeft: rented?["days_left"] as? Int
+            )
+        }
+    }
+
+    private static func parseStocks(_ json: [String: Any]) -> [StockHolding] {
+        guard let stocks = json["stocks"] as? [String: [String: Any]] else { return [] }
+        return stocks.values.compactMap { stock in
+            guard let data = try? JSONSerialization.data(withJSONObject: stock) else {
+                return nil
+            }
+            return try? JSONDecoder().decode(StockHolding.self, from: data)
+        }
+    }
+}
+
+/// Semantic contract for the v1 user snapshot. The evidence set is derived from
+/// selections requested by `user.fast` and selections granted by `/key/info`.
+enum UserSnapshotContract {
+    static func isSatisfied(
+        by json: [String: Any],
+        requestedSelections: [String],
+        grantedSelections: [String]?
+    ) -> Bool {
+        let requested = Set(requestedSelections)
+        let available = grantedSelections.map { requested.intersection(Set($0)) } ?? requested
+        guard !available.isEmpty else { return false }
+        return available.contains { hasEvidence(for: $0, in: json) }
+    }
+
+    private static func hasEvidence(for selection: String, in json: [String: Any]) -> Bool {
+        switch selection {
+        case "basic", "profile":
+            return json["name"] is String || json["player_id"] is NSNumber
+        case "bars":
+            return ["energy", "nerve", "life", "happy"].allSatisfy {
+                json[$0] is [String: Any]
+            }
+        case "cooldowns", "travel", "properties", "stocks":
+            return json[selection] is [String: Any]
+        case "money":
+            return ["money_onhand", "points", "cayman_bank", "vault_amount",
+                    "property_vault", "networth"].contains { json[$0] != nil }
+        case "battlestats":
+            return ["strength", "defense", "speed", "dexterity"].contains {
+                json[$0] is NSNumber
+            }
+        default:
+            return false
+        }
+    }
+}

--- a/MacTorn/MacTorn/Views/AttacksView.swift
+++ b/MacTorn/MacTorn/Views/AttacksView.swift
@@ -7,6 +7,15 @@ struct AttacksView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
+                ModuleStateView(
+                    state: appState.presentationState(
+                        endpointIDs: ["user.fast", "user.activity"],
+                        hasContent: appState.battleStats != nil || appState.recentAttacks != nil,
+                        staleAfter: 360
+                    ),
+                    onRetry: appState.refreshNow
+                )
+
                 // Battle Stats
                 VStack(alignment: .leading, spacing: 8) {
                     HStack {

--- a/MacTorn/MacTorn/Views/Components/FeedbackPromptView.swift
+++ b/MacTorn/MacTorn/Views/Components/FeedbackPromptView.swift
@@ -7,7 +7,7 @@ struct FeedbackPromptView: View {
     var body: some View {
         VStack(spacing: 16) {
             Image(systemName: "heart.fill")
-                .font(.system(size: 32))
+                .font(.title)
                 .foregroundStyle(
                     LinearGradient(
                         colors: [.pink, .red],

--- a/MacTorn/MacTorn/Views/Components/NextActionView.swift
+++ b/MacTorn/MacTorn/Views/Components/NextActionView.swift
@@ -1,85 +1,51 @@
 import SwiftUI
 
-/// The Next Action timeline card (Etap J): the single soonest event, prominently, plus a
-/// list of what follows. Counts down live via `TimelineView` off a shared clock — no
-/// extra timers or API calls. Hidden categories are filtered by AppState.
+/// A compact "what now" strip. Status already shows bars and cooldowns in detail, so this
+/// surface deliberately avoids repeating the full timeline.
 struct NextActionView: View {
     @Environment(AppState.self) private var appState
     var reduceTransparency: Bool = false
 
     var body: some View {
         TimelineView(.periodic(from: .now, by: 1)) { context in
-            let events = appState.nextEvents(now: context.date)
-            VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                    Image(systemName: "flag.checkered")
-                        .foregroundStyle(.secondary)
-                        .accessibilityHidden(true)
-                    Text("Next Action")
-                        .font(.caption.bold())
-                        .foregroundStyle(.secondary)
-                }
-
-                if let nearest = events.first {
-                    nearestRow(nearest)
-                    if events.count > 1 {
-                        Divider().opacity(0.5)
-                        VStack(spacing: 4) {
-                            ForEach(events.dropFirst().prefix(6)) { event in
-                                upcomingRow(event)
-                            }
-                        }
-                    }
-                } else {
-                    Text("Nothing pending — you're all caught up.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+            if let nearest = appState.nextEvents(now: context.date).first {
+                nearestRow(nearest)
             }
-            .padding(10)
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(Color.accentColor.opacity(reduceTransparency ? 0.14 : 0.08))
-            )
         }
     }
 
     private func nearestRow(_ event: NextEvent) -> some View {
-        HStack(spacing: 10) {
+        HStack(spacing: 9) {
             Image(systemName: event.systemImage)
-                .font(.title3)
+                .font(.body.weight(.semibold))
                 .foregroundStyle(.tint)
-                .frame(width: 24)
+                .frame(width: 20)
                 .accessibilityHidden(true)
-            VStack(alignment: .leading, spacing: 1) {
-                Text(event.title).font(.subheadline.weight(.semibold))
-                Text(event.isReady ? "ready now" : "in \(Self.formatETA(event.eta))")
-                    .font(.caption).foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Next")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text(event.title)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
             }
+
             Spacer()
+
             Text(event.isReady ? "now" : Self.formatETA(event.eta))
-                .font(.system(.body, design: .monospaced).weight(.semibold))
+                .font(.caption.monospacedDigit().weight(.semibold))
                 .foregroundStyle(event.isReady ? Color.green : Color.primary)
         }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.accentColor.opacity(reduceTransparency ? 0.14 : 0.08))
+        )
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Next: \(event.title), \(event.isReady ? "ready now" : "in \(Self.formatETA(event.eta))")")
-    }
-
-    private func upcomingRow(_ event: NextEvent) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: event.systemImage)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .frame(width: 18)
-                .accessibilityHidden(true)
-            Text(event.title).font(.caption)
-            Spacer()
-            Text(event.isReady ? "now" : Self.formatETA(event.eta))
-                .font(.caption.monospaced())
-                .foregroundStyle(.secondary)
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(event.title), \(event.isReady ? "ready now" : "in \(Self.formatETA(event.eta))")")
+        .uiTestID("uitest.nextAction")
     }
 
     /// Compact human countdown: "45s", "4:32", "2h 05m", "1d 3h".

--- a/MacTorn/MacTorn/Views/Components/ProgressBarView.swift
+++ b/MacTorn/MacTorn/Views/Components/ProgressBarView.swift
@@ -63,7 +63,11 @@ struct ProgressBarView: View {
                 }
             }
             .frame(height: 10)
+            .accessibilityHidden(true)
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(label)
+        .accessibilityValue("\(current) of \(maximum), \(Int(progress * 100)) percent")
     }
 }
 

--- a/MacTorn/MacTorn/Views/Components/SentryOptInPromptView.swift
+++ b/MacTorn/MacTorn/Views/Components/SentryOptInPromptView.swift
@@ -11,7 +11,7 @@ struct SentryOptInPromptView: View {
     var body: some View {
         VStack(spacing: 12) {
             Image(systemName: "ladybug.fill")
-                .font(.system(size: 32))
+                .font(.title)
                 .foregroundColor(.purple)
 
             Text("Help fix MacTorn bugs")

--- a/MacTorn/MacTorn/Views/ContentView.swift
+++ b/MacTorn/MacTorn/Views/ContentView.swift
@@ -135,7 +135,7 @@ struct ContentView: View {
                 SentryOptInPromptView(isPresented: $showSentryOptIn)
             }
         }
-        .frame(width: 320)
+        .frame(width: 320, height: 640, alignment: .top)
         .environment(\.openMacTornSettings, OpenMacTornSettingsAction {
             navigation.showSettings()
         })

--- a/MacTorn/MacTorn/Views/ContentView.swift
+++ b/MacTorn/MacTorn/Views/ContentView.swift
@@ -1,5 +1,31 @@
 import SwiftUI
 
+enum AppGroup: String, CaseIterable {
+    case now = "Now"
+    case account = "Account"
+    case watch = "Watch"
+
+    var icon: String {
+        switch self {
+        case .now: return "bolt.fill"
+        case .account: return "person.crop.circle"
+        case .watch: return "eye.fill"
+        }
+    }
+
+    var tabs: [AppTab] {
+        switch self {
+        case .now: return [.status, .travel, .attacks]
+        case .account: return [.money, .faction]
+        case .watch: return [.watchlist, .forums]
+        }
+    }
+
+    var defaultTab: AppTab {
+        tabs[0]
+    }
+}
+
 enum AppTab: String, CaseIterable {
     case status = "Status"
     case travel = "Travel"
@@ -20,28 +46,49 @@ enum AppTab: String, CaseIterable {
         case .forums: return "bubble.left.and.bubble.right.fill"
         }
     }
+
+    var group: AppGroup {
+        switch self {
+        case .status, .travel, .attacks: return .now
+        case .money, .faction: return .account
+        case .watchlist, .forums: return .watch
+        }
+    }
+}
+
+private enum NavigationFocus: Hashable {
+    case group(AppGroup)
+    case tab(AppTab)
+    case settings
+    case commands
+    case quit
 }
 
 struct ContentView: View {
     @Environment(AppState.self) private var appState
+    @Environment(AppNavigationState.self) private var navigation
     @Environment(\.reduceTransparency) private var reduceTransparency
-    @State private var showSettings = false
-    @State private var currentTab: AppTab = .status
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+    @FocusState private var navigationFocus: NavigationFocus?
     @State private var showSentryOptIn = false
-    
+
     var body: some View {
 
         ZStack {
             VStack(spacing: 0) {
-                if appState.apiKey.isEmpty || showSettings {
-                    SettingsView()
+                if appState.apiKey.isEmpty || navigation.isShowingSettings {
+                    SettingsView {
+                        _ = navigation.dismissSettings(hasConfiguredAccount: !appState.apiKey.isEmpty)
+                    }
                         .environment(appState)
                 } else {
                     // Header with last updated
                     headerView
                     
-                    // Tab bar
-                    tabBar
+                    // Two-level navigation: three stable groups and only the active
+                    // group's modules. Every destination is at most two actions away.
+                    groupBar
+                    modulePicker
                     
                     Divider()
                     
@@ -89,6 +136,10 @@ struct ContentView: View {
             }
         }
         .frame(width: 320)
+        .environment(\.openMacTornSettings, OpenMacTornSettingsAction {
+            navigation.showSettings()
+        })
+        .onExitCommand(perform: handleEscape)
         .onAppear {
             appState.startPolling()
             appState.startForumPolling()
@@ -117,32 +168,91 @@ struct ContentView: View {
         .padding(.top, 8)
     }
     
-    // MARK: - Tab Bar
-    private var tabBar: some View {
-        HStack(spacing: 4) {
-            ForEach(AppTab.allCases, id: \.self) { tab in
+    // MARK: - Navigation
+    private var currentGroup: AppGroup {
+        currentTab.group
+    }
+
+    private var selectedBackgroundOpacity: Double {
+        reduceTransparency || colorSchemeContrast == .increased ? 0.35 : 0.16
+    }
+
+    private var groupBar: some View {
+        HStack(spacing: 6) {
+            ForEach(AppGroup.allCases, id: \.self) { group in
                 Button {
-                    currentTab = tab
+                    guard currentGroup != group else { return }
+                    navigation.select(group.defaultTab)
                 } label: {
-                    VStack(spacing: 2) {
-                        Image(systemName: tab.icon)
-                            .font(.system(size: 14))
-                        Text(tab.rawValue)
-                            .font(.system(size: 8))
+                    Label {
+                        Text(group.rawValue)
+                            .font(.caption.weight(.semibold))
+                    } icon: {
+                        Image(systemName: group.icon)
+                            .font(.caption)
                     }
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, 6)
-                    .background(currentTab == tab ? Color.accentColor.opacity(reduceTransparency ? 0.3 : 0.2) : Color.clear)
+                    .padding(.vertical, 7)
+                    .background(currentGroup == group
+                                ? Color.accentColor.opacity(selectedBackgroundOpacity)
+                                : Color.clear)
                     .cornerRadius(6)
-                    .contentShape(Rectangle()) // Make entire area clickable
+                    .contentShape(Rectangle())
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(navigationFocus == .group(group)
+                                    ? Color.accentColor
+                                    : Color.clear,
+                                    lineWidth: 2)
+                    }
                 }
                 .buttonStyle(.plain)
-                .foregroundColor(currentTab == tab ? .accentColor : .secondary)
-                .uiTestID("uitest.tab.\(tab.rawValue)")
+                .focused($navigationFocus, equals: .group(group))
+                .foregroundColor(currentGroup == group ? .accentColor : .secondary)
+                .accessibilityLabel("\(group.rawValue) group")
+                .accessibilityAddTraits(currentGroup == group ? .isSelected : [])
+                .uiTestID("uitest.group.\(group.rawValue)")
             }
         }
         .padding(.horizontal, 8)
-        .padding(.vertical, 4)
+        .padding(.top, 5)
+        .padding(.bottom, 3)
+    }
+
+    private var modulePicker: some View {
+        HStack(spacing: 6) {
+            ForEach(currentGroup.tabs, id: \.self) { tab in
+                Button {
+                    navigation.select(tab)
+                } label: {
+                    Text(tab.rawValue)
+                        .font(.caption)
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 6)
+                        .background(currentTab == tab
+                                    ? Color.accentColor.opacity(selectedBackgroundOpacity)
+                                    : Color.secondary.opacity(reduceTransparency ? 0.12 : 0.06))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 5)
+                                .stroke(moduleBorderColor(for: tab),
+                                        lineWidth: navigationFocus == .tab(tab) ? 2 : 1)
+                        }
+                        .cornerRadius(5)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .focused($navigationFocus, equals: .tab(tab))
+                .foregroundColor(currentTab == tab ? .accentColor : .secondary)
+                .accessibilityLabel(tab.rawValue)
+                .accessibilityAddTraits(currentTab == tab ? .isSelected : [])
+                .uiTestID("uitest.tab.\(tab.rawValue)")
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(currentGroup.rawValue) modules")
+        .padding(.horizontal, 8)
+        .padding(.bottom, 5)
     }
     
     // MARK: - Tab Content
@@ -185,25 +295,98 @@ struct ContentView: View {
     private var footerView: some View {
         HStack {
             if !appState.apiKey.isEmpty {
-                Button(showSettings ? "Back" : "Settings") {
-                    showSettings.toggle()
+                Button(navigation.isShowingSettings ? "Back" : "Settings") {
+                    navigation.toggleSettings()
                 }
                 .buttonStyle(.plain)
+                .focused($navigationFocus, equals: .settings)
                 .foregroundColor(.secondary)
                 .uiTestID("uitest.openSettings")
             }
             
             Spacer()
-            
+
+            commandMenu
+
             Button("Quit") {
                 NSApplication.shared.terminate(nil)
             }
             .buttonStyle(.plain)
+            .focused($navigationFocus, equals: .quit)
             .foregroundColor(.secondary)
         }
         .font(.caption)
         .padding(.horizontal)
         .padding(.bottom, 8)
+    }
+
+    private var commandMenu: some View {
+        Menu {
+            commandButton(.refresh)
+
+            Divider()
+
+            ForEach(MacTornCommand.navigation) { command in
+                commandButton(command)
+            }
+
+            Divider()
+
+            commandButton(.settings)
+        } label: {
+            Label("Commands", systemImage: "command")
+                .labelStyle(.titleAndIcon)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .focused($navigationFocus, equals: .commands)
+        .accessibilityLabel("Commands")
+        .accessibilityHint("Refresh, open Settings, or go directly to a module")
+    }
+
+    private func commandButton(_ command: MacTornCommand) -> some View {
+        Button(command.title) {
+            perform(command)
+        }
+        .keyboardShortcut(KeyEquivalent(command.keyEquivalent), modifiers: .command)
+        .disabled(command != .settings && appState.apiKey.isEmpty)
+    }
+
+    private func perform(_ command: MacTornCommand) {
+        switch command {
+        case .refresh:
+            appState.refreshNow()
+        case .settings:
+            navigation.showSettings()
+        default:
+            if let tab = command.tab {
+                navigation.select(tab)
+            }
+        }
+    }
+
+    private func handleEscape() {
+        if showSentryOptIn {
+            let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+            UserDefaults.standard.set(version, forKey: SentryManager.promptShownKey)
+            showSentryOptIn = false
+            return
+        }
+        if appState.showFeedbackPrompt {
+            appState.feedbackDismissed()
+            return
+        }
+        _ = navigation.dismissSettings(hasConfiguredAccount: !appState.apiKey.isEmpty)
+    }
+
+    private func moduleBorderColor(for tab: AppTab) -> Color {
+        if navigationFocus == .tab(tab) {
+            return .accentColor
+        }
+        if currentTab == tab && colorSchemeContrast == .increased {
+            return .accentColor
+        }
+        return .clear
     }
     
     private func checkSentryOptInPrompt() {
@@ -221,4 +404,8 @@ struct ContentView: View {
         formatter.timeStyle = .short
         return formatter
     }()
+
+    private var currentTab: AppTab {
+        navigation.selectedTab
+    }
 }

--- a/MacTorn/MacTorn/Views/CreditsView.swift
+++ b/MacTorn/MacTorn/Views/CreditsView.swift
@@ -24,7 +24,7 @@ struct CreditsView: View {
             // Header
             VStack(spacing: 8) {
                 Image(systemName: "heart.fill")
-                    .font(.system(size: 36))
+                    .font(.largeTitle)
                     .foregroundStyle(
                         LinearGradient(
                             colors: [.pink, .red],

--- a/MacTorn/MacTorn/Views/DiagnosticsView.swift
+++ b/MacTorn/MacTorn/Views/DiagnosticsView.swift
@@ -153,3 +153,99 @@ struct DiagnosticsView: View {
         }
     }
 }
+
+/// Shared, compact status for feature modules. Successful cached content stays visible
+/// during transient failures; this view only adds freshness and a recovery action.
+struct ModuleStateView: View {
+    let state: ModulePresentationState
+    let onRetry: () -> Void
+
+    @Environment(\.openMacTornSettings) private var openSettings
+
+    var body: some View {
+        HStack(spacing: 6) {
+            if state.kind == .loading {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Image(systemName: icon)
+                    .foregroundStyle(color)
+                    .accessibilityHidden(true)
+            }
+
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(state.kind == .fresh ? Color.secondary : color)
+
+            Spacer(minLength: 4)
+
+            switch state.recovery {
+            case .retry:
+                Button("Retry", action: onRetry)
+                    .buttonStyle(.plain)
+                    .font(.caption2.weight(.semibold))
+            case .settings:
+                Button("Settings") { openSettings() }
+                    .buttonStyle(.plain)
+                    .font(.caption2.weight(.semibold))
+            case .none:
+                EmptyView()
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(color.opacity(state.kind == .fresh ? 0.06 : 0.12))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(label)
+    }
+
+    private var label: String {
+        switch state.kind {
+        case .loading:
+            return "Loading data"
+        case .empty:
+            return "No data yet"
+        case .fresh:
+            return state.updatedAt.map { "Updated \(relativeDate($0))" } ?? "Data available"
+        case .stale:
+            return state.updatedAt.map { "Stale · updated \(relativeDate($0))" } ?? "Data may be stale"
+        case .offline:
+            return state.hasContent ? "Offline · showing last data" : "No internet connection"
+        case .permission:
+            return state.hasContent ? "Permission changed · showing last data" : "API permission required"
+        case .rateLimited:
+            return state.hasContent ? "Rate limited · showing last data" : "Rate limited · retry shortly"
+        case .error:
+            return "Couldn’t refresh this module"
+        }
+    }
+
+    private var icon: String {
+        switch state.kind {
+        case .loading: return "clock"
+        case .empty: return "tray"
+        case .fresh: return "checkmark.circle.fill"
+        case .stale: return "clock.badge.exclamationmark"
+        case .offline: return "wifi.slash"
+        case .permission: return "lock.trianglebadge.exclamationmark"
+        case .rateLimited: return "hourglass"
+        case .error: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var color: Color {
+        switch state.kind {
+        case .fresh: return .green
+        case .loading, .empty: return .secondary
+        case .stale, .offline, .rateLimited: return .orange
+        case .permission, .error: return .red
+        }
+    }
+
+    private func relativeDate(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}

--- a/MacTorn/MacTorn/Views/FactionView.swift
+++ b/MacTorn/MacTorn/Views/FactionView.swift
@@ -7,6 +7,18 @@ struct FactionView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
+                ModuleStateView(
+                    state: appState.presentationState(
+                        endpointIDs: ["faction.basic", "faction.rankedwars", "faction.news", "user.v2"],
+                        hasContent: appState.factionData != nil
+                            || appState.organizedCrime != nil
+                            || !appState.rankedWars.isEmpty
+                            || !appState.factionNews.isEmpty,
+                        staleAfter: 360
+                    ),
+                    onRetry: appState.refreshNow
+                )
+
                 // Faction Info
                 VStack(alignment: .leading, spacing: 8) {
                     if let faction = appState.factionData {
@@ -363,7 +375,7 @@ struct ArmoryButton: View {
         Button(action: action) {
             VStack(spacing: 2) {
                 Image(systemName: icon)
-                    .font(.system(size: 14))
+                    .font(.caption)
                 Text(title)
                     .font(.caption2)
             }

--- a/MacTorn/MacTorn/Views/ForumWatchView.swift
+++ b/MacTorn/MacTorn/Views/ForumWatchView.swift
@@ -5,10 +5,17 @@ struct ForumWatchView: View {
     @Environment(\.reduceTransparency) private var reduceTransparency
     @State private var showAddThread = false
     @State private var threadInput = ""
+    @State private var threadInputError: String?
+    @State private var recentlyRemoved: RemovedWatchedThread?
+    @State private var undoDismissTask: Task<Void, Never>?
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
+                ModuleStateView(state: moduleState) {
+                    appState.refreshForumWatch()
+                }
+
                 // Header
                 HStack {
                     Image(systemName: "bubble.left.and.bubble.right.fill")
@@ -25,6 +32,7 @@ struct ForumWatchView: View {
                             .foregroundColor(.blue)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Refresh watched threads")
 
                     Button {
                         withAnimation {
@@ -35,6 +43,7 @@ struct ForumWatchView: View {
                             .foregroundColor(showAddThread ? .red : .green)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel(showAddThread ? "Close add thread form" : "Add watched thread")
                 }
 
                 // Add Thread Section
@@ -48,6 +57,9 @@ struct ForumWatchView: View {
                             TextField("forums.php...t=12345 or 12345", text: $threadInput)
                                 .textFieldStyle(.roundedBorder)
                                 .font(.caption)
+                                .onChange(of: threadInput) { _, _ in
+                                    threadInputError = nil
+                                }
                                 .onSubmit {
                                     addThread()
                                 }
@@ -57,7 +69,14 @@ struct ForumWatchView: View {
                             }
                             .buttonStyle(.borderedProminent)
                             .controlSize(.small)
-                            .disabled(threadInput.isEmpty)
+                            .disabled(threadInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        }
+
+                        if let threadInputError {
+                            Text(threadInputError)
+                                .font(.caption2)
+                                .foregroundStyle(.red)
+                                .accessibilityLabel("Thread input error: \(threadInputError)")
                         }
                     }
                     .padding(8)
@@ -104,10 +123,17 @@ struct ForumWatchView: View {
                                 appState.toggleThreadNotifications(thread.id)
                             },
                             onRemove: {
-                                appState.removeWatchedThread(thread.id)
+                                removeWithUndo(thread)
                             }
                         )
                     }
+                }
+
+                if let recentlyRemoved {
+                    UndoBanner(message: "\(recentlyRemoved.thread.title) removed") {
+                        undoRemoval()
+                    }
+                    .transition(.move(edge: .top).combined(with: .opacity))
                 }
 
                 Divider()
@@ -128,12 +154,31 @@ struct ForumWatchView: View {
             .padding()
         }
         .fixedSize(horizontal: false, vertical: true)
+        .onDisappear {
+            undoDismissTask?.cancel()
+            recentlyRemoved = nil
+        }
+    }
+
+    private var moduleState: ModulePresentationState {
+        appState.presentationState(
+            endpointIDs: ["forum.thread"],
+            hasContent: !appState.watchedThreads.isEmpty,
+            staleAfter: TimeInterval(max(appState.forumWatchConfig.pollingIntervalSeconds, 180))
+        )
     }
 
     private func addThread() {
-        guard !threadInput.isEmpty else { return }
-        appState.addWatchedThread(input: threadInput)
+        guard appState.parseThreadInput(threadInput) != nil else {
+            threadInputError = "Enter a positive thread ID or Torn forum URL."
+            return
+        }
+        guard appState.addWatchedThread(input: threadInput) else {
+            threadInputError = "This thread is already being watched."
+            return
+        }
         threadInput = ""
+        threadInputError = nil
         withAnimation {
             showAddThread = false
         }
@@ -148,6 +193,41 @@ struct ForumWatchView: View {
             BrowserManager.shared.open(url)
         }
     }
+
+    private func removeWithUndo(_ thread: WatchedThread) {
+        guard let index = appState.watchedThreads.firstIndex(where: { $0.id == thread.id }) else {
+            return
+        }
+        let removedThread = appState.watchedThreads[index]
+
+        undoDismissTask?.cancel()
+        appState.removeWatchedThread(thread.id)
+        withAnimation {
+            recentlyRemoved = RemovedWatchedThread(thread: removedThread, index: index)
+        }
+        undoDismissTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 6_000_000_000)
+            guard !Task.isCancelled else { return }
+            withAnimation {
+                recentlyRemoved = nil
+            }
+        }
+    }
+
+    private func undoRemoval() {
+        guard let recentlyRemoved else { return }
+
+        undoDismissTask?.cancel()
+        appState.restoreWatchedThread(recentlyRemoved.thread, at: recentlyRemoved.index)
+        withAnimation {
+            self.recentlyRemoved = nil
+        }
+    }
+}
+
+private struct RemovedWatchedThread {
+    let thread: WatchedThread
+    let index: Int
 }
 
 // MARK: - Forum Thread Row
@@ -207,6 +287,9 @@ struct ForumThreadRow: View {
             }
             .buttonStyle(.plain)
             .help(thread.notificationsEnabled ? "Notifications on" : "Notifications off")
+            .accessibilityLabel(thread.notificationsEnabled
+                                ? "Disable notifications for \(thread.title)"
+                                : "Enable notifications for \(thread.title)")
 
             // Remove button
             Button {
@@ -217,10 +300,25 @@ struct ForumThreadRow: View {
                     .foregroundColor(.secondary)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Remove \(thread.title) from watched threads")
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)
         .background(Color.gray.opacity(reduceTransparency ? 0.3 : 0.05))
         .cornerRadius(4)
+    }
+}
+
+extension AppState {
+    @discardableResult
+    func restoreWatchedThread(_ thread: WatchedThread, at originalIndex: Int) -> Bool {
+        guard !watchedThreads.contains(where: { $0.id == thread.id }) else {
+            return false
+        }
+
+        let insertionIndex = min(max(originalIndex, 0), watchedThreads.count)
+        watchedThreads.insert(thread, at: insertionIndex)
+        saveForumWatch()
+        return true
     }
 }

--- a/MacTorn/MacTorn/Views/MoneyView.swift
+++ b/MacTorn/MacTorn/Views/MoneyView.swift
@@ -7,6 +7,14 @@ struct MoneyView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
+                ModuleStateView(
+                    state: appState.presentationState(
+                        endpointIDs: ["user.fast"],
+                        hasContent: appState.moneyData != nil,
+                        staleAfter: 120
+                    ),
+                    onRetry: appState.refreshNow
+                )
 
                 // MARK: - Cash Section
                 VStack(alignment: .leading, spacing: 8) {
@@ -254,7 +262,7 @@ struct ActionButton: View {
         Button(action: action) {
             VStack(spacing: 4) {
                 Image(systemName: icon)
-                    .font(.system(size: 16))
+                    .font(.body)
                 Text(title)
                     .font(.caption2)
             }

--- a/MacTorn/MacTorn/Views/SettingsView.swift
+++ b/MacTorn/MacTorn/Views/SettingsView.swift
@@ -1,5 +1,57 @@
 import SwiftUI
 
+enum SettingsSection: String, CaseIterable, Identifiable {
+    case account
+    case refresh
+    case notifications
+    case privacy
+    case startup
+    case diagnostics
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .account: return "Account"
+        case .refresh: return "Refresh"
+        case .notifications: return "Notifications"
+        case .privacy: return "Privacy"
+        case .startup: return "Startup"
+        case .diagnostics: return "Diagnostics & About"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .account: return "person.crop.circle"
+        case .refresh: return "arrow.clockwise"
+        case .notifications: return "bell"
+        case .privacy: return "lock.shield"
+        case .startup: return "power"
+        case .diagnostics: return "stethoscope"
+        }
+    }
+
+    var anchorID: String {
+        "settings.section.\(rawValue)"
+    }
+
+    var compactTitle: String {
+        switch self {
+        case .account: return "Account"
+        case .refresh: return "Refresh"
+        case .notifications: return "Alerts"
+        case .privacy: return "Privacy"
+        case .startup: return "Startup"
+        case .diagnostics: return "About"
+        }
+    }
+}
+
+private enum SettingsFocus: Hashable {
+    case apiKey
+}
+
 struct SettingsView: View {
     @Environment(AppState.self) private var appState
     @AppStorage("appearanceMode") private var appearanceMode: String = AppearanceMode.system.rawValue
@@ -9,346 +61,55 @@ struct SettingsView: View {
     @AppStorage("privateIsland") private var privateIsland: Bool = false
     @AppStorage(SentryManager.enabledKey) private var sentryEnabled: Bool = false
     @State private var inputKey: String = ""
-    @State private var showCredits: Bool = false
-    @State private var showDiagnostics: Bool = false
+    @State private var showCredits = false
+    @State private var showDiagnostics = false
+    @State private var selectedSection: SettingsSection = .account
     @State private var availableBrowsers: [PreferredBrowser] = PreferredBrowser.availableBrowsers()
+    @FocusState private var settingsFocus: SettingsFocus?
 
+    private let onDismiss: () -> Void
     private let developerID = TornConstants.developerID
 
+    init(onDismiss: @escaping () -> Void = {}) {
+        self.onDismiss = onDismiss
+    }
+
     var body: some View {
-        if showCredits {
-            CreditsView(showCredits: $showCredits)
-        } else {
-            settingsContent
+        Group {
+            if showCredits {
+                CreditsView(showCredits: $showCredits)
+            } else {
+                settingsContent
+            }
         }
+        .onExitCommand(perform: handleEscape)
     }
 
     private var settingsContent: some View {
-        // @Bindable creates write-back bindings on @Observable model fields. Shadowing
-        // the existing `appState` lets us use `$appState.refreshInterval` inline below
-        // without changing the SwiftUI binding syntax at call sites.
-        @Bindable var appState = appState
-        return VStack(spacing: 20) {
-            // Header
-            Image(systemName: "bolt.circle.fill")
-                .font(.system(size: 48))
-                .foregroundStyle(
-                    LinearGradient(
-                        colors: [.orange, .yellow],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                )
-            
-            Text("MacTorn")
-                .font(.title2.bold())
-            
-            // API Key section
-            VStack(spacing: 8) {
-                SecureField("Torn API Key", text: $inputKey)
-                    .textFieldStyle(.roundedBorder)
-                    .uiTestID("uitest.apiKeyField")
+        VStack(alignment: .leading, spacing: 10) {
+            settingsHeader
+            sectionPicker
 
-                Button("Save & Connect") {
-                    appState.apiKey = inputKey.trimmingCharacters(in: .whitespacesAndNewlines)
-                    appState.refreshNow()
+            ScrollView {
+                settingsSection(selectedSection) {
+                    selectedSectionContent
                 }
-                .buttonStyle(.borderedProminent)
-                .disabled(inputKey.isEmpty)
-                .uiTestID("uitest.saveKey")
-
-                Button {
-                    // Validate the typed key WITHOUT saving it — saving would set apiKey,
-                    // which flips ContentView off the Settings screen during onboarding
-                    // before the result panel is seen. Falls back to the saved key.
-                    let typed = inputKey.trimmingCharacters(in: .whitespacesAndNewlines)
-                    Task { await appState.validateKey(typed.isEmpty ? nil : typed) }
-                } label: {
-                    if appState.keyValidation == .validating {
-                        HStack(spacing: 6) {
-                            ProgressView().controlSize(.small)
-                            Text("Testing…")
-                        }
-                    } else {
-                        Text("Test Connection")
-                    }
-                }
-                .buttonStyle(.bordered)
-                .disabled(appState.keyValidation == .validating
-                          || (inputKey.isEmpty && appState.apiKey.isEmpty))
-                .uiTestID("uitest.testConnection")
-
-                keyValidationResult
-
-                Link("Get API Key from Torn",
-                     destination: URL(string: "https://www.torn.com/preferences.php#tab=api")!)
-                    .font(.caption)
+                .id(selectedSection)
             }
-            .padding(.horizontal)
-
-            // API ToS Compliance
-            apiUsageDisclosure
-
-            Divider()
-            
-            // Settings
-            VStack(spacing: 12) {
-                // Refresh Interval
-                HStack {
-                    Image(systemName: "clock")
-                        .foregroundColor(.secondary)
-                        .frame(width: 20)
-                    
-                    Picker("Refresh", selection: $appState.refreshInterval) {
-                        Text("15s ⚡︎").tag(15)
-                        Text("30s").tag(30)
-                        Text("60s").tag(60)
-                        Text("2m").tag(120)
-                    }
-                    .pickerStyle(.segmented)
-                    .onChange(of: appState.refreshInterval) { _, _ in
-                        Task { @MainActor in
-                            appState.startPolling()
-                        }
-                    }
-                }
-                if appState.refreshInterval == 15 {
-                    Text("⚡︎ Aggressive: Torn may return cached data for up to ~30s, so 15s can spend API budget without fresher data. 30s is recommended.")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                nextActionConfigSection
-
-                // Launch at Login
-                HStack {
-                    Image(systemName: "power")
-                        .foregroundColor(.secondary)
-                        .frame(width: 20)
-                    Toggle("Launch at Login", isOn: Binding(
-                        get: { appState.launchAtLogin.isEnabled },
-                        set: { _ in appState.launchAtLogin.toggle() }
-                    ))
-                    .toggleStyle(.switch)
-                }
-
-                // Appearance Mode
-                HStack {
-                    Image(systemName: "moon.circle")
-                        .foregroundColor(.secondary)
-                        .frame(width: 20)
-
-                    Picker("Appearance", selection: $appearanceMode) {
-                        ForEach(AppearanceMode.allCases, id: \.self) { mode in
-                            Text(mode.rawValue).tag(mode.rawValue)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .labelsHidden()
-                }
-
-                // Preferred Browser
-                HStack {
-                    Image(systemName: "globe")
-                        .foregroundColor(.secondary)
-                        .frame(width: 20)
-
-                    Picker("Preferred Browser", selection: $preferredBrowser) {
-                        ForEach(availableBrowsers) { browser in
-                            Text(browser.rawValue).tag(browser.rawValue)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                }
-
-                // Reduce Transparency (Accessibility)
-                HStack {
-                    Image(systemName: "eye")
-                        .foregroundColor(.secondary)
-                        .frame(width: 20)
-                    Toggle("Reduce Transparency", isOn: $reduceTransparency)
-                        .toggleStyle(.switch)
-                }
-
-                // Booster Cooldown Target
-                HStack {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .foregroundColor(.secondary)
-                        .frame(width: 20)
-
-                    Picker("Booster cooldown link", selection: $boosterCooldownTarget) {
-                        Text("Boosters").tag("boosters")
-                        Text("Alcohol").tag("alcohol")
-                    }
-                    .pickerStyle(.segmented)
-                }
-
-                // Private Island
-                HStack {
-                    Text("🏝️")
-                        .frame(width: 20)
-                    Toggle("Private Island (return icon)", isOn: $privateIsland)
-                        .toggleStyle(.switch)
-                }
-
-                // Forum Polling Interval
-                HStack {
-                    Image(systemName: "bubble.left.and.bubble.right")
-                        .foregroundColor(.secondary)
-                        .frame(width: 20)
-
-                    Picker("Forum check", selection: Binding(
-                        get: { appState.forumWatchConfig.pollingIntervalSeconds },
-                        set: { newValue in
-                            appState.forumWatchConfig.pollingIntervalSeconds = newValue
-                            appState.saveForumWatch()
-                            appState.startForumPolling()
-                        }
-                    )) {
-                        Text("2m").tag(120)
-                        Text("3m").tag(180)
-                        Text("5m").tag(300)
-                    }
-                    .pickerStyle(.segmented)
-                }
-
-                // Crash reporting (opt-in)
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Image(systemName: "ladybug")
-                            .foregroundColor(.secondary)
-                            .frame(width: 20)
-                        Toggle("Send crash reports", isOn: $sentryEnabled)
-                            .toggleStyle(.switch)
-                            .onChange(of: sentryEnabled) { _, _ in
-                                SentryManager.applyState()
-                            }
-                    }
-                    Text("Anonymous crash + error reports help fix bugs. API keys and player data are never sent.")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                        .padding(.leading, 28)
-                }
-            }
-            .padding(.horizontal)
-
-            Divider()
-
-            // Support section
-            VStack(spacing: 8) {
-                HStack(spacing: 4) {
-                    Image(systemName: "gift.fill")
-                        .foregroundColor(.purple)
-                    Text("Support the Developer")
-                        .font(.caption.bold())
-                }
-                
-                Text("Send me some Xanax or cash :)")
-                    .font(.caption2)
-                    .foregroundColor(.secondary)
-                
-                Button {
-                    openTornProfile()
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "paperplane.fill")
-                        Text("Send to bombel")
-                    }
-                    .font(.caption)
-                    .padding(.vertical, 6)
-                    .padding(.horizontal, 12)
-                    .background(Color.purple.opacity(reduceTransparency ? 0.4 : 0.15))
-                    .cornerRadius(6)
-                }
-                .buttonStyle(.plain)
-            }
-            .padding(.vertical, 8)
-            .padding(.horizontal)
-            .background(Color.purple.opacity(reduceTransparency ? 0.25 : 0.05))
-            .cornerRadius(8)
-
-            // Update Section
-            if let update = appState.updateAvailable {
-                VStack(spacing: 8) {
-                    HStack {
-                        Image(systemName: "arrow.triangle.2.circlepath")
-                            .foregroundColor(.green)
-                        Text("New version available: \(update.tagName)")
-                            .font(.caption.bold())
-                    }
-                    
-                    Button("Download Update") {
-                        if let url = URL(string: update.htmlUrl) {
-                            BrowserManager.shared.open(url)
-                        }
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-                }
-                .padding(10)
-                .frame(maxWidth: .infinity)
-                .background(Color.green.opacity(reduceTransparency ? 0.4 : 0.1))
-                .cornerRadius(8)
-            }
-
-            // GitHub & Version
-            VStack(spacing: 4) {
-                HStack(spacing: 12) {
-                    HStack(spacing: 4) {
-                        Image(systemName: "chevron.left.forwardslash.chevron.right")
-                            .font(.caption2)
-                            .foregroundColor(.gray)
-                        Link("View on GitHub",
-                             destination: URL(string: "https://github.com/pawelorzech/MacTorn")!)
-                            .font(.caption)
-                    }
-
-                    Button {
-                        showCredits = true
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: "heart.fill")
-                                .font(.caption2)
-                                .foregroundColor(.pink)
-                            Text("Credits")
-                                .font(.caption)
-                        }
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundColor(.accentColor)
-
-                    Button {
-                        showDiagnostics = true
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: "stethoscope")
-                                .font(.caption2)
-                            Text("Diagnostics")
-                                .font(.caption)
-                        }
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundColor(.accentColor)
-                    .accessibilityIdentifier("settings.diagnostics")
-                }
-
-                if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
-                    Text("v\(version)")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                        .opacity(0.5)
-                }
-            }
+            .scrollIndicators(.automatic)
         }
-        .padding()
+        .padding(12)
         .frame(width: 320)
+        .frame(height: 500, alignment: .top)
         .onAppear {
             inputKey = appState.apiKey
             refreshAvailableBrowsers()
         }
         .sheet(isPresented: $showDiagnostics) {
             DiagnosticsView(appState: appState)
+                .onExitCommand {
+                    showDiagnostics = false
+                }
         }
         .alert("Launch at Login Error", isPresented: Binding(
             get: { appState.launchAtLogin.errorMessage != nil },
@@ -362,6 +123,367 @@ struct SettingsView: View {
         }
     }
 
+    private var settingsHeader: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "bolt.circle.fill")
+                .font(.title)
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: [.orange, .yellow],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text("MacTorn")
+                    .font(.title2.bold())
+                Text("Settings")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if !appState.apiKey.isEmpty {
+                Button("Done", action: onDismiss)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private var sectionPicker: some View {
+        LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(), spacing: 6), count: 3),
+            spacing: 6
+        ) {
+            ForEach(SettingsSection.allCases) { section in
+                Button {
+                    selectedSection = section
+                } label: {
+                    VStack(spacing: 3) {
+                        Image(systemName: section.icon)
+                            .font(.caption)
+                        Text(section.compactTitle)
+                            .font(.caption2.weight(.medium))
+                            .lineLimit(1)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6)
+                    .background(
+                        selectedSection == section
+                            ? Color.accentColor.opacity(reduceTransparency ? 0.28 : 0.14)
+                            : Color.secondary.opacity(reduceTransparency ? 0.12 : 0.06)
+                    )
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(
+                                selectedSection == section
+                                    ? Color.accentColor.opacity(0.65)
+                                    : Color.clear
+                            )
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(selectedSection == section ? Color.accentColor : Color.secondary)
+                .accessibilityLabel(section.title)
+                .accessibilityAddTraits(selectedSection == section ? .isSelected : [])
+                .uiTestID(section.anchorID)
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Settings sections")
+    }
+
+    @ViewBuilder
+    private var selectedSectionContent: some View {
+        switch selectedSection {
+        case .account:
+            accountSection
+        case .refresh:
+            refreshSection
+        case .notifications:
+            notificationsSection
+        case .privacy:
+            privacySection
+        case .startup:
+            startupSection
+        case .diagnostics:
+            diagnosticsSection
+        }
+    }
+
+    private func settingsSection<Content: View>(
+        _ section: SettingsSection,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label(section.title, systemImage: section.icon)
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+
+            content()
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.secondary.opacity(reduceTransparency ? 0.14 : 0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .accessibilityElement(children: .contain)
+        .id(section.anchorID)
+        .uiTestID("uitest.settingsContent.\(section.rawValue)")
+    }
+
+    private var accountSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SecureField("Torn API Key", text: $inputKey)
+                .textFieldStyle(.roundedBorder)
+                .focused($settingsFocus, equals: .apiKey)
+                .accessibilityLabel("Torn API Key")
+                .uiTestID("uitest.apiKeyField")
+
+            HStack(spacing: 8) {
+                Button("Save & Connect") {
+                    appState.apiKey = inputKey.trimmingCharacters(in: .whitespacesAndNewlines)
+                    appState.refreshNow()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(trimmedInputKey.isEmpty)
+                .uiTestID("uitest.saveKey")
+
+                Button {
+                    let typed = trimmedInputKey
+                    Task { await appState.validateKey(typed.isEmpty ? nil : typed) }
+                } label: {
+                    if appState.keyValidation == .validating {
+                        HStack(spacing: 5) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Testing…")
+                        }
+                    } else {
+                        Text("Test Connection")
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(appState.keyValidation == .validating
+                          || (trimmedInputKey.isEmpty && appState.apiKey.isEmpty))
+                .uiTestID("uitest.testConnection")
+            }
+            .controlSize(.small)
+
+            keyValidationResult
+
+            Link(
+                "Get API Key from Torn",
+                destination: URL(string: "https://www.torn.com/preferences.php#tab=api")!
+            )
+            .font(.caption)
+        }
+    }
+
+    private var refreshSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Picker("Main refresh", selection: refreshIntervalBinding) {
+                Text("15s ⚡︎").tag(15)
+                Text("30s").tag(30)
+                Text("60s").tag(60)
+                Text("2m").tag(120)
+            }
+            .pickerStyle(.segmented)
+
+            if appState.refreshInterval == 15 {
+                Text("Torn may cache data for about 30 seconds. A 15-second interval can spend API budget without returning fresher data; 30 seconds is recommended.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Picker("Forum check", selection: forumPollingBinding) {
+                Text("2m").tag(120)
+                Text("3m").tag(180)
+                Text("5m").tag(300)
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
+    private var notificationsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            nextActionConfigSection
+
+            Picker("Booster cooldown link", selection: $boosterCooldownTarget) {
+                Text("Boosters").tag("boosters")
+                Text("Alcohol").tag("alcohol")
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
+    private var privacySection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            apiUsageDisclosure
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 3) {
+                Toggle("Send crash reports", isOn: $sentryEnabled)
+                    .toggleStyle(.switch)
+                    .onChange(of: sentryEnabled) { _, _ in
+                        SentryManager.applyState()
+                    }
+                Text("Anonymous crash and error reports help fix bugs. API keys and player data are never sent.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var startupSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle("Launch at Login", isOn: Binding(
+                get: { appState.launchAtLogin.isEnabled },
+                set: { _ in appState.launchAtLogin.toggle() }
+            ))
+            .toggleStyle(.switch)
+
+            Picker("Appearance", selection: $appearanceMode) {
+                ForEach(AppearanceMode.allCases, id: \.self) { mode in
+                    Text(mode.rawValue).tag(mode.rawValue)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Picker("Preferred Browser", selection: $preferredBrowser) {
+                ForEach(availableBrowsers) { browser in
+                    Text(browser.rawValue).tag(browser.rawValue)
+                }
+            }
+            .pickerStyle(.menu)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Toggle("Private Island return icon", isOn: $privateIsland)
+                    .toggleStyle(.switch)
+                Text("Shows the Private Island shortcut for the return trip. Quick Travel time is selected separately.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            Toggle("Reduce Transparency", isOn: $reduceTransparency)
+                .toggleStyle(.switch)
+        }
+    }
+
+    private var diagnosticsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if let update = appState.updateAvailable {
+                VStack(alignment: .leading, spacing: 6) {
+                    Label(
+                        "New version available: \(update.tagName)",
+                        systemImage: "arrow.triangle.2.circlepath"
+                    )
+                    .font(.caption.bold())
+                    .foregroundStyle(.green)
+
+                    Button("Download Update") {
+                        if let url = URL(string: update.htmlUrl) {
+                            BrowserManager.shared.open(url)
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                }
+            }
+
+            HStack(spacing: 8) {
+                Button("Diagnostics") {
+                    showDiagnostics = true
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .accessibilityIdentifier("settings.diagnostics")
+
+                Button("Credits") {
+                    showCredits = true
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Link(
+                    "GitHub",
+                    destination: URL(string: "https://github.com/pawelorzech/MacTorn")!
+                )
+                .font(.caption)
+            }
+
+            Divider()
+
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Support the Developer")
+                        .font(.caption.bold())
+                    Text("Send me some Xanax or cash :)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Button("Send to bombel") {
+                    openTornProfile()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
+            if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+                Text("MacTorn v\(version)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var refreshIntervalBinding: Binding<Int> {
+        Binding(
+            get: { appState.refreshInterval },
+            set: { newValue in
+                appState.refreshInterval = newValue
+                appState.startPolling()
+            }
+        )
+    }
+
+    private var forumPollingBinding: Binding<Int> {
+        Binding(
+            get: { appState.forumWatchConfig.pollingIntervalSeconds },
+            set: { newValue in
+                appState.forumWatchConfig.pollingIntervalSeconds = newValue
+                appState.saveForumWatch()
+                appState.startForumPolling()
+            }
+        )
+    }
+
+    private var trimmedInputKey: String {
+        inputKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func handleEscape() {
+        if settingsFocus != nil {
+            settingsFocus = nil
+        } else if showDiagnostics {
+            showDiagnostics = false
+        } else if showCredits {
+            showCredits = false
+        } else if !appState.apiKey.isEmpty {
+            onDismiss()
+        }
+    }
+
     private func refreshAvailableBrowsers() {
         let browsers = PreferredBrowser.availableBrowsers()
         availableBrowsers = browsers
@@ -369,14 +491,14 @@ struct SettingsView: View {
             preferredBrowser = PreferredBrowser.system.rawValue
         }
     }
-    
-    // MARK: - API Usage Disclosure
+
     private var nextActionConfigSection: some View {
         DisclosureGroup {
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 3) {
                 Text("Choose which events appear in the Next Action timeline.")
                     .font(.caption2)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
+
                 ForEach(NextActionCategory.allCases, id: \.self) { category in
                     Toggle(isOn: Binding(
                         get: { !appState.hiddenNextActionCategories.contains(category) },
@@ -396,17 +518,11 @@ struct SettingsView: View {
             }
             .padding(.top, 4)
         } label: {
-            HStack(spacing: 4) {
-                Image(systemName: "flag.checkered")
-                    .foregroundColor(.secondary)
-                Text("Next Action")
-                    .font(.caption.bold())
-            }
+            Label("Next Action timeline", systemImage: "flag.checkered")
+                .font(.caption.bold())
         }
-        .padding(.horizontal)
     }
 
-    // MARK: - Key validation result (Etap C, ISC-16)
     @ViewBuilder
     private var keyValidationResult: some View {
         switch appState.keyValidation {
@@ -415,10 +531,13 @@ struct SettingsView: View {
         case .success(let result):
             let blocked = result.availability.filter { !$0.available }
             VStack(alignment: .leading, spacing: 4) {
-                Label("\(result.accessType) · ID \(result.playerID)",
-                      systemImage: "checkmark.seal.fill")
-                    .font(.caption.bold())
-                    .foregroundStyle(.green)
+                Label(
+                    "\(result.accessType) · ID \(result.playerID)",
+                    systemImage: "checkmark.seal.fill"
+                )
+                .font(.caption.bold())
+                .foregroundStyle(.green)
+
                 if blocked.isEmpty {
                     Text("All MacTorn features are available with this key.")
                         .font(.caption2)
@@ -449,18 +568,26 @@ struct SettingsView: View {
     private var apiUsageDisclosure: some View {
         DisclosureGroup {
             VStack(alignment: .leading, spacing: 8) {
-                disclosureLine("key.fill",
-                               "Requires a Torn key with at least **\(TornEndpointRegistry.requiredAccessLevel.label)** for every feature. Lower access still works — modules your key can't read are shown after Test Connection.")
-                disclosureLine("lock.fill",
-                               "Your key is stored in the macOS **Keychain**, never in plaintext preferences.")
-                disclosureLine("desktopcomputer",
-                               "All Torn data stays **on this Mac**. MacTorn is read-only — it never takes any action on your account.")
-                disclosureLine("exclamationmark.shield",
-                               "Crash reporting (Sentry) is **opt-in** and off by default; no Torn data is sent.")
+                disclosureLine(
+                    "key.fill",
+                    "Requires a Torn key with at least **\(TornEndpointRegistry.requiredAccessLevel.label)** for every feature. Lower access still works — unavailable modules are shown after Test Connection."
+                )
+                disclosureLine(
+                    "lock.fill",
+                    "Your key is stored in the macOS **Keychain**, never in plaintext preferences."
+                )
+                disclosureLine(
+                    "desktopcomputer",
+                    "All Torn data stays **on this Mac**. MacTorn is read-only — it never takes action on your account."
+                )
+                disclosureLine(
+                    "exclamationmark.shield",
+                    "Crash reporting is **opt-in** and off by default; no Torn data is sent."
+                )
 
                 Divider()
 
-                Text("Selections requested (from the app's endpoint registry):")
+                Text("Selections requested:")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                 Text(TornEndpointRegistry.allSelections.joined(separator: ", "))
@@ -468,22 +595,17 @@ struct SettingsView: View {
                     .foregroundStyle(Color.accentColor)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Divider()
-
-                Link("View Torn API Terms of Service",
-                     destination: URL(string: "https://www.torn.com/api.html")!)
-                    .font(.caption)
+                Link(
+                    "View Torn API Terms of Service",
+                    destination: URL(string: "https://www.torn.com/api.html")!
+                )
+                .font(.caption)
             }
             .padding(.top, 4)
         } label: {
-            HStack(spacing: 4) {
-                Image(systemName: "doc.text")
-                    .foregroundColor(.secondary)
-                Text("API Data Usage & Privacy")
-                    .font(.caption.bold())
-            }
+            Label("API Data Usage", systemImage: "doc.text")
+                .font(.caption.bold())
         }
-        .padding(.horizontal)
     }
 
     private func disclosureLine(_ icon: String, _ markdown: String) -> some View {
@@ -498,7 +620,6 @@ struct SettingsView: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
     }
-
 
     private func openTornProfile() {
         let url = "https://www.torn.com/profiles.php?XID=\(developerID)"

--- a/MacTorn/MacTorn/Views/StatusView.swift
+++ b/MacTorn/MacTorn/Views/StatusView.swift
@@ -7,9 +7,18 @@ struct StatusView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 10) {
                 // Header
                 headerSection
+
+                ModuleStateView(
+                    state: appState.presentationState(
+                        endpointIDs: ["user.fast", "user.v2", "user.activity"],
+                        hasContent: appState.data != nil,
+                        staleAfter: 120
+                    ),
+                    onRetry: appState.refreshNow
+                )
 
                 // Next Action timeline (Etap J) — the single most useful glance.
                 if appState.data != nil {
@@ -67,9 +76,9 @@ struct StatusView: View {
                 // Quick Links
                 quickLinksSection
             }
-            .padding()
+            .padding(12)
         }
-        .fixedSize(horizontal: false, vertical: true)
+        .frame(height: 480)
     }
     
     // MARK: - Header
@@ -104,6 +113,7 @@ struct StatusView: View {
                     }
                     .buttonStyle(.plain)
                     .foregroundColor(.secondary)
+                    .accessibilityLabel("Refresh Torn data")
                 }
             }
         }
@@ -278,7 +288,7 @@ struct StatusView: View {
                 } label: {
                     HStack(spacing: 2) {
                         Image(systemName: "globe")
-                            .font(.system(size: 8))
+                            .font(.caption2)
                         Text("TRI Hub")
                             .font(.caption2)
                     }

--- a/MacTorn/MacTorn/Views/TravelView.swift
+++ b/MacTorn/MacTorn/Views/TravelView.swift
@@ -82,10 +82,28 @@ struct FlyingStatusView: View {
 struct TravelView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.reduceTransparency) private var reduceTransparency
+    // Deliberately separate from the legacy `privateIsland` preference: owning or
+    // renting a PI does not prove that its Airstrip upgrade exists or that a pilot
+    // is currently hired.
+    @AppStorage("travelFlightMethod")
+    private var flightMethodRawValue = TornDestination.FlightMethod.standard.rawValue
+
+    private var selectedFlightMethod: TornDestination.FlightMethod {
+        TornDestination.FlightMethod(rawValue: flightMethodRawValue) ?? .standard
+    }
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
+                ModuleStateView(
+                    state: appState.presentationState(
+                        endpointIDs: ["user.fast"],
+                        hasContent: appState.data?.travel != nil,
+                        staleAfter: 120
+                    ),
+                    onRetry: appState.refreshNow
+                )
+
                 // Travel Status Section
                 travelStatusSection
 
@@ -198,6 +216,18 @@ struct TravelView: View {
                 Text("Quick Travel")
                     .font(.subheadline.bold())
                     .foregroundColor(.secondary)
+                Spacer()
+                if !isAbroad {
+                    Picker("Estimate method", selection: $flightMethodRawValue) {
+                        ForEach(TornDestination.FlightMethod.allCases, id: \.self) { method in
+                            Text(method.rawValue).tag(method.rawValue)
+                        }
+                    }
+                    .labelsHidden()
+                    .controlSize(.small)
+                    .accessibilityLabel("Quick Travel estimate method")
+                    .help("Airstrip estimates require both the Airstrip upgrade and a hired pilot.")
+                }
             }
 
             if isAbroad {
@@ -228,6 +258,22 @@ struct TravelView: View {
                         destinationButton(destination)
                     }
                 }
+
+                if selectedFlightMethod == .airstrip {
+                    Text("Requires a Private Island Airstrip upgrade and a currently hired pilot.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Text(
+                    "Current Torn base estimates; actual flights can vary by "
+                        + "±\(TornDestination.estimateVariancePercent)%. "
+                        + "Active-flight countdowns use API arrival data."
+                )
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }
@@ -244,7 +290,9 @@ struct TravelView: View {
                         .font(.caption)
                         .lineLimit(1)
                 }
-                Text("~\(destination.flightTimeFormatted)")
+                Text(
+                    "~\(destination.flightTimeFormatted(method: selectedFlightMethod))"
+                )
                     .font(.caption2)
                     .foregroundColor(.secondary)
             }
@@ -254,6 +302,9 @@ struct TravelView: View {
             .cornerRadius(8)
         }
         .buttonStyle(.plain)
+        .accessibilityHint(
+            "Estimated with \(selectedFlightMethod.rawValue.lowercased()) travel"
+        )
     }
 
     // MARK: - Pre-Arrival Alerts Section

--- a/MacTorn/MacTorn/Views/WatchlistView.swift
+++ b/MacTorn/MacTorn/Views/WatchlistView.swift
@@ -4,10 +4,16 @@ struct WatchlistView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.reduceTransparency) private var reduceTransparency
     @State private var showAddItem = false
+    @State private var recentlyRemoved: RemovedWatchlistItem?
+    @State private var undoDismissTask: Task<Void, Never>?
     
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
+                ModuleStateView(state: moduleState) {
+                    appState.refreshWatchlistPrices()
+                }
+
                 // Watchlist Header
                 HStack {
                     Image(systemName: "chart.line.uptrend.xyaxis")
@@ -25,6 +31,7 @@ struct WatchlistView: View {
                             .foregroundColor(.blue)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Refresh watched prices")
                     
                     Button {
                         withAnimation {
@@ -35,6 +42,7 @@ struct WatchlistView: View {
                             .foregroundColor(showAddItem ? .red : .green)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel(showAddItem ? "Close add item panel" : "Add watched item")
                 }
                 
                 // Add Item Section (inline)
@@ -89,7 +97,7 @@ struct WatchlistView: View {
                         WatchlistPriceRow(item: item) {
                             openURL("https://www.torn.com/page.php?sid=ItemMarket#/market/view=item&itemID=\(item.id)")
                         } onRemove: {
-                            appState.removeFromWatchlist(item.id)
+                            removeWithUndo(item)
                         } onSetThreshold: { threshold in
                             if let index = appState.watchlistItems.firstIndex(where: { $0.id == item.id }) {
                                 appState.watchlistItems[index].priceThreshold = threshold
@@ -98,6 +106,13 @@ struct WatchlistView: View {
                             }
                         }
                     }
+                }
+
+                if let recentlyRemoved {
+                    UndoBanner(message: "\(recentlyRemoved.item.name) removed") {
+                        undoRemoval()
+                    }
+                    .transition(.move(edge: .top).combined(with: .opacity))
                 }
                 
                 Divider()
@@ -119,6 +134,10 @@ struct WatchlistView: View {
         .task {
             appState.refreshWatchlistPrices()
         }
+        .onDisappear {
+            undoDismissTask?.cancel()
+            recentlyRemoved = nil
+        }
     }
     
     private let popularItems = [
@@ -129,12 +148,55 @@ struct WatchlistView: View {
         ("Energy Drink", 261),
         ("First Aid Kit", 68)
     ]
+
+    private var moduleState: ModulePresentationState {
+        appState.presentationState(
+            endpointIDs: ["market.item"],
+            hasContent: !appState.watchlistItems.isEmpty,
+            staleAfter: 180
+        )
+    }
     
     private func openURL(_ urlString: String) {
         if let url = URL(string: urlString) {
             BrowserManager.shared.open(url)
         }
     }
+
+    private func removeWithUndo(_ item: WatchlistItem) {
+        guard let index = appState.watchlistItems.firstIndex(where: { $0.id == item.id }) else {
+            return
+        }
+        let removedItem = appState.watchlistItems[index]
+
+        undoDismissTask?.cancel()
+        appState.removeFromWatchlist(item.id)
+        withAnimation {
+            recentlyRemoved = RemovedWatchlistItem(item: removedItem, index: index)
+        }
+        undoDismissTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 6_000_000_000)
+            guard !Task.isCancelled else { return }
+            withAnimation {
+                recentlyRemoved = nil
+            }
+        }
+    }
+
+    private func undoRemoval() {
+        guard let recentlyRemoved else { return }
+
+        undoDismissTask?.cancel()
+        appState.restoreWatchlistItem(recentlyRemoved.item, at: recentlyRemoved.index)
+        withAnimation {
+            self.recentlyRemoved = nil
+        }
+    }
+}
+
+private struct RemovedWatchlistItem {
+    let item: WatchlistItem
+    let index: Int
 }
 
 // MARK: - Watchlist Price Row
@@ -147,6 +209,11 @@ struct WatchlistPriceRow: View {
 
     @State private var showThresholdPopover = false
     @State private var thresholdText = ""
+    @State private var thresholdError: String?
+
+    private var thresholdValue: Int? {
+        PositiveIntegerInput.value(from: thresholdText)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -162,6 +229,7 @@ struct WatchlistPriceRow: View {
                     }
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Open \(item.name) in Item Market")
 
                 Spacer()
 
@@ -195,7 +263,7 @@ struct WatchlistPriceRow: View {
                         if item.priceDifference > 0 {
                             HStack(spacing: 2) {
                                 Image(systemName: "arrow.up")
-                                    .font(.system(size: 8))
+                                    .font(.caption2)
                                 Text("+\(formatPrice(item.priceDifference))")
                                     .font(.caption2.monospacedDigit())
                             }
@@ -207,6 +275,7 @@ struct WatchlistPriceRow: View {
                 // Bell button for price threshold
                 Button {
                     thresholdText = item.priceThreshold.map { String($0) } ?? ""
+                    thresholdError = nil
                     showThresholdPopover = true
                 } label: {
                     Image(systemName: item.priceThreshold != nil ? "bell.fill" : "bell")
@@ -214,6 +283,9 @@ struct WatchlistPriceRow: View {
                         .font(.caption)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel(item.priceThreshold != nil
+                                    ? "Edit price alert for \(item.name)"
+                                    : "Set price alert for \(item.name)")
                 .popover(isPresented: $showThresholdPopover) {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Alert when below:")
@@ -222,11 +294,19 @@ struct WatchlistPriceRow: View {
                         TextField("Price", text: $thresholdText)
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 120)
-                            .onSubmit {
-                                let value = Int(thresholdText)
-                                onSetThreshold(value)
-                                showThresholdPopover = false
+                            .onChange(of: thresholdText) { _, newValue in
+                                thresholdError = PositiveIntegerInput.errorMessage(for: newValue)
                             }
+                            .onSubmit {
+                                submitThreshold()
+                            }
+
+                        if let thresholdError {
+                            Text(thresholdError)
+                                .font(.caption2)
+                                .foregroundStyle(.red)
+                                .accessibilityLabel("Price threshold error: \(thresholdError)")
+                        }
 
                         HStack(spacing: 8) {
                             Button("Clear") {
@@ -237,12 +317,11 @@ struct WatchlistPriceRow: View {
                             .foregroundColor(.secondary)
 
                             Button("Set") {
-                                let value = Int(thresholdText)
-                                onSetThreshold(value)
-                                showThresholdPopover = false
+                                submitThreshold()
                             }
                             .buttonStyle(.plain)
                             .foregroundColor(.blue)
+                            .disabled(thresholdValue == nil)
                         }
                     }
                     .padding(12)
@@ -255,6 +334,7 @@ struct WatchlistPriceRow: View {
                         .font(.caption)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Remove \(item.name) from price watch")
             }
 
             // Threshold indicator
@@ -281,5 +361,74 @@ struct WatchlistPriceRow: View {
             return String(format: "$%.0fK", Double(price) / 1_000)
         }
         return "$\(price)"
+    }
+
+    private func submitThreshold() {
+        guard let thresholdValue else {
+            thresholdError = PositiveIntegerInput.errorMessage(for: thresholdText)
+            return
+        }
+
+        onSetThreshold(thresholdValue)
+        thresholdError = nil
+        showThresholdPopover = false
+    }
+}
+
+enum PositiveIntegerInput {
+    static func value(from input: String) -> Int? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let value = Int(trimmed), value > 0 else { return nil }
+        return value
+    }
+
+    static func errorMessage(for input: String) -> String? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard value(from: input) == nil else { return nil }
+        if trimmed.isEmpty {
+            return "Enter a price."
+        }
+        if let value = Int(trimmed), value <= 0 {
+            return "Price must be greater than zero."
+        }
+        return "Enter a whole number."
+    }
+}
+
+struct UndoBanner: View {
+    let message: String
+    let onUndo: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(message)
+                .font(.caption)
+                .lineLimit(1)
+
+            Spacer()
+
+            Button("Undo", action: onUndo)
+                .buttonStyle(.borderless)
+                .font(.caption.bold())
+                .accessibilityLabel("Undo \(message)")
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color.accentColor.opacity(0.14))
+        .cornerRadius(6)
+    }
+}
+
+extension AppState {
+    @discardableResult
+    func restoreWatchlistItem(_ item: WatchlistItem, at originalIndex: Int) -> Bool {
+        guard !watchlistItems.contains(where: { $0.id == item.id }) else {
+            return false
+        }
+
+        let insertionIndex = min(max(originalIndex, 0), watchlistItems.count)
+        watchlistItems.insert(item, at: insertionIndex)
+        saveWatchlist()
+        return true
     }
 }

--- a/MacTorn/MacTornTests/Models/TornResponseTests.swift
+++ b/MacTorn/MacTornTests/Models/TornResponseTests.swift
@@ -125,6 +125,22 @@ final class TornResponseTests: XCTestCase {
         XCTAssertEqual(events[2].timestamp, 1000) // Oldest last
     }
 
+    func testRecentEvents_sameTimestampRetainDistinctStableIds() throws {
+        let json: [String: Any] = [
+            "events": [
+                "event-a": ["timestamp": 3000, "event": "First", "seen": 0],
+                "event-b": ["timestamp": 3000, "event": "Second", "seen": 0]
+            ]
+        ]
+        let response = try JSONDecoder().decode(
+            TornResponse.self,
+            from: TornAPIFixtures.toData(json)
+        )
+
+        let ids = response.recentEvents.map(\.id)
+        XCTAssertEqual(Set(ids), Set(["event-a", "event-b"]))
+    }
+
     // MARK: - Error Response Tests
 
     func testDecoding_errorResponse() throws {
@@ -389,5 +405,51 @@ final class TornAPIErrorEnvelopeTests: XCTestCase {
     func testTopLevelErrorStringWithoutCode_returnsNil() {
         let json: [String: Any] = ["error": "some unrelated field"]
         XCTAssertNil(tornAPIErrorMessage(in: json))
+    }
+}
+
+// MARK: - Main user snapshot semantic contract
+
+final class UserSnapshotContractTests: XCTestCase {
+    private let requested = [
+        "basic", "bars", "cooldowns", "travel", "profile", "money",
+        "battlestats", "properties", "stocks",
+    ]
+
+    func testFullCapabilitiesAcceptARealSnapshot() {
+        XCTAssertTrue(UserSnapshotContract.isSatisfied(
+            by: TornAPIFixtures.validFullResponse(),
+            requestedSelections: requested,
+            grantedSelections: requested
+        ))
+    }
+
+    func testCustomProfileCapabilityDoesNotArbitrarilyRequireBars() {
+        let profileOnly: [String: Any] = [
+            "name": "CustomKeyPlayer",
+            "player_id": 42,
+        ]
+
+        XCTAssertTrue(UserSnapshotContract.isSatisfied(
+            by: profileOnly,
+            requestedSelections: requested,
+            grantedSelections: ["profile"]
+        ))
+    }
+
+    func testUnderprivilegedKeyWithoutRequestedCapabilitiesRejectsPayload() {
+        XCTAssertFalse(UserSnapshotContract.isSatisfied(
+            by: ["name": "Unexpected"],
+            requestedSelections: requested,
+            grantedSelections: []
+        ))
+    }
+
+    func testEmptyObjectIsNeverASuccessfulSnapshot() {
+        XCTAssertFalse(UserSnapshotContract.isSatisfied(
+            by: [:],
+            requestedSelections: requested,
+            grantedSelections: nil
+        ))
     }
 }

--- a/MacTorn/MacTornTests/Models/TravelTests.swift
+++ b/MacTorn/MacTornTests/Models/TravelTests.swift
@@ -3,6 +3,90 @@ import XCTest
 
 final class TravelTests: XCTestCase {
 
+    // MARK: - Current travel duration table
+
+    func testStandardFlightTimesMatchTornPatch438Table() {
+        let expected: [TornDestination: Int] = [
+            .mexico: 24,
+            .caymanIslands: 33,
+            .canada: 39,
+            .hawaii: 127,
+            .unitedKingdom: 151,
+            .argentina: 158,
+            .switzerland: 166,
+            .japan: 213,
+            .china: 229,
+            .uae: 257,
+            .southAfrica: 282,
+        ]
+
+        XCTAssertEqual(TornDestination.allCases.count, expected.count)
+        for destination in TornDestination.allCases {
+            XCTAssertEqual(
+                destination.flightTimeMinutes(method: .standard),
+                expected[destination],
+                "Outdated standard time for \(destination.rawValue)"
+            )
+        }
+    }
+
+    func testAirstripFlightTimesMatchTornPatch438Table() {
+        let expected: [TornDestination: Int] = [
+            .mexico: 17,
+            .caymanIslands: 23,
+            .canada: 27,
+            .hawaii: 89,
+            .unitedKingdom: 106,
+            .argentina: 111,
+            .switzerland: 116,
+            .japan: 149,
+            .china: 160,
+            .uae: 180,
+            .southAfrica: 197,
+        ]
+
+        XCTAssertEqual(TornDestination.allCases.count, expected.count)
+        for destination in TornDestination.allCases {
+            XCTAssertEqual(
+                destination.flightTimeMinutes(method: .airstrip),
+                expected[destination],
+                "Outdated airstrip time for \(destination.rawValue)"
+            )
+        }
+    }
+
+    func testFlightTimeFormattingUsesSelectedMethod() {
+        XCTAssertEqual(TornDestination.mexico.flightTimeFormatted(method: .standard), "24m")
+        XCTAssertEqual(TornDestination.hawaii.flightTimeFormatted(method: .airstrip), "1h 29m")
+        XCTAssertEqual(TornDestination.southAfrica.flightTimeFormatted(method: .standard), "4h 42m")
+    }
+
+    func testPublishedEstimateSemanticsRemainExplicit() {
+        XCTAssertEqual(TornDestination.FlightMethod.standard.rawValue, "Standard")
+        XCTAssertEqual(TornDestination.FlightMethod.airstrip.rawValue, "Airstrip + pilot")
+        XCTAssertEqual(TornDestination.estimateVariancePercent, 3)
+    }
+
+    func testActiveFlightProgressUsesAPITimestampsNotQuickTravelEstimate() throws {
+        let now = Int(Date().timeIntervalSince1970)
+        let json: [String: Any] = [
+            "destination": TornDestination.japan.rawValue,
+            "timestamp": now + 600,
+            "departed": now - 900,
+            // Deliberately inconsistent with the timestamps. The timestamp remains
+            // authoritative while present; static Quick Travel tables are not involved.
+            "time_left": 12,
+        ]
+        let travel = try decode(Travel.self, from: json)
+
+        let remaining = travel.remainingSeconds(from: Date())
+        XCTAssertGreaterThanOrEqual(remaining, 598)
+        XCTAssertLessThanOrEqual(remaining, 600)
+
+        let progress = travel.flightProgress(from: Date())
+        XCTAssertEqual(progress, 0.6, accuracy: 0.002)
+    }
+
     // MARK: - isAbroad Tests
 
     func testIsAbroad_inTorn() throws {

--- a/MacTorn/MacTornTests/ViewModels/AccountSessionStoreTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AccountSessionStoreTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import MacTorn
+
+@MainActor
+final class AccountSessionStoreTests: XCTestCase {
+    func testMigratesLegacyKeyAndRemovesUserDefaultsCopy() {
+        let defaults = makeDefaults()
+        defaults.set("legacy-key", forKey: "apiKey")
+        let credentials = MemoryAPIKeyStore()
+
+        let store = AccountSessionStore(
+            defaults: defaults,
+            credentialStore: credentials
+        )
+
+        XCTAssertEqual(store.apiKey, "legacy-key")
+        XCTAssertEqual(credentials.get(), "legacy-key")
+        XCTAssertNil(defaults.string(forKey: "apiKey"))
+    }
+
+    func testChangingKeyAdvancesGenerationAndRejectsOldIdentity() {
+        let credentials = MemoryAPIKeyStore("old-key")
+        let store = AccountSessionStore(
+            defaults: makeDefaults(),
+            credentialStore: credentials
+        )
+        let oldIdentity = store.identity
+        store.isHalted = true
+
+        XCTAssertTrue(store.updateAPIKey("new-key"))
+        XCTAssertEqual(store.apiKey, "new-key")
+        XCTAssertEqual(store.identity.generation, oldIdentity.generation + 1)
+        XCTAssertFalse(store.isCurrent(oldIdentity))
+        XCTAssertFalse(store.isHalted)
+        XCTAssertEqual(credentials.get(), "new-key")
+        XCTAssertFalse(store.updateAPIKey("new-key"))
+        XCTAssertEqual(store.identity.generation, oldIdentity.generation + 1)
+    }
+
+    func testChangingKeyCancelsRegisteredAccountTask() async {
+        let store = AccountSessionStore(
+            defaults: makeDefaults(),
+            credentialStore: MemoryAPIKeyStore("old-key")
+        )
+        let cancelled = expectation(description: "account task cancelled")
+
+        store.startTask(.userSnapshot) {
+            do {
+                try await Task.sleep(nanoseconds: 10_000_000_000)
+            } catch {
+                cancelled.fulfill()
+            }
+        }
+
+        store.updateAPIKey("new-key")
+        await fulfillment(of: [cancelled], timeout: 1)
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "AccountSessionStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}
+
+private final class MemoryAPIKeyStore: APIKeyStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: String?
+
+    init(_ value: String? = nil) {
+        self.value = value
+    }
+
+    func get() -> String? {
+        lock.withLock { value }
+    }
+
+    func set(_ value: String) {
+        lock.withLock {
+            self.value = value.isEmpty ? nil : value
+        }
+    }
+}

--- a/MacTorn/MacTornTests/ViewModels/AppStateForumWatchTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateForumWatchTests.swift
@@ -53,13 +53,16 @@ final class AppStateForumWatchTests: XCTestCase {
         XCTAssertNil(appState.parseThreadInput("abc"))
         XCTAssertNil(appState.parseThreadInput(""))
         XCTAssertNil(appState.parseThreadInput("https://www.torn.com/forums.php"))
+        XCTAssertNil(appState.parseThreadInput("0"))
+        XCTAssertNil(appState.parseThreadInput("-42"))
+        XCTAssertNil(appState.parseThreadInput("https://www.torn.com/forums.php?t=0"))
     }
 
     // MARK: - Add Thread Tests
 
     func testAddWatchedThread_addsThread() {
         appState.apiKey = "valid_key"
-        appState.addWatchedThread(input: "12345")
+        XCTAssertTrue(appState.addWatchedThread(input: "12345"))
 
         XCTAssertEqual(appState.watchedThreads.count, 1)
         XCTAssertEqual(appState.watchedThreads.first?.id, 12345)
@@ -68,15 +71,15 @@ final class AppStateForumWatchTests: XCTestCase {
 
     func testAddWatchedThread_preventsDuplicate() {
         appState.apiKey = "valid_key"
-        appState.addWatchedThread(input: "12345")
-        appState.addWatchedThread(input: "12345")
+        XCTAssertTrue(appState.addWatchedThread(input: "12345"))
+        XCTAssertFalse(appState.addWatchedThread(input: "12345"))
 
         XCTAssertEqual(appState.watchedThreads.count, 1)
     }
 
     func testAddWatchedThread_invalidInput() {
         appState.apiKey = "valid_key"
-        appState.addWatchedThread(input: "invalid")
+        XCTAssertFalse(appState.addWatchedThread(input: "invalid"))
 
         XCTAssertTrue(appState.watchedThreads.isEmpty)
     }
@@ -112,6 +115,46 @@ final class AppStateForumWatchTests: XCTestCase {
         appState.removeWatchedThread(999)
 
         XCTAssertEqual(appState.watchedThreads.count, 1)
+    }
+
+    func testRestoreWatchedThread_restoresFullModelAtOriginalIndexAndPersists() {
+        let removed = WatchedThread(
+            id: 222,
+            title: "Important faction thread",
+            notificationsEnabled: false,
+            lastKnownPostCount: 42,
+            lastChecked: Date(timeIntervalSince1970: 5_678),
+            error: "Previous error",
+            isFactionThread: true
+        )
+        appState.watchedThreads = [
+            WatchedThread(id: 111, title: "Thread A"),
+            WatchedThread(id: 333, title: "Thread C")
+        ]
+
+        XCTAssertTrue(appState.restoreWatchedThread(removed, at: 1))
+
+        XCTAssertEqual(appState.watchedThreads.map(\.id), [111, 222, 333])
+        let restored = appState.watchedThreads[1]
+        XCTAssertEqual(restored.title, removed.title)
+        XCTAssertEqual(restored.notificationsEnabled, removed.notificationsEnabled)
+        XCTAssertEqual(restored.lastKnownPostCount, removed.lastKnownPostCount)
+        XCTAssertEqual(restored.lastChecked, removed.lastChecked)
+        XCTAssertEqual(restored.error, removed.error)
+        XCTAssertEqual(restored.isFactionThread, removed.isFactionThread)
+
+        let reloaded = AppState(session: mockSession, defaults: testDefaults)
+        XCTAssertEqual(reloaded.watchedThreads.map(\.id), [111, 222, 333])
+        XCTAssertEqual(reloaded.watchedThreads[1].lastKnownPostCount, removed.lastKnownPostCount)
+        XCTAssertEqual(reloaded.watchedThreads[1].isFactionThread, removed.isFactionThread)
+    }
+
+    func testRestoreWatchedThread_doesNotDuplicateExistingThread() {
+        let thread = WatchedThread(id: 111, title: "Thread A")
+        appState.watchedThreads = [thread]
+
+        XCTAssertFalse(appState.restoreWatchedThread(thread, at: 0))
+        XCTAssertEqual(appState.watchedThreads.map(\.id), [111])
     }
 
     // MARK: - Toggle Notifications Tests
@@ -160,6 +203,15 @@ final class AppStateForumWatchTests: XCTestCase {
         XCTAssertFalse(appState.forumWatchConfig.factionForumAutoMonitor)
     }
 
+    func testLoadForumWatch_normalizesUnsafePollingInterval() throws {
+        let unsafe = ForumWatchConfig(pollingIntervalSeconds: 0)
+        testDefaults.set(try JSONEncoder().encode(unsafe), forKey: "forumWatchConfig")
+
+        let newAppState = AppState(session: mockSession, defaults: testDefaults)
+
+        XCTAssertEqual(newAppState.forumWatchConfig.pollingIntervalSeconds, 180)
+    }
+
     // MARK: - v2 Error Envelope Contract (forum endpoint)
 
     /// The forum endpoint is v2 (`/v2/forum/{threadId}/thread`). Torn's v2 error
@@ -174,7 +226,7 @@ final class AppStateForumWatchTests: XCTestCase {
         try await Task.sleep(nanoseconds: 800_000_000)
 
         let thread = appState.watchedThreads.first
-        XCTAssertEqual(thread?.error, "Too many requests",
+        XCTAssertEqual(thread?.error, "Too many requests — backing off.",
                        "v2 forum error envelope must be surfaced, not parsed as an 'Unknown' thread")
         XCTAssertNotEqual(thread?.title, "Unknown",
                           "on a v2 error the thread title must not be corrupted to 'Unknown'")

--- a/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
@@ -69,12 +69,18 @@ final class AppStateTests: XCTestCase {
         let mock = MockNetworkSession()
         let app = AppState(session: mock, connectivity: conn, defaults: .createMockDefaults())
         app.apiKey = "bad_key"
+        app.keyValidation = .validating
+        app.moneyData = MoneyData(cash: 42)
         try mock.setSuccessResponse(json: ["code": 2, "error": "Incorrect key"]) // HTTP 200 + Torn envelope
         app.startPolling()
         try await Task.sleep(nanoseconds: 1_000_000_000)
         XCTAssertTrue(app.keyHalted, "a code-2 error must halt polling")
         XCTAssertNil(app.data)
+        XCTAssertNil(app.moneyData, "revoked credentials must not leave stale account data visible")
         XCTAssertNotNil(app.errorMsg)
+        guard case .failure = app.keyValidation else {
+            return XCTFail("a permanently rejected key must invalidate prior validation")
+        }
         app.stopPolling()
     }
 
@@ -84,6 +90,83 @@ final class AppStateTests: XCTestCase {
         app.keyHalted = true
         app.apiKey = "fresh_key"   // didSet clears the halt
         XCTAssertFalse(app.keyHalted)
+    }
+
+    func testChangingKeyClearsPreviouslyAuthenticatedAccountData() throws {
+        let app = AppState(session: MockNetworkSession(),
+                           connectivity: ControllableConnectivity(),
+                           defaults: .createMockDefaults())
+        app.apiKey = "account_a"
+        app.data = try JSONDecoder().decode(
+            TornResponse.self,
+            from: TornAPIFixtures.toData(TornAPIFixtures.validFullResponse())
+        )
+        app.moneyData = MoneyData(cash: 1_000, vault: 2_000)
+        app.activityEvents = try XCTUnwrap(app.data?.recentEvents)
+        app.lastUpdated = Date()
+
+        app.apiKey = "account_b"
+
+        XCTAssertNil(app.data)
+        XCTAssertNil(app.moneyData)
+        XCTAssertTrue(app.activityEvents.isEmpty)
+        XCTAssertNil(app.lastUpdated)
+        XCTAssertEqual(app.menuBarDisplay, .fallbackIcon)
+    }
+
+    func testResponseFromPreviousKeyCannotOverwriteCurrentAccount() async throws {
+        let delayed = try NonCooperativeDelayedNetworkSession(
+            json: TornAPIFixtures.validFullResponse(),
+            delay: 0.25
+        )
+        let app = AppState(session: delayed,
+                           connectivity: ControllableConnectivity(),
+                           defaults: .createMockDefaults())
+        app.apiKey = "account_a"
+        app.fetchData()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        app.apiKey = "account_b"
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertNil(app.data, "a non-cooperative response for account A must be discarded")
+        XCTAssertNil(app.lastUpdated)
+        XCTAssertFalse(app.isLoading)
+    }
+
+    func testKeyValidationFromPreviousKeyCannotOverwriteCurrentAccount() async throws {
+        let delayed = try NonCooperativeDelayedNetworkSession(
+            json: [
+                "info": [
+                    "access": [
+                        "level": 4, "type": "Full Access",
+                        "faction": true, "company": false
+                    ],
+                    "user": [
+                        "id": 42, "faction_id": 100,
+                        "company_id": NSNull()
+                    ],
+                    "selections": [
+                        "user": [], "faction": [], "market": [],
+                        "property": [], "torn": [], "racing": [],
+                        "forum": [], "key": ["info"], "company": []
+                    ]
+                ]
+            ],
+            delay: 0.25
+        )
+        let app = AppState(session: delayed,
+                           connectivity: ControllableConnectivity(),
+                           defaults: .createMockDefaults())
+        app.apiKey = "account_a"
+        let validation = Task { await app.validateKey() }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        app.apiKey = "account_b"
+        await validation.value
+
+        XCTAssertEqual(app.keyValidation, .idle)
+        XCTAssertNil(app.keyInfo)
     }
 
     func testHaltedPollingIssuesNoRequests() {
@@ -151,6 +234,91 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(appState.data?.playerId, 123456)
         XCTAssertNil(appState.errorMsg)
         XCTAssertNotNil(appState.lastUpdated)
+    }
+
+    func testMalformedResponseDoesNotAdvanceLastSuccessfulRefresh() async throws {
+        appState.apiKey = "valid_key"
+        try mockSession.setSuccessResponse(json: ["energy": "not-an-object"])
+
+        appState.fetchData()
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
+        XCTAssertNil(appState.lastUpdated)
+        XCTAssertEqual(appState.errorMsg, "Failed to decode user data")
+        XCTAssertEqual(appState.endpointHealth.latest(for: "user.fast")?.outcome, .error)
+    }
+
+    func testEmptyResponsePreservesLastGoodSnapshotAndTimestamp() async throws {
+        appState.apiKey = "valid_key"
+        try mockSession.setSuccessResponse(json: TornAPIFixtures.validFullResponse())
+        appState.fetchData()
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
+        let goodSnapshot = try XCTUnwrap(appState.data)
+        let goodTimestamp = try XCTUnwrap(appState.lastUpdated)
+
+        try mockSession.setSuccessResponse(json: [:])
+        appState.fetchData()
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
+        XCTAssertEqual(appState.data?.playerId, goodSnapshot.playerId)
+        XCTAssertEqual(appState.data?.name, goodSnapshot.name)
+        XCTAssertEqual(appState.lastUpdated, goodTimestamp)
+        XCTAssertEqual(appState.errorMsg, "Failed to decode user data")
+        XCTAssertEqual(appState.endpointHealth.latest(for: "user.fast")?.outcome, .error)
+    }
+
+    func testNetworkErrorMessageNeverEchoesSensitiveLocalizedDescription() async throws {
+        appState.apiKey = "valid_key"
+        let secret = "TOP_SECRET_API_KEY"
+        mockSession.setNetworkError(
+            NSError(domain: "test", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "failed https://api.torn.com/user/?key=\(secret)"
+            ])
+        )
+
+        appState.fetchData()
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
+        XCTAssertNotNil(appState.errorMsg)
+        XCTAssertFalse(appState.errorMsg?.contains(secret) == true)
+    }
+
+    func testAllRequestPathsRespectInjectedHardCap() async throws {
+        let coordinator = PollingCoordinator(hardCapPerMinute: 1)
+        let mock = MockNetworkSession()
+        try mock.setSuccessResponse(json: TornAPIFixtures.validFullResponse())
+        let app = AppState(session: mock,
+                           connectivity: ControllableConnectivity(),
+                           defaults: .createMockDefaults(),
+                           pollingCoordinator: coordinator)
+        app.apiKey = "valid_key"
+
+        await app.validateKey()
+        let countAtCap = mock.requestedURLs.count
+        app.addToWatchlist(itemId: 206, name: "Xanax")
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        XCTAssertEqual(countAtCap, 1)
+        XCTAssertEqual(mock.requestedURLs.count, 1,
+                       "market refresh must not bypass the shared per-minute cap")
+        XCTAssertEqual(app.watchlistItems.first?.error, "Request limit reached")
+    }
+
+    func testInvalidPersistedRefreshIntervalFallsBackToSafeDefault() {
+        let defaults = UserDefaults.createMockDefaults()
+        defaults.set(0, forKey: "refreshInterval")
+
+        let app = AppState(session: MockNetworkSession(), defaults: defaults)
+
+        XCTAssertEqual(app.refreshInterval, 30)
+    }
+
+    func testRuntimeRefreshIntervalRejectsUnsafeValue() {
+        appState.refreshInterval = -1
+
+        XCTAssertEqual(appState.refreshInterval, 30)
+        XCTAssertEqual(testDefaults.integer(forKey: "refreshInterval"), 30)
     }
 
     func testFetchData_parsesAllBars() async throws {
@@ -459,7 +627,9 @@ final class AppStateTests: XCTestCase {
 
         try await Task.sleep(nanoseconds: 1_000_000_000)
 
-        XCTAssertEqual(appState.errorMsg, "API Error: Too many requests")
+        XCTAssertEqual(appState.errorMsg, "Too many requests — backing off.")
+        XCTAssertEqual(mockSession.requestedURLs.count, 1,
+                       "a rate-limited main response must not fan out optional requests")
     }
 
     // MARK: - Network Error Tests
@@ -472,8 +642,7 @@ final class AppStateTests: XCTestCase {
 
         try await Task.sleep(nanoseconds: 1_000_000_000)
 
-        XCTAssertNotNil(appState.errorMsg)
-        XCTAssertTrue(appState.errorMsg?.contains("Network error") ?? false)
+        XCTAssertEqual(appState.errorMsg, "Network request failed. Please try again.")
     }
 
     // MARK: - HTTP Error Tests
@@ -715,8 +884,7 @@ final class AppStateTests: XCTestCase {
     /// drives the chain alert.
     func testDailyRowLimitPausesOnlyRowSources() async throws {
         let clock = MutableTimeSource()
-        let mock = MockNetworkSession()
-        try mock.setTornAPIError(code: 14, message: "Daily read limit reached")
+        let mock = try DailyRowLimitNetworkSession()
         let state = AppState(session: mock,
                              connectivity: ControllableConnectivity(connected: true),
                              defaults: .createMockDefaults(),
@@ -736,8 +904,7 @@ final class AppStateTests: XCTestCase {
     /// The pause re-arms once its window elapses (driven by the injected clock).
     func testRowSourcePauseReArmsAfterWindow() async throws {
         let clock = MutableTimeSource()
-        let mock = MockNetworkSession()
-        try mock.setTornAPIError(code: 14, message: "Daily read limit reached")
+        let mock = try DailyRowLimitNetworkSession()
         let state = AppState(session: mock,
                              connectivity: ControllableConnectivity(connected: true),
                              defaults: .createMockDefaults(),
@@ -757,15 +924,20 @@ final class AppStateTests: XCTestCase {
 
     /// A successful poll records health for every fan-out endpoint, not just the fast poll.
     func testFetchDataRecordsHealthForFanOutEndpoints() async throws {
-        appState.apiKey = "valid_key"
-        try mockSession.setSuccessResponse(json: TornAPIFixtures.validFullResponse())
+        let session = try FanOutSuccessNetworkSession()
+        let state = AppState(
+            session: session,
+            connectivity: ControllableConnectivity(connected: true),
+            defaults: .createMockDefaults()
+        )
+        state.apiKey = "valid_key"
 
-        appState.fetchData()
+        state.fetchData()
         try await Task.sleep(nanoseconds: 1_000_000_000)
 
         for id in ["user.fast", "faction.basic", "user.v2", "user.activity",
                    "faction.rankedwars", "faction.news"] {
-            XCTAssertEqual(appState.endpointHealth.latest(for: id)?.outcome, .ok,
+            XCTAssertEqual(state.endpointHealth.latest(for: id)?.outcome, .ok,
                            "health should be recorded (ok) for \(id)")
         }
     }
@@ -808,5 +980,136 @@ final class AppStateTests: XCTestCase {
         XCTAssertFalse(relaunched.shouldNotifyOCReady(ready5), "dedup persists across restart")
         let ready6 = OrganizedCrime2(id: 6, name: "New OC", readyAt: now - 10)
         XCTAssertTrue(relaunched.shouldNotifyOCReady(ready6), "a new OC id re-arms")
+    }
+}
+
+/// Simulates URLSession work that completes even after its caller is cancelled. This
+/// proves account isolation does not rely on cooperative task cancellation.
+private final class NonCooperativeDelayedNetworkSession: NetworkSession, @unchecked Sendable {
+    private let responseData: Data
+    private let delay: TimeInterval
+
+    init(json: [String: Any], delay: TimeInterval) throws {
+        self.responseData = try JSONSerialization.data(withJSONObject: json)
+        self.delay = delay
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
+                let response = HTTPURLResponse(
+                    url: request.url ?? URL(string: "https://api.torn.com")!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                continuation.resume(returning: (self.responseData, response))
+            }
+        }
+    }
+}
+
+/// Returns a successful point-in-time poll while applying Torn code 14 only to the two
+/// row-based fan-out endpoints. A code-14 envelope on `user.fast` is not representative:
+/// that endpoint requests no row selections and now correctly stops fan-out on any main
+/// error rather than issuing more requests into a limited API.
+private final class DailyRowLimitNetworkSession: NetworkSession, @unchecked Sendable {
+    private let userFastData: Data
+    private let factionBasicData: Data
+    private let userV2Data: Data
+    private let rankedWarsData: Data
+    private let dailyLimitData: Data
+
+    init() throws {
+        userFastData = try TornAPIFixtures.toData(TornAPIFixtures.validFullResponse())
+        factionBasicData = try TornAPIFixtures.toData([
+            "name": "Test Faction",
+            "ID": 123,
+            "respect": 456,
+            "chain": ["current": 0, "max": 0, "timeout": 0, "cooldown": 0]
+        ])
+        userV2Data = try TornAPIFixtures.toData([:])
+        rankedWarsData = try TornAPIFixtures.toData(["rankedwars": []])
+        dailyLimitData = try TornAPIFixtures.toData([
+            "error": ["code": 14, "error": "Daily read limit reached"]
+        ])
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let url = request.url ?? URL(string: "https://api.torn.com")!
+        let selections = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .first(where: { $0.name == "selections" })?
+            .value ?? ""
+
+        let data: Data
+        if url.path.contains("/v2/faction/news") {
+            data = dailyLimitData
+        } else if url.path.contains("/v2/faction/rankedwars") {
+            data = rankedWarsData
+        } else if url.path == "/v2/user" {
+            data = userV2Data
+        } else if url.pathComponents.contains("faction") {
+            data = factionBasicData
+        } else if selections.contains("events") {
+            data = dailyLimitData
+        } else {
+            data = userFastData
+        }
+
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (data, response)
+    }
+}
+
+/// Returns the correct successful schema for every endpoint in the poll fan-out.
+/// A single generic user payload is intentionally insufficient now that each extracted
+/// service owns strict semantic decoding for its endpoint.
+private final class FanOutSuccessNetworkSession: NetworkSession, @unchecked Sendable {
+    private let userData: Data
+    private let factionBasicData: Data
+    private let userV2Data: Data
+    private let rankedWarsData: Data
+    private let factionNewsData: Data
+
+    init() throws {
+        userData = try TornAPIFixtures.toData(TornAPIFixtures.validFullResponse())
+        factionBasicData = try TornAPIFixtures.toData([
+            "name": "Test Faction",
+            "ID": 123,
+            "respect": 456,
+            "chain": ["current": 0, "max": 0, "timeout": 0, "cooldown": 0],
+        ])
+        userV2Data = try TornAPIFixtures.toData([:])
+        rankedWarsData = try TornAPIFixtures.toData(TornAPIFixtures.rankedWarsResponse())
+        factionNewsData = try TornAPIFixtures.toData(TornAPIFixtures.factionNewsResponse)
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let url = request.url ?? URL(string: "https://api.torn.com")!
+        let data: Data
+        if url.path.contains("/v2/faction/news") {
+            data = factionNewsData
+        } else if url.path.contains("/v2/faction/rankedwars") {
+            data = rankedWarsData
+        } else if url.path == "/v2/user" {
+            data = userV2Data
+        } else if url.pathComponents.contains("faction") {
+            data = factionBasicData
+        } else {
+            data = userData
+        }
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (data, response)
     }
 }

--- a/MacTorn/MacTornTests/ViewModels/AppStateWatchlistTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateWatchlistTests.swift
@@ -98,6 +98,67 @@ final class AppStateWatchlistTests: XCTestCase {
         XCTAssertEqual(appState.watchlistItems.count, 1) // Should still have 1 item
     }
 
+    func testRestoreWatchlistItem_restoresFullModelAtOriginalIndexAndPersists() {
+        let removed = WatchlistItem(
+            id: 456,
+            name: "Donator Pack",
+            lowestPrice: 9_000_000,
+            lowestPriceQuantity: 3,
+            secondLowestPrice: 9_500_000,
+            lastUpdated: Date(timeIntervalSince1970: 1_234),
+            error: "Previous error",
+            priceThreshold: 8_500_000,
+            lastAlertedPrice: 8_400_000
+        )
+        appState.watchlistItems = [
+            WatchlistItem(id: 123, name: "Xanax", lowestPrice: 1_000, lowestPriceQuantity: 5, secondLowestPrice: 1_100, lastUpdated: nil, error: nil),
+            WatchlistItem(id: 789, name: "Vicodin", lowestPrice: 800, lowestPriceQuantity: 2, secondLowestPrice: 850, lastUpdated: nil, error: nil)
+        ]
+
+        XCTAssertTrue(appState.restoreWatchlistItem(removed, at: 1))
+
+        XCTAssertEqual(appState.watchlistItems.map(\.id), [123, 456, 789])
+        let restored = appState.watchlistItems[1]
+        XCTAssertEqual(restored.name, removed.name)
+        XCTAssertEqual(restored.lowestPrice, removed.lowestPrice)
+        XCTAssertEqual(restored.lowestPriceQuantity, removed.lowestPriceQuantity)
+        XCTAssertEqual(restored.secondLowestPrice, removed.secondLowestPrice)
+        XCTAssertEqual(restored.lastUpdated, removed.lastUpdated)
+        XCTAssertEqual(restored.error, removed.error)
+        XCTAssertEqual(restored.priceThreshold, removed.priceThreshold)
+        XCTAssertEqual(restored.lastAlertedPrice, removed.lastAlertedPrice)
+
+        let reloaded = AppState(session: mockSession, defaults: testDefaults)
+        XCTAssertEqual(reloaded.watchlistItems.map(\.id), [123, 456, 789])
+        XCTAssertEqual(reloaded.watchlistItems[1].priceThreshold, removed.priceThreshold)
+        XCTAssertEqual(reloaded.watchlistItems[1].lastAlertedPrice, removed.lastAlertedPrice)
+    }
+
+    func testRestoreWatchlistItem_doesNotDuplicateExistingItem() {
+        let item = WatchlistItem(id: 123, name: "Xanax", lowestPrice: 1_000, lowestPriceQuantity: 5, secondLowestPrice: 1_100, lastUpdated: nil, error: nil)
+        appState.watchlistItems = [item]
+
+        XCTAssertFalse(appState.restoreWatchlistItem(item, at: 0))
+        XCTAssertEqual(appState.watchlistItems.map(\.id), [123])
+    }
+
+    func testPositiveIntegerInput_acceptsOnlyPositiveInts() {
+        XCTAssertEqual(PositiveIntegerInput.value(from: " 42 "), 42)
+        XCTAssertNil(PositiveIntegerInput.value(from: ""))
+        XCTAssertNil(PositiveIntegerInput.value(from: "0"))
+        XCTAssertNil(PositiveIntegerInput.value(from: "-1"))
+        XCTAssertNil(PositiveIntegerInput.value(from: "1.5"))
+        XCTAssertNil(PositiveIntegerInput.value(from: "abc"))
+    }
+
+    func testPositiveIntegerInput_explainsInvalidInput() {
+        XCTAssertEqual(PositiveIntegerInput.errorMessage(for: ""), "Enter a price.")
+        XCTAssertEqual(PositiveIntegerInput.errorMessage(for: "0"), "Price must be greater than zero.")
+        XCTAssertEqual(PositiveIntegerInput.errorMessage(for: "-5"), "Price must be greater than zero.")
+        XCTAssertEqual(PositiveIntegerInput.errorMessage(for: "1.5"), "Enter a whole number.")
+        XCTAssertNil(PositiveIntegerInput.errorMessage(for: "2500"))
+    }
+
     // MARK: - Persistence Tests
 
     func testSaveWatchlist_persists() {
@@ -143,6 +204,68 @@ final class AppStateWatchlistTests: XCTestCase {
         let requestedURLStrings = mockSession.requestedURLs.map { $0.absoluteString }
         XCTAssertTrue(requestedURLStrings.contains { $0.contains("123") })
         XCTAssertTrue(requestedURLStrings.contains { $0.contains("456") })
+    }
+
+    func testRefreshWatchlistPricesLimitsConcurrencyToFour() async throws {
+        let probe = try ConcurrencyProbeNetworkSession(
+            json: TornAPIFixtures.marketItemSuccess,
+            delayNanoseconds: 120_000_000
+        )
+        let state = AppState(
+            session: probe,
+            connectivity: ControllableConnectivity(),
+            defaults: .createMockDefaults()
+        )
+        state.apiKey = "valid_key"
+        state.watchlistItems = (1...12).map {
+            WatchlistItem(
+                id: $0,
+                name: "Item \($0)",
+                lowestPrice: 0,
+                lowestPriceQuantity: 0,
+                secondLowestPrice: 0,
+                lastUpdated: nil,
+                error: nil
+            )
+        }
+
+        state.refreshWatchlistPrices()
+        try await Task.sleep(nanoseconds: 800_000_000)
+
+        XCTAssertEqual(probe.requestCount, 12)
+        XCTAssertEqual(probe.maximumConcurrentRequests, 4)
+    }
+
+    func testAccountSwitchCancelsQueuedWatchlistRequests() async throws {
+        let probe = try ConcurrencyProbeNetworkSession(
+            json: TornAPIFixtures.marketItemSuccess,
+            delayNanoseconds: 300_000_000
+        )
+        let state = AppState(
+            session: probe,
+            connectivity: ControllableConnectivity(),
+            defaults: .createMockDefaults()
+        )
+        state.apiKey = "account_a"
+        state.watchlistItems = (1...20).map {
+            WatchlistItem(
+                id: $0,
+                name: "Item \($0)",
+                lowestPrice: 0,
+                lowestPriceQuantity: 0,
+                secondLowestPrice: 0,
+                lastUpdated: nil,
+                error: nil
+            )
+        }
+
+        state.refreshWatchlistPrices()
+        try await Task.sleep(nanoseconds: 80_000_000)
+        state.apiKey = "account_b"
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertLessThanOrEqual(probe.requestCount, 4)
+        XCTAssertTrue(state.watchlistItems.allSatisfy { $0.lastUpdated == nil })
     }
 
     // MARK: - Price Update Tests
@@ -327,6 +450,11 @@ final class AppStateWatchlistTests: XCTestCase {
         XCTAssertFalse(stored.hasSuffix(" "), "trailing whitespace not trimmed")
     }
 
+    func testAddToWatchlist_rejectsWhitespaceOnlyName() {
+        appState.addToWatchlist(itemId: 123, name: "   \n ")
+        XCTAssertTrue(appState.watchlistItems.isEmpty)
+    }
+
     // MARK: - v2 Error Envelope Contract (market endpoint)
 
     /// The market endpoint is v2 (`/v2/market/{id}`). Torn's v2 error envelope is
@@ -340,7 +468,7 @@ final class AppStateWatchlistTests: XCTestCase {
         appState.addToWatchlist(itemId: 123, name: "Xanax")
         try await Task.sleep(nanoseconds: 800_000_000)
 
-        XCTAssertEqual(appState.watchlistItems.first?.error, "Too many requests",
+        XCTAssertEqual(appState.watchlistItems.first?.error, "Too many requests — backing off.",
                        "v2 market error envelope must be surfaced, not swallowed as 'No listings'")
     }
 
@@ -353,5 +481,49 @@ final class AppStateWatchlistTests: XCTestCase {
 
         XCTAssertEqual(appState.watchlistItems.first?.error, "Incorrect key",
                        "v2 incorrect-key error must surface")
+    }
+}
+
+private final class ConcurrencyProbeNetworkSession: NetworkSession, @unchecked Sendable {
+    private let responseData: Data
+    private let delayNanoseconds: UInt64
+    private let lock = NSLock()
+    private var activeRequests = 0
+    private var recordedRequestCount = 0
+    private var recordedMaximum = 0
+
+    init(json: [String: Any], delayNanoseconds: UInt64) throws {
+        self.responseData = try JSONSerialization.data(withJSONObject: json)
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    var requestCount: Int {
+        lock.withLock { recordedRequestCount }
+    }
+
+    var maximumConcurrentRequests: Int {
+        lock.withLock { recordedMaximum }
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        lock.withLock {
+            recordedRequestCount += 1
+            activeRequests += 1
+            recordedMaximum = max(recordedMaximum, activeRequests)
+        }
+        defer {
+            lock.withLock {
+                activeRequests -= 1
+            }
+        }
+
+        try await Task.sleep(nanoseconds: delayNanoseconds)
+        let response = HTTPURLResponse(
+            url: request.url ?? URL(string: "https://api.torn.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (responseData, response)
     }
 }

--- a/MacTorn/MacTornTests/ViewModels/DiagnosticsTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/DiagnosticsTests.swift
@@ -86,4 +86,76 @@ final class DiagnosticsTests: XCTestCase {
         XCTAssertFalse(DiagnosticsEnvironment.osVersion.isEmpty)
         XCTAssertTrue(["arm64", "x86_64", "unknown"].contains(DiagnosticsEnvironment.architecture))
     }
+
+    // MARK: Module presentation state
+
+    func testModuleStateKeepsCachedContentVisibleOnError() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let state = ModulePresentationState.resolve(
+            health: [
+                EndpointHealth(endpointID: "user.fast", outcome: .error, latencyMs: 10,
+                               responseBytes: 0, at: now, errorClass: "temporaryBackend")
+            ],
+            hasContent: true, isLoading: false, fallbackError: nil,
+            now: now, staleAfter: 120
+        )
+
+        XCTAssertEqual(state.kind, .stale)
+        XCTAssertTrue(state.hasContent)
+        XCTAssertEqual(state.recovery, .retry)
+    }
+
+    func testModuleStateRoutesPermissionFailureToSettings() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let state = ModulePresentationState.resolve(
+            health: [
+                EndpointHealth(endpointID: "faction.basic", outcome: .error, latencyMs: 10,
+                               responseBytes: 0, at: now, errorClass: "insufficientPermissions")
+            ],
+            hasContent: false, isLoading: false, fallbackError: nil,
+            now: now, staleAfter: 120
+        )
+
+        XCTAssertEqual(state.kind, .permission)
+        XCTAssertEqual(state.recovery, .settings)
+    }
+
+    func testModuleStateMarksOldSuccessfulDataStale() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let state = ModulePresentationState.resolve(
+            health: [
+                EndpointHealth(endpointID: "user.fast", outcome: .ok, latencyMs: 10,
+                               responseBytes: 100, at: now.addingTimeInterval(-121), errorClass: nil)
+            ],
+            hasContent: true, isLoading: false, fallbackError: nil,
+            now: now, staleAfter: 120
+        )
+
+        XCTAssertEqual(state.kind, .stale)
+        XCTAssertEqual(state.updatedAt, now.addingTimeInterval(-121))
+    }
+
+    func testModuleStateDistinguishesLoadingEmptyAndFresh() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let loading = ModulePresentationState.resolve(
+            health: [], hasContent: false, isLoading: true, fallbackError: nil,
+            now: now, staleAfter: 120
+        )
+        let empty = ModulePresentationState.resolve(
+            health: [], hasContent: false, isLoading: false, fallbackError: nil,
+            now: now, staleAfter: 120
+        )
+        let fresh = ModulePresentationState.resolve(
+            health: [
+                EndpointHealth(endpointID: "user.fast", outcome: .ok, latencyMs: 10,
+                               responseBytes: 100, at: now, errorClass: nil)
+            ],
+            hasContent: true, isLoading: false, fallbackError: nil,
+            now: now, staleAfter: 120
+        )
+
+        XCTAssertEqual(loading.kind, .loading)
+        XCTAssertEqual(empty.kind, .empty)
+        XCTAssertEqual(fresh.kind, .fresh)
+    }
 }

--- a/MacTorn/MacTornTests/ViewModels/FactionServiceTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/FactionServiceTests.swift
@@ -1,0 +1,206 @@
+import XCTest
+@testable import MacTorn
+
+@MainActor
+final class FactionServiceTests: XCTestCase {
+    private let basicJSON: [String: Any] = [
+        "name": "The Masters",
+        "ID": 11_559,
+        "respect": 12_345,
+        "chain": [
+            "current": 42,
+            "max": 100,
+            "timeout": 250,
+            "cooldown": 0,
+        ],
+    ]
+
+    func testLoadsAndPublishesBasicFactionOnlyAfterFacadeDecision() async throws {
+        let (service, mock) = makeService()
+        try mock.setSuccessResponse(json: basicJSON)
+
+        let result = try await service.loadBasic(from: endpoint("faction"))
+
+        XCTAssertNil(service.basic, "Transport must not bypass facade publication policy")
+        guard case .success(let payload, let bytes) = result else {
+            return XCTFail("Expected decoded faction.basic payload")
+        }
+        XCTAssertEqual(payload.name, "The Masters")
+        XCTAssertEqual(payload.factionId, 11_559)
+        XCTAssertEqual(payload.respect, 12_345)
+        XCTAssertEqual(payload.chain.current, 42)
+        XCTAssertEqual(bytes, mock.mockData?.count)
+
+        service.publishBasic(payload)
+        XCTAssertEqual(service.basic?.factionId, 11_559)
+    }
+
+    func testLoadsAndPublishesRankedWarsOnlyAfterFacadeDecision() async throws {
+        let (service, mock) = makeService()
+        try mock.setSuccessResponse(json: TornAPIFixtures.rankedWarsResponse())
+
+        let result = try await service.loadWars(from: endpoint("rankedwars"))
+
+        XCTAssertTrue(service.wars.isEmpty)
+        guard case .success(let payload, _) = result else {
+            return XCTFail("Expected decoded faction.wars payload")
+        }
+        XCTAssertEqual(payload.count, 2)
+        XCTAssertEqual(payload.first?.id, 44_751)
+
+        service.publishWars(payload)
+        XCTAssertEqual(service.wars.count, 2)
+    }
+
+    func testLoadsAndPublishesNewsOnlyAfterFacadeDecision() async throws {
+        let (service, mock) = makeService()
+        try mock.setSuccessResponse(json: TornAPIFixtures.factionNewsResponse)
+
+        let result = try await service.loadNews(from: endpoint("news"))
+
+        XCTAssertTrue(service.news.isEmpty)
+        guard case .success(let payload, _) = result else {
+            return XCTFail("Expected decoded faction.news payload")
+        }
+        XCTAssertEqual(payload.count, 2)
+        XCTAssertEqual(payload.first?.id, "zL8X")
+
+        service.publishNews(payload)
+        XCTAssertEqual(service.news.count, 2)
+    }
+
+    func testBasicReportsAPIErrorWithoutPublishing() async throws {
+        let (service, mock) = makeService()
+        try mock.setTornAPIError(code: 2, message: "Incorrect key")
+
+        let result = try await service.loadBasic(from: endpoint("faction"))
+
+        guard case .apiError(let error, _) = result else {
+            return XCTFail("Expected faction.basic API error")
+        }
+        XCTAssertTrue(error.haltsAllRequests)
+        XCTAssertNil(service.basic)
+    }
+
+    func testWarsReportsAPIErrorWithoutPublishing() async throws {
+        let (service, mock) = makeService()
+        try mock.setTornAPIErrorV2(code: 16, message: "Access level too low")
+
+        let result = try await service.loadWars(from: endpoint("rankedwars"))
+
+        guard case .apiError(let error, _) = result else {
+            return XCTFail("Expected faction.wars API error")
+        }
+        XCTAssertTrue(error.haltsAllRequests)
+        XCTAssertTrue(service.wars.isEmpty)
+    }
+
+    func testNewsReportsCategoryAPIErrorWithoutPublishing() async throws {
+        let (service, mock) = makeService()
+        try mock.setTornAPIErrorV2(code: 14, message: "Daily read limit reached")
+
+        let result = try await service.loadNews(from: endpoint("news"))
+
+        guard case .apiError(let error, _) = result else {
+            return XCTFail("Expected faction.news API error")
+        }
+        XCTAssertTrue(error.haltsCategoryOnly)
+        XCTAssertTrue(service.news.isEmpty)
+    }
+
+    func testBasicRejectsMissingRequiredFieldsAsMalformed() async throws {
+        let (service, mock) = makeService()
+        try mock.setSuccessResponse(json: ["name": "Looks plausible"])
+
+        let result = try await service.loadBasic(from: endpoint("faction"))
+
+        guard case .malformed(let bytes) = result else {
+            return XCTFail("Expected malformed faction.basic response")
+        }
+        XCTAssertEqual(bytes, mock.mockData?.count)
+    }
+
+    func testWarsRejectsMalformedElementAsMalformed() async throws {
+        let (service, mock) = makeService()
+        try mock.setSuccessResponse(json: ["rankedwars": [["id": "not-an-int"]]])
+
+        let result = try await service.loadWars(from: endpoint("rankedwars"))
+
+        guard case .malformed = result else {
+            return XCTFail("Expected malformed faction.wars response")
+        }
+    }
+
+    func testNewsRejectsMissingArrayAsMalformed() async throws {
+        let (service, mock) = makeService()
+        try mock.setSuccessResponse(json: ["news": "not-an-array"])
+
+        let result = try await service.loadNews(from: endpoint("news"))
+
+        guard case .malformed = result else {
+            return XCTFail("Expected malformed faction.news response")
+        }
+    }
+
+    func testResetClearsAllOwnedFactionState() async throws {
+        let (service, mock) = makeService()
+        try mock.setSuccessResponse(json: basicJSON)
+        if case .success(let basic, _) = try await service.loadBasic(from: endpoint("faction")) {
+            service.publishBasic(basic)
+        }
+        try mock.setSuccessResponse(json: TornAPIFixtures.rankedWarsResponse())
+        if case .success(let wars, _) = try await service.loadWars(from: endpoint("rankedwars")) {
+            service.publishWars(wars)
+        }
+        try mock.setSuccessResponse(json: TornAPIFixtures.factionNewsResponse)
+        if case .success(let news, _) = try await service.loadNews(from: endpoint("news")) {
+            service.publishNews(news)
+        }
+
+        service.reset()
+
+        XCTAssertNil(service.basic)
+        XCTAssertTrue(service.wars.isEmpty)
+        XCTAssertTrue(service.news.isEmpty)
+    }
+
+    func testAppStateFacadePublishesServiceStateAndResetsItOnAccountChange() {
+        let service = FactionService(session: MockNetworkSession())
+        let state = AppState(
+            session: MockNetworkSession(),
+            connectivity: ControllableConnectivity(),
+            defaults: .createMockDefaults(),
+            factionService: service
+        )
+        state.apiKey = "account-a"
+        service.publishBasic(
+            FactionData(
+                name: "Faction A",
+                factionId: 1,
+                respect: 2,
+                chain: FactionChain(current: 3, max: 4, timeout: 5, cooldown: 0)
+            )
+        )
+        service.publishWars([])
+        service.publishNews([])
+
+        XCTAssertEqual(state.factionData?.name, "Faction A")
+        XCTAssertEqual(state.rankedWars.count, service.wars.count)
+        XCTAssertEqual(state.factionNews.count, service.news.count)
+
+        state.apiKey = "account-b"
+
+        XCTAssertNil(state.factionData)
+        XCTAssertTrue(state.rankedWars.isEmpty)
+        XCTAssertTrue(state.factionNews.isEmpty)
+    }
+
+    private func makeService() -> (FactionService, MockNetworkSession) {
+        let mock = MockNetworkSession()
+        return (FactionService(session: mock), mock)
+    }
+
+    private func endpoint(_ path: String) -> URL {
+        URL(string: "https://api.torn.com/\(path)")!
+    }
+}

--- a/MacTorn/MacTornTests/ViewModels/ForumWatchServiceTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/ForumWatchServiceTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+@testable import MacTorn
+
+@MainActor
+final class ForumWatchServiceTests: XCTestCase {
+    func testOwnsParsingStateConfigAndPersistence() throws {
+        let defaults = UserDefaults.createMockDefaults()
+        let service = ForumWatchService(
+            defaults: defaults,
+            session: MockNetworkSession()
+        )
+
+        XCTAssertEqual(service.parseThreadInput(" 12345 "), 12345)
+        XCTAssertEqual(
+            service.parseThreadInput("https://www.torn.com/forums.php#/p=threads&t=16532308"),
+            16_532_308
+        )
+        XCTAssertNil(service.parseThreadInput("invalid"))
+        XCTAssertEqual(service.add(input: "12345"), 12345)
+        XCTAssertNil(service.add(input: "12345"))
+        service.config.pollingIntervalSeconds = 300
+        service.save()
+
+        let reloaded = ForumWatchService(
+            defaults: defaults,
+            session: MockNetworkSession()
+        )
+        reloaded.load()
+        XCTAssertEqual(reloaded.threads.map(\.id), [12345])
+        XCTAssertEqual(reloaded.config.pollingIntervalSeconds, 300)
+    }
+
+    func testLoadNormalizesUnsafePollingInterval() throws {
+        let defaults = UserDefaults.createMockDefaults()
+        defaults.set(
+            try JSONEncoder().encode(ForumWatchConfig(pollingIntervalSeconds: 0)),
+            forKey: "forumWatchConfig"
+        )
+        let service = ForumWatchService(
+            defaults: defaults,
+            session: MockNetworkSession()
+        )
+
+        service.load()
+
+        XCTAssertEqual(service.config.pollingIntervalSeconds, 180)
+    }
+
+    func testRestoreToggleAndMarkReadMutateOwnedState() {
+        let service = ForumWatchService(
+            defaults: .createMockDefaults(),
+            session: MockNetworkSession()
+        )
+        service.threads = [
+            WatchedThread(id: 1, title: "One"),
+            WatchedThread(id: 3, title: "Three")
+        ]
+        let restored = WatchedThread(
+            id: 2,
+            title: "Two",
+            notificationsEnabled: true,
+            lastKnownPostCount: 12,
+            error: "old"
+        )
+
+        XCTAssertTrue(service.restore(restored, at: 1))
+        service.toggleNotifications(threadID: 2)
+        service.markAsRead(threadID: 2)
+
+        XCTAssertEqual(service.threads.map(\.id), [1, 2, 3])
+        XCTAssertFalse(service.threads[1].notificationsEnabled)
+        XCTAssertNil(service.threads[1].error)
+        XCTAssertFalse(service.restore(restored, at: 0))
+    }
+
+    func testApplyUpdatesThreadAndReturnsOnlyEnabledPostIncrease() {
+        let service = ForumWatchService(
+            defaults: .createMockDefaults(),
+            session: MockNetworkSession()
+        )
+        service.threads = [
+            WatchedThread(
+                id: 123,
+                title: "Old",
+                notificationsEnabled: true,
+                lastKnownPostCount: 40,
+                error: "old"
+            )
+        ]
+
+        let update = service.apply(
+            ForumThreadSnapshot(title: "Updated", postCount: 43),
+            to: 123
+        )
+        let unchanged = service.apply(
+            ForumThreadSnapshot(title: "Updated", postCount: 43),
+            to: 123
+        )
+
+        XCTAssertEqual(
+            update,
+            ForumNewPosts(threadID: 123, title: "Updated", count: 3)
+        )
+        XCTAssertNil(unchanged)
+        XCTAssertEqual(service.threads[0].lastKnownPostCount, 43)
+        XCTAssertNil(service.threads[0].error)
+    }
+
+    func testFetchThreadDecodesNestedPayload() async throws {
+        let mock = MockNetworkSession()
+        try mock.setSuccessResponse(json: TornAPIFixtures.forumThreadSuccess)
+        let service = ForumWatchService(
+            defaults: .createMockDefaults(),
+            session: mock
+        )
+
+        let result = try await service.fetchThread(
+            from: URL(string: "https://api.torn.com/v2/forum/12345/thread")!
+        )
+
+        guard case .success(let snapshot, _) = result else {
+            return XCTFail("Expected thread payload")
+        }
+        XCTAssertEqual(snapshot.title, "Test Forum Thread")
+        XCTAssertEqual(snapshot.postCount, 42)
+    }
+
+    func testFetchThreadSurfacesV2APIError() async throws {
+        let mock = MockNetworkSession()
+        try mock.setTornAPIErrorV2(code: 5, message: "Too many requests")
+        let service = ForumWatchService(
+            defaults: .createMockDefaults(),
+            session: mock
+        )
+
+        let result = try await service.fetchThread(
+            from: URL(string: "https://api.torn.com/v2/forum/12345/thread")!
+        )
+
+        guard case .apiError(let error, _) = result else {
+            return XCTFail("Expected API error")
+        }
+        XCTAssertEqual(error.userMessage, "Too many requests — backing off.")
+    }
+}

--- a/MacTorn/MacTornTests/ViewModels/MarketWatchServiceTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/MarketWatchServiceTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import MacTorn
+
+@MainActor
+final class MarketWatchServiceTests: XCTestCase {
+    func testOwnsValidatedStateAndPersistence() {
+        let defaults = UserDefaults.createMockDefaults()
+        let service = MarketWatchService(
+            defaults: defaults,
+            session: MockNetworkSession()
+        )
+
+        XCTAssertTrue(service.add(itemID: 123, name: "  Xanax  "))
+        XCTAssertFalse(service.add(itemID: 123, name: "Duplicate"))
+        XCTAssertFalse(service.add(itemID: 0, name: "Invalid"))
+        XCTAssertEqual(service.items.map(\.name), ["Xanax"])
+
+        let reloaded = MarketWatchService(
+            defaults: defaults,
+            session: MockNetworkSession()
+        )
+        reloaded.load()
+        XCTAssertEqual(reloaded.items.map(\.id), [123])
+    }
+
+    func testRestorePreservesFullItemAtOriginalIndex() {
+        let service = MarketWatchService(
+            defaults: .createMockDefaults(),
+            session: MockNetworkSession()
+        )
+        service.items = [
+            item(id: 1, name: "One"),
+            item(id: 3, name: "Three")
+        ]
+        let restored = WatchlistItem(
+            id: 2,
+            name: "Two",
+            lowestPrice: 90,
+            lowestPriceQuantity: 4,
+            secondLowestPrice: 100,
+            lastUpdated: Date(timeIntervalSince1970: 123),
+            error: "old",
+            priceThreshold: 80,
+            lastAlertedPrice: 75
+        )
+
+        XCTAssertTrue(service.restore(restored, at: 1))
+        XCTAssertEqual(service.items.map(\.id), [1, 2, 3])
+        XCTAssertEqual(service.items[1].priceThreshold, 80)
+        XCTAssertFalse(service.restore(restored, at: 0))
+    }
+
+    func testApplyingPriceUpdatesStateAndReturnsThresholdAlertOnce() {
+        let service = MarketWatchService(
+            defaults: .createMockDefaults(),
+            session: MockNetworkSession()
+        )
+        service.items = [
+            WatchlistItem(
+                id: 7,
+                name: "Target",
+                lowestPrice: 0,
+                lowestPriceQuantity: 0,
+                secondLowestPrice: 0,
+                lastUpdated: nil,
+                error: "loading",
+                priceThreshold: 1_000
+            )
+        ]
+
+        let first = service.apply(
+            MarketPriceSnapshot(
+                lowestPrice: 900,
+                lowestPriceQuantity: 2,
+                secondLowestPrice: 950
+            ),
+            to: 7
+        )
+        let second = service.apply(
+            MarketPriceSnapshot(
+                lowestPrice: 900,
+                lowestPriceQuantity: 2,
+                secondLowestPrice: 950
+            ),
+            to: 7
+        )
+
+        XCTAssertEqual(first, MarketPriceAlert(name: "Target", price: 900))
+        XCTAssertNil(second)
+        XCTAssertEqual(service.items[0].lastAlertedPrice, 900)
+        XCTAssertNil(service.items[0].error)
+    }
+
+    func testFetchPriceDecodesAndSortsAllListingSources() async throws {
+        let mock = MockNetworkSession()
+        try mock.setSuccessResponse(json: TornAPIFixtures.marketItemSuccess)
+        let service = MarketWatchService(
+            defaults: .createMockDefaults(),
+            session: mock
+        )
+
+        let result = try await service.fetchPrice(
+            from: URL(string: "https://api.torn.com/v2/market/123/itemmarket")!
+        )
+
+        guard case .success(let snapshot, _) = result else {
+            return XCTFail("Expected market price")
+        }
+        XCTAssertEqual(snapshot.lowestPrice, 950)
+        XCTAssertEqual(snapshot.lowestPriceQuantity, 2)
+        XCTAssertEqual(snapshot.secondLowestPrice, 1_000)
+    }
+
+    func testFetchPriceSurfacesV2APIError() async throws {
+        let mock = MockNetworkSession()
+        try mock.setTornAPIErrorV2(code: 5, message: "Too many requests")
+        let service = MarketWatchService(
+            defaults: .createMockDefaults(),
+            session: mock
+        )
+
+        let result = try await service.fetchPrice(
+            from: URL(string: "https://api.torn.com/v2/market/123/itemmarket")!
+        )
+
+        guard case .apiError(let error, _) = result else {
+            return XCTFail("Expected API error")
+        }
+        XCTAssertEqual(error.userMessage, "Too many requests — backing off.")
+    }
+
+    private func item(id: Int, name: String) -> WatchlistItem {
+        WatchlistItem(
+            id: id,
+            name: name,
+            lowestPrice: 0,
+            lowestPriceQuantity: 0,
+            secondLowestPrice: 0,
+            lastUpdated: nil,
+            error: nil
+        )
+    }
+}

--- a/MacTorn/MacTornTests/ViewModels/UITestHarnessTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/UITestHarnessTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Sentry
 @testable import MacTorn
 
 /// Unit coverage for the deterministic UI-test harness (Etap G / ISC-20). The XCUITest
@@ -65,7 +66,149 @@ final class UITestHarnessTests: XCTestCase {
         XCTAssertEqual(FixtureScenario(rawValue: "full"), .full)
         XCTAssertEqual(FixtureScenario(rawValue: "invalidKey"), .invalidKey)
         XCTAssertEqual(FixtureScenario(rawValue: "empty"), .empty)
+        XCTAssertEqual(FixtureScenario(rawValue: "accountSwitch"), .accountSwitch)
         XCTAssertNil(FixtureScenario(rawValue: "nonsense"))
+    }
+
+    func testAccountSwitchFixtureRoutesSyntheticIdentityByKey() throws {
+        let accountAURL = try XCTUnwrap(TornAPI.url(for: FixtureNetworkSession.accountAKey))
+        let accountBURL = try XCTUnwrap(TornAPI.url(for: FixtureNetworkSession.accountBKey))
+
+        let accountAData = FixtureNetworkSession.body(for: accountAURL, scenario: .accountSwitch)
+        let accountBData = FixtureNetworkSession.body(for: accountBURL, scenario: .accountSwitch)
+        let accountA = try JSONDecoder().decode(TornResponse.self, from: accountAData)
+        let accountB = try JSONDecoder().decode(TornResponse.self, from: accountBData)
+
+        XCTAssertEqual(accountA.name, "Fixture Account A")
+        XCTAssertEqual(accountA.playerId, 100_001)
+        XCTAssertEqual(accountB.name, "Fixture Account B")
+        XCTAssertEqual(accountB.playerId, 200_002)
+    }
+
+    func testAccountSwitchFixtureRejectsUnknownSyntheticKey() throws {
+        let url = try XCTUnwrap(TornAPI.url(for: "fixture-unknown"))
+        let data = FixtureNetworkSession.body(for: url, scenario: .accountSwitch)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let error = try XCTUnwrap(json["error"] as? [String: Any])
+
+        XCTAssertEqual(error["code"] as? Int, 2)
+    }
+
+    // MARK: - Sentry maintenance contract
+
+    func testSentryStartupRemainsOptInAndDisabledForUITests() {
+        XCTAssertFalse(SentryManager.shouldStart(isEnabled: false, isUITesting: false))
+        XCTAssertFalse(SentryManager.shouldStart(isEnabled: true, isUITesting: true))
+        XCTAssertTrue(SentryManager.shouldStart(isEnabled: true, isUITesting: false))
+    }
+
+    func testSentryConfigurationRemainsCrashOnlyAndPIIFree() throws {
+        let options = Options()
+
+        SentryManager.configure(options, release: "1.2.3", environment: "test")
+
+        XCTAssertEqual(options.releaseName, "mactorn@1.2.3")
+        XCTAssertEqual(options.environment, "test")
+        XCTAssertEqual(options.tracesSampleRate?.doubleValue, 0)
+        XCTAssertFalse(options.sendDefaultPii)
+        XCTAssertFalse(options.enableNetworkTracking)
+        XCTAssertFalse(options.enableNetworkBreadcrumbs)
+        XCTAssertFalse(options.enableCaptureFailedRequests)
+        XCTAssertFalse(options.enableAppHangTracking)
+
+        let request = SentryRequest()
+        request.url = "https://api.torn.com/user/?selections=basic&key=TOP_SECRET"
+        request.queryString = "selections=basic&key=TOP_SECRET"
+        let event = Event(level: .error)
+        event.request = request
+
+        let scrubbedEvent = try XCTUnwrap(options.beforeSend?(event))
+        XCTAssertEqual(scrubbedEvent.request?.url, "https://api.torn.com/user?[key,selections]")
+        XCTAssertNil(scrubbedEvent.request?.queryString)
+
+        let breadcrumb = Breadcrumb(level: .info, category: "http")
+        breadcrumb.data = [
+            "url": "https://api.torn.com/user/?selections=basic&key=TOP_SECRET",
+        ]
+        let scrubbedBreadcrumb = try XCTUnwrap(options.beforeBreadcrumb?(breadcrumb))
+        XCTAssertEqual(
+            scrubbedBreadcrumb.data?["url"] as? String,
+            "https://api.torn.com/user?[key,selections]"
+        )
+    }
+
+    // MARK: - Grouped navigation
+
+    func testNavigationGroupsCoverEveryTabExactlyOnce() {
+        let groupedTabs = AppGroup.allCases.flatMap(\.tabs)
+
+        XCTAssertEqual(groupedTabs.count, AppTab.allCases.count)
+        XCTAssertEqual(Set(groupedTabs), Set(AppTab.allCases))
+    }
+
+    func testNavigationGroupMappingsAndDefaults() {
+        XCTAssertEqual(AppGroup.now.tabs, [.status, .travel, .attacks])
+        XCTAssertEqual(AppGroup.account.tabs, [.money, .faction])
+        XCTAssertEqual(AppGroup.watch.tabs, [.watchlist, .forums])
+
+        for group in AppGroup.allCases {
+            XCTAssertEqual(group.defaultTab.group, group)
+            XCTAssertTrue(group.tabs.allSatisfy { $0.group == group })
+        }
+    }
+
+    // MARK: - Keyboard-first command contract
+
+    func testNavigationCommandsCoverEveryTabWithUniqueShortcuts() {
+        let commands = MacTornCommand.navigation
+
+        XCTAssertEqual(Set(commands.compactMap(\.tab)), Set(AppTab.allCases))
+        XCTAssertEqual(Set(commands.map(\.keyEquivalent)).count, AppTab.allCases.count)
+        XCTAssertEqual(commands.map(\.keyEquivalent), Array("1234567"))
+    }
+
+    func testGlobalCommandShortcutsRemainConventional() {
+        XCTAssertEqual(MacTornCommand.refresh.keyEquivalent, "r")
+        XCTAssertEqual(MacTornCommand.settings.keyEquivalent, ",")
+        XCTAssertNil(MacTornCommand.refresh.tab)
+        XCTAssertNil(MacTornCommand.settings.tab)
+    }
+
+    func testNavigationStateKeepsClicksAndCommandsInSync() {
+        let navigation = AppNavigationState()
+
+        XCTAssertEqual(navigation.selectedTab, .status)
+        XCTAssertFalse(navigation.isShowingSettings)
+
+        navigation.showSettings()
+        XCTAssertTrue(navigation.isShowingSettings)
+        XCTAssertFalse(
+            navigation.dismissSettings(hasConfiguredAccount: false),
+            "Onboarding Settings must not be dismissible"
+        )
+
+        navigation.select(.forums)
+        XCTAssertEqual(navigation.selectedTab, .forums)
+        XCTAssertFalse(navigation.isShowingSettings)
+
+        navigation.showSettings()
+        XCTAssertTrue(navigation.dismissSettings(hasConfiguredAccount: true))
+        XCTAssertFalse(navigation.isShowingSettings)
+    }
+
+    func testSettingsSectionsHaveStableCompactNavigation() {
+        XCTAssertEqual(
+            SettingsSection.allCases.map(\.title),
+            ["Account", "Refresh", "Notifications", "Privacy", "Startup", "Diagnostics & About"]
+        )
+        XCTAssertEqual(
+            SettingsSection.allCases.map(\.compactTitle),
+            ["Account", "Refresh", "Alerts", "Privacy", "Startup", "About"]
+        )
+        XCTAssertEqual(
+            Set(SettingsSection.allCases.map(\.anchorID)).count,
+            SettingsSection.allCases.count
+        )
     }
 }
 #endif

--- a/MacTorn/MacTornTests/ViewModels/UserSnapshotServiceTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/UserSnapshotServiceTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import MacTorn
+
+final class UserSnapshotServiceTests: XCTestCase {
+    func testParsesValidSnapshotIntoTypedPayload() async throws {
+        let service = UserSnapshotService(session: MockNetworkSession())
+        var json = TornAPIFixtures.validFullResponse()
+        json["money_onhand"] = 123
+        json["strength"] = 456
+        let data = try TornAPIFixtures.toData(json)
+
+        let result = await service.parseSnapshot(
+            data: data,
+            requestedSelections: ["basic", "bars", "money", "battlestats"],
+            grantedSelections: nil
+        )
+
+        guard case .success(let payload, let bytes) = result else {
+            return XCTFail("Expected a typed snapshot payload")
+        }
+        XCTAssertEqual(payload.snapshot.name, "TestPlayer")
+        XCTAssertEqual(payload.money.cash, 123)
+        XCTAssertEqual(payload.battleStats.strength, 456)
+        XCTAssertEqual(bytes, data.count)
+    }
+
+    func testRejectsEmptySnapshotWithoutPublishingDefaults() async throws {
+        let service = UserSnapshotService(session: MockNetworkSession())
+        let data = try TornAPIFixtures.toData([:])
+
+        let result = await service.parseSnapshot(
+            data: data,
+            requestedSelections: ["basic", "bars"],
+            grantedSelections: nil
+        )
+
+        guard case .malformed(let bytes) = result else {
+            return XCTFail("Expected malformed response")
+        }
+        XCTAssertEqual(bytes, data.count)
+    }
+
+    func testGrantedProfileSelectionDoesNotRequireBars() async throws {
+        let service = UserSnapshotService(session: MockNetworkSession())
+        let data = try TornAPIFixtures.toData([
+            "name": "ProfileOnly",
+            "player_id": 42
+        ])
+
+        let result = await service.parseSnapshot(
+            data: data,
+            requestedSelections: ["basic", "bars"],
+            grantedSelections: ["basic"]
+        )
+
+        guard case .success(let payload, _) = result else {
+            return XCTFail("Expected profile-only payload")
+        }
+        XCTAssertEqual(payload.snapshot.name, "ProfileOnly")
+    }
+
+    func testLoadsActivityThroughInjectedSession() async throws {
+        let mock = MockNetworkSession()
+        let data = try TornAPIFixtures.toData(TornAPIFixtures.validFullResponse())
+        mock.mockData = data
+        let service = UserSnapshotService(session: mock)
+
+        let result = try await service.loadActivity(
+            URL(string: "https://api.torn.com/user")!
+        )
+
+        guard case .success(let payload, let bytes) = result else {
+            return XCTFail("Expected activity payload")
+        }
+        XCTAssertEqual(payload.events?.count, 1)
+        XCTAssertEqual(payload.unreadMessages, 1)
+        XCTAssertEqual(bytes, data.count)
+    }
+
+    func testLoadsUserV2SectionsIndependently() async throws {
+        let mock = MockNetworkSession()
+        let data = try TornAPIFixtures.toData(
+            TornAPIFixtures.userV2Response(
+                bounties: [TornAPIFixtures.bountyOnMe()]
+            )
+        )
+        mock.mockData = data
+        let service = UserSnapshotService(session: mock)
+
+        let result = try await service.loadUserV2(
+            URL(string: "https://api.torn.com/v2/user")!
+        )
+
+        guard case .success(let payload, let bytes) = result else {
+            return XCTFail("Expected v2 payload")
+        }
+        XCTAssertEqual(payload.organizedCrime?.id, 1_836_033)
+        XCTAssertEqual(payload.bounties.count, 1)
+        XCTAssertNotNil(payload.refills)
+        XCTAssertNotNil(payload.education)
+        XCTAssertEqual(bytes, data.count)
+    }
+
+    func testReportsTornAPIErrorWithoutDecodingPayload() async throws {
+        let mock = MockNetworkSession()
+        try mock.setTornAPIError(code: 14, message: "Daily read limit reached")
+        let service = UserSnapshotService(session: mock)
+
+        let result = try await service.loadActivity(
+            URL(string: "https://api.torn.com/user")!
+        )
+
+        guard case .apiError(let error, _) = result else {
+            return XCTFail("Expected Torn API error")
+        }
+        XCTAssertTrue(error.haltsCategoryOnly)
+    }
+}

--- a/MacTorn/MacTornUITests/MacTornUITests.swift
+++ b/MacTorn/MacTornUITests/MacTornUITests.swift
@@ -15,11 +15,25 @@ final class MacTornUITests: XCTestCase {
 
     /// Launches the app under the harness with a chosen fixture and optional seeded key.
     private func launch(fixture: String, apiKey: String? = nil,
-                        online: Bool = true) -> XCUIApplication {
+                        online: Bool = true,
+                        accessibilityDisplayOptions: Bool = false,
+                        windowHeight: Int? = nil) -> XCUIApplication {
         let app = XCUIApplication()
         var args = ["--uitesting", "-uitest-fixture", fixture,
                     "-uitest-online", online ? "1" : "0"]
         if let apiKey { args += ["-uitest-apikey", apiKey] }
+        if let windowHeight {
+            args += ["-uitest-window-height", String(windowHeight)]
+        }
+        if accessibilityDisplayOptions {
+            // These are process-local harness inputs. They do not mutate the user's
+            // global accessibility preferences.
+            args += [
+                "-reduceTransparency", "YES",
+                "-AppleReduceMotion", "YES",
+                "-AppleIncreaseContrast", "YES",
+            ]
+        }
         app.launchArguments = args
         app.launch()
         return app
@@ -46,31 +60,225 @@ final class MacTornUITests: XCTestCase {
         // The tab bar belongs to the signed-in UI and must be absent during onboarding.
         XCTAssertFalse(app.buttons["uitest.tab.Status"].exists,
                        "Tabs must not be shown before a key is entered")
+        XCTAssertFalse(app.buttons["uitest.group.Now"].exists,
+                       "Navigation groups must not be shown before a key is entered")
     }
 
     // MARK: - Navigation
 
-    /// With a key + a healthy fixture, tapping a tab switches the visible content.
-    func testTabNavigationSwitchesContent() throws {
+    /// Every module stays reachable in at most two actions: group, then module.
+    func testGroupedNavigationSwitchesContentAndPreservesSelectedState() throws {
         let app = launch(fixture: "full", apiKey: "sample-full-user")
         _ = window(app)
 
+        let nowGroup = app.buttons["uitest.group.Now"]
+        XCTAssertTrue(nowGroup.waitForExistence(timeout: 10), "Now group should exist")
+        XCTAssertTrue(nowGroup.isSelected, "Now should be the selected group by default")
+
         let statusTab = app.buttons["uitest.tab.Status"]
         XCTAssertTrue(statusTab.waitForExistence(timeout: 10), "Status tab should exist")
+        XCTAssertTrue(statusTab.isSelected, "Status should be selected by default")
 
         // Status content is the default.
         XCTAssertTrue(app.descendants(matching: .any)["uitest.tabContent.Status"].waitForExistence(timeout: 10),
                       "Status content should be shown by default")
 
-        // Switch to Watchlist and assert the content element tracks the new tab.
-        app.buttons["uitest.tab.Watchlist"].click()
+        // One action selects Watch and its default module, Watchlist.
+        let watchGroup = app.buttons["uitest.group.Watch"]
+        watchGroup.click()
         XCTAssertTrue(app.descendants(matching: .any)["uitest.tabContent.Watchlist"].waitForExistence(timeout: 10),
-                      "Watchlist content should be shown after tapping the Watchlist tab")
+                      "Watchlist should be the Watch group's default module")
+        XCTAssertTrue(watchGroup.isSelected, "Watch group should report selected in AX")
+        XCTAssertTrue(app.buttons["uitest.tab.Watchlist"].isSelected,
+                      "Watchlist should report selected in AX")
 
-        // And back to Money.
-        app.buttons["uitest.tab.Money"].click()
+        // A second action reaches the other module in the active group.
+        app.buttons["uitest.tab.Forums"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["uitest.tabContent.Forums"].waitForExistence(timeout: 10),
+                      "Forums content should be shown from the Watch module picker")
+        XCTAssertTrue(app.buttons["uitest.tab.Forums"].isSelected,
+                      "Forums should report selected in AX")
+
+        // Account is also one action away and defaults to Money.
+        app.buttons["uitest.group.Account"].click()
         XCTAssertTrue(app.descendants(matching: .any)["uitest.tabContent.Money"].waitForExistence(timeout: 10),
-                      "Money content should be shown after tapping the Money tab")
+                      "Money should be the Account group's default module")
+        XCTAssertTrue(app.buttons["uitest.tab.Money"].isSelected,
+                      "Money should report selected in AX")
+    }
+
+    /// The fixed menu-bar surface remains 320 pt wide and neither navigation row clips
+    /// when reduced transparency and increased contrast are requested.
+    func testGroupedNavigationFits320WithAccessibilityDisplayOptions() throws {
+        let app = launch(
+            fixture: "full",
+            apiKey: "sample-accessibility-user",
+            accessibilityDisplayOptions: true
+        )
+        let win = window(app)
+        XCTAssertEqual(win.frame.width, 320, accuracy: 3,
+                       "The compact UI-test surface should remain 320 pt wide")
+
+        let groupIDs = ["Now", "Account", "Watch"]
+        let groups = groupIDs.map { app.buttons["uitest.group.\($0)"] }
+        for group in groups {
+            XCTAssertTrue(group.waitForExistence(timeout: 10))
+            assertContained(group, in: win)
+        }
+        assertDoNotOverlap(groups)
+
+        let nowModules = ["Status", "Travel", "Attacks"].map {
+            app.buttons["uitest.tab.\($0)"]
+        }
+        for module in nowModules {
+            XCTAssertTrue(module.waitForExistence(timeout: 10))
+            XCTAssertTrue(module.isHittable)
+            assertContained(module, in: win)
+        }
+        assertDoNotOverlap(nowModules)
+    }
+
+    /// Pins the AX contract for all seven modules and Settings. Audio order and keyboard
+    /// focus still require the manual system-level matrix documented in the QA report.
+    func testAllModulesAndSettingsExposeStableAXContract() throws {
+        let app = launch(fixture: "full", apiKey: "sample-ax-user", windowHeight: 1000)
+        _ = window(app)
+
+        let groups: [(name: String, modules: [String])] = [
+            ("Now", ["Status", "Travel", "Attacks"]),
+            ("Account", ["Money", "Faction"]),
+            ("Watch", ["Watchlist", "Forums"]),
+        ]
+
+        for group in groups {
+            let groupButton = app.buttons["uitest.group.\(group.name)"]
+            XCTAssertTrue(groupButton.waitForExistence(timeout: 10))
+            XCTAssertEqual(groupButton.label, "\(group.name) group")
+            groupButton.click()
+            assertBecomesSelected(groupButton)
+
+            for module in group.modules {
+                let moduleButton = app.buttons["uitest.tab.\(module)"]
+                XCTAssertTrue(moduleButton.waitForExistence(timeout: 10))
+                XCTAssertEqual(moduleButton.label, module)
+                moduleButton.click()
+                assertBecomesSelected(moduleButton)
+                XCTAssertTrue(
+                    app.descendants(matching: .any)["uitest.tabContent.\(module)"]
+                        .waitForExistence(timeout: 10),
+                    "\(module) content should be reachable through its AX identifier"
+                )
+            }
+        }
+
+        // Return to Status and pin the progress-bar elements exposed by XCUI.
+        // On macOS, SwiftUI's accessibilityValue is available to assistive
+        // technologies but is omitted from XCUI's snapshot for these `Other`
+        // elements; spoken values remain part of the manual VoiceOver matrix.
+        app.buttons["uitest.group.Now"].click()
+        app.buttons["uitest.tab.Status"].click()
+        let refresh = app.buttons["Refresh Torn data"]
+        XCTAssertTrue(refresh.waitForExistence(timeout: 10))
+        XCTAssertEqual(refresh.label, "Refresh Torn data")
+
+        let expectedProgressLabels = ["Energy", "Nerve", "Happy", "Life"]
+        let statusScroll = app.scrollViews["uitest.tabContent.Status"]
+        XCTAssertTrue(statusScroll.waitForExistence(timeout: 10))
+        XCTAssertLessThanOrEqual(
+            statusScroll.frame.height,
+            481,
+            "Status should stay a compact, bounded surface"
+        )
+        let nextAction = app.descendants(matching: .any)["uitest.nextAction"]
+        XCTAssertTrue(nextAction.waitForExistence(timeout: 10))
+        XCTAssertLessThanOrEqual(
+            nextAction.frame.height,
+            52,
+            "Next Action should remain a single compact row"
+        )
+        for label in expectedProgressLabels {
+            let element = statusScroll.otherElements[label]
+            XCTAssertTrue(
+                element.waitForExistence(timeout: 10),
+                "\(label) progress AX element missing"
+            )
+            XCTAssertEqual(element.label, label)
+        }
+
+        app.buttons["uitest.openSettings"].click()
+        let keyField = app.secureTextFields["uitest.apiKeyField"]
+        XCTAssertTrue(keyField.waitForExistence(timeout: 10))
+        XCTAssertEqual(keyField.label, "Torn API Key")
+        XCTAssertEqual(app.buttons["uitest.saveKey"].label, "Save & Connect")
+        XCTAssertEqual(app.buttons["uitest.testConnection"].label, "Test Connection")
+
+        let settingsSections: [(id: String, title: String)] = [
+            ("account", "Account"),
+            ("refresh", "Refresh"),
+            ("notifications", "Notifications"),
+            ("privacy", "Privacy"),
+            ("startup", "Startup"),
+            ("diagnostics", "Diagnostics & About"),
+        ]
+        for section in settingsSections {
+            let button = app.buttons["settings.section.\(section.id)"]
+            XCTAssertTrue(button.waitForExistence(timeout: 10))
+            XCTAssertTrue(button.isHittable)
+            XCTAssertEqual(button.label, section.title)
+            button.click()
+            assertBecomesSelected(button)
+            XCTAssertTrue(
+                app.descendants(matching: .any)["uitest.settingsContent.\(section.id)"]
+                    .waitForExistence(timeout: 10),
+                "\(section.title) should replace the current Settings section"
+            )
+        }
+    }
+
+    // MARK: - Account isolation (T15 fixture preparation)
+
+    /// A delayed, cancellation-ignoring response for synthetic account A must never
+    /// overwrite or briefly reappear after switching to synthetic account B.
+    func testAccountSwitchNeverFlashesStaleIdentity() throws {
+        let app = launch(
+            fixture: "accountSwitch",
+            apiKey: "fixture-account-a",
+            windowHeight: 900
+        )
+        _ = window(app)
+
+        let accountA = app.staticTexts["Fixture Account A"]
+        XCTAssertTrue(accountA.waitForExistence(timeout: 10), "Fixture account A should load")
+
+        // Start the deliberately delayed second A request, then switch while it is in flight.
+        app.buttons["Refresh Torn data"].click()
+        app.buttons["uitest.openSettings"].click()
+
+        let keyField = app.secureTextFields["uitest.apiKeyField"]
+        XCTAssertTrue(keyField.waitForExistence(timeout: 10))
+        keyField.click()
+        keyField.typeKey("a", modifierFlags: .command)
+        keyField.typeText("fixture-account-b")
+        app.buttons["uitest.saveKey"].click()
+
+        // During the new account's initial load ContentView disables interaction. Wait
+        // for the fixture B response, then return to Status.
+        let back = app.buttons["uitest.openSettings"]
+        expectation(for: NSPredicate(format: "hittable == true"), evaluatedWith: back)
+        waitForExpectations(timeout: 10)
+        back.click()
+
+        let accountB = app.staticTexts["Fixture Account B"]
+        XCTAssertTrue(accountB.waitForExistence(timeout: 10), "Fixture account B should load")
+
+        // The non-cancellable A response arrives after 3 seconds. Sample beyond that
+        // boundary so even a short stale-identity flash fails the test.
+        let observationDeadline = Date().addingTimeInterval(4)
+        while Date() < observationDeadline {
+            XCTAssertFalse(accountA.exists, "Stale fixture account A flashed after switching to B")
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        XCTAssertTrue(accountB.exists, "Fixture account B should remain visible")
     }
 
     // MARK: - Error surfacing
@@ -90,7 +298,11 @@ final class MacTornUITests: XCTestCase {
 
     /// "Test Connection" validates the key against /key/info and reports what it unlocks.
     func testTestConnectionReportsAccess() throws {
-        let app = launch(fixture: "full", apiKey: "sample-connection-user")
+        let app = launch(
+            fixture: "full",
+            apiKey: "sample-connection-user",
+            windowHeight: 900
+        )
         _ = window(app)
 
         // Open Settings from the signed-in footer, then run Test Connection.
@@ -125,5 +337,43 @@ final class MacTornUITests: XCTestCase {
                       "Test Connection must not save the key / leave the onboarding screen")
         XCTAssertFalse(app.buttons["uitest.tab.Status"].exists,
                        "The signed-in tab UI must not appear from a mere Test Connection")
+    }
+
+    private func assertContained(_ element: XCUIElement,
+                                 in window: XCUIElement,
+                                 file: StaticString = #filePath,
+                                 line: UInt = #line) {
+        let tolerance: CGFloat = 1
+        XCTAssertGreaterThanOrEqual(element.frame.minX, window.frame.minX - tolerance,
+                                    file: file, line: line)
+        XCTAssertLessThanOrEqual(element.frame.maxX, window.frame.maxX + tolerance,
+                                 file: file, line: line)
+    }
+
+    private func assertDoNotOverlap(_ elements: [XCUIElement],
+                                    file: StaticString = #filePath,
+                                    line: UInt = #line) {
+        let ordered = elements.sorted { $0.frame.minX < $1.frame.minX }
+        for (left, right) in zip(ordered, ordered.dropFirst()) {
+            XCTAssertLessThanOrEqual(left.frame.maxX, right.frame.minX,
+                                     "Navigation controls should not overlap",
+                                     file: file, line: line)
+        }
+    }
+
+    private func assertBecomesSelected(_ element: XCUIElement,
+                                       file: StaticString = #filePath,
+                                       line: UInt = #line) {
+        let selected = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "selected == true"),
+            object: element
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [selected], timeout: 3),
+            .completed,
+            "\(element.identifier) should report selected in AX",
+            file: file,
+            line: line
+        )
     }
 }

--- a/MacTorn/MacTornUITests/MacTornUITests.swift
+++ b/MacTorn/MacTornUITests/MacTornUITests.swift
@@ -41,7 +41,7 @@ final class MacTornUITests: XCTestCase {
 
     /// The single UI-test window. Waits for it so tests don't race the launch.
     private func window(_ app: XCUIApplication) -> XCUIElement {
-        let win = app.windows.firstMatch
+        let win = app.windows["MacTorn UI Tests"]
         XCTAssertTrue(win.waitForExistence(timeout: 15), "UI-test window never appeared")
         return win
     }

--- a/MacTorn/MacTornUITests/MacTornUITests.swift
+++ b/MacTorn/MacTornUITests/MacTornUITests.swift
@@ -141,7 +141,7 @@ final class MacTornUITests: XCTestCase {
     /// Pins the AX contract for all seven modules and Settings. Audio order and keyboard
     /// focus still require the manual system-level matrix documented in the QA report.
     func testAllModulesAndSettingsExposeStableAXContract() throws {
-        let app = launch(fixture: "full", apiKey: "sample-ax-user", windowHeight: 1000)
+        let app = launch(fixture: "full", apiKey: "sample-ax-user")
         _ = window(app)
 
         let groups: [(name: String, modules: [String])] = [
@@ -242,8 +242,7 @@ final class MacTornUITests: XCTestCase {
     func testAccountSwitchNeverFlashesStaleIdentity() throws {
         let app = launch(
             fixture: "accountSwitch",
-            apiKey: "fixture-account-a",
-            windowHeight: 900
+            apiKey: "fixture-account-a"
         )
         _ = window(app)
 
@@ -300,8 +299,7 @@ final class MacTornUITests: XCTestCase {
     func testTestConnectionReportsAccess() throws {
         let app = launch(
             fixture: "full",
-            apiKey: "sample-connection-user",
-            windowHeight: 900
+            apiKey: "sample-connection-user"
         )
         _ = window(app)
 

--- a/MacTorn/MacTornUITests/MacTornUITests.swift
+++ b/MacTorn/MacTornUITests/MacTornUITests.swift
@@ -51,16 +51,16 @@ final class MacTornUITests: XCTestCase {
     /// With no API key, the app must present onboarding (the key entry), not the tabs.
     func testOnboardingWithoutKeyShowsKeyEntry() throws {
         let app = launch(fixture: "empty", apiKey: nil)
-        _ = window(app)
+        let win = window(app)
 
-        let keyField = app.descendants(matching: .any)["uitest.apiKeyField"]
+        let keyField = win.descendants(matching: .any)["uitest.apiKeyField"]
         XCTAssertTrue(keyField.waitForExistence(timeout: 10),
                       "API-key field should be shown when no key is configured")
 
         // The tab bar belongs to the signed-in UI and must be absent during onboarding.
-        XCTAssertFalse(app.buttons["uitest.tab.Status"].exists,
+        XCTAssertFalse(win.buttons["uitest.tab.Status"].exists,
                        "Tabs must not be shown before a key is entered")
-        XCTAssertFalse(app.buttons["uitest.group.Now"].exists,
+        XCTAssertFalse(win.buttons["uitest.group.Now"].exists,
                        "Navigation groups must not be shown before a key is entered")
     }
 
@@ -69,41 +69,41 @@ final class MacTornUITests: XCTestCase {
     /// Every module stays reachable in at most two actions: group, then module.
     func testGroupedNavigationSwitchesContentAndPreservesSelectedState() throws {
         let app = launch(fixture: "full", apiKey: "sample-full-user")
-        _ = window(app)
+        let win = window(app)
 
-        let nowGroup = app.buttons["uitest.group.Now"]
+        let nowGroup = win.buttons["uitest.group.Now"]
         XCTAssertTrue(nowGroup.waitForExistence(timeout: 10), "Now group should exist")
         XCTAssertTrue(nowGroup.isSelected, "Now should be the selected group by default")
 
-        let statusTab = app.buttons["uitest.tab.Status"]
+        let statusTab = win.buttons["uitest.tab.Status"]
         XCTAssertTrue(statusTab.waitForExistence(timeout: 10), "Status tab should exist")
         XCTAssertTrue(statusTab.isSelected, "Status should be selected by default")
 
         // Status content is the default.
-        XCTAssertTrue(app.descendants(matching: .any)["uitest.tabContent.Status"].waitForExistence(timeout: 10),
+        XCTAssertTrue(win.descendants(matching: .any)["uitest.tabContent.Status"].waitForExistence(timeout: 10),
                       "Status content should be shown by default")
 
         // One action selects Watch and its default module, Watchlist.
-        let watchGroup = app.buttons["uitest.group.Watch"]
+        let watchGroup = win.buttons["uitest.group.Watch"]
         watchGroup.click()
-        XCTAssertTrue(app.descendants(matching: .any)["uitest.tabContent.Watchlist"].waitForExistence(timeout: 10),
+        XCTAssertTrue(win.descendants(matching: .any)["uitest.tabContent.Watchlist"].waitForExistence(timeout: 10),
                       "Watchlist should be the Watch group's default module")
         XCTAssertTrue(watchGroup.isSelected, "Watch group should report selected in AX")
-        XCTAssertTrue(app.buttons["uitest.tab.Watchlist"].isSelected,
+        XCTAssertTrue(win.buttons["uitest.tab.Watchlist"].isSelected,
                       "Watchlist should report selected in AX")
 
         // A second action reaches the other module in the active group.
-        app.buttons["uitest.tab.Forums"].click()
-        XCTAssertTrue(app.descendants(matching: .any)["uitest.tabContent.Forums"].waitForExistence(timeout: 10),
+        win.buttons["uitest.tab.Forums"].click()
+        XCTAssertTrue(win.descendants(matching: .any)["uitest.tabContent.Forums"].waitForExistence(timeout: 10),
                       "Forums content should be shown from the Watch module picker")
-        XCTAssertTrue(app.buttons["uitest.tab.Forums"].isSelected,
+        XCTAssertTrue(win.buttons["uitest.tab.Forums"].isSelected,
                       "Forums should report selected in AX")
 
         // Account is also one action away and defaults to Money.
-        app.buttons["uitest.group.Account"].click()
-        XCTAssertTrue(app.descendants(matching: .any)["uitest.tabContent.Money"].waitForExistence(timeout: 10),
+        win.buttons["uitest.group.Account"].click()
+        XCTAssertTrue(win.descendants(matching: .any)["uitest.tabContent.Money"].waitForExistence(timeout: 10),
                       "Money should be the Account group's default module")
-        XCTAssertTrue(app.buttons["uitest.tab.Money"].isSelected,
+        XCTAssertTrue(win.buttons["uitest.tab.Money"].isSelected,
                       "Money should report selected in AX")
     }
 
@@ -120,7 +120,7 @@ final class MacTornUITests: XCTestCase {
                        "The compact UI-test surface should remain 320 pt wide")
 
         let groupIDs = ["Now", "Account", "Watch"]
-        let groups = groupIDs.map { app.buttons["uitest.group.\($0)"] }
+        let groups = groupIDs.map { win.buttons["uitest.group.\($0)"] }
         for group in groups {
             XCTAssertTrue(group.waitForExistence(timeout: 10))
             assertContained(group, in: win)
@@ -128,7 +128,7 @@ final class MacTornUITests: XCTestCase {
         assertDoNotOverlap(groups)
 
         let nowModules = ["Status", "Travel", "Attacks"].map {
-            app.buttons["uitest.tab.\($0)"]
+            win.buttons["uitest.tab.\($0)"]
         }
         for module in nowModules {
             XCTAssertTrue(module.waitForExistence(timeout: 10))
@@ -142,7 +142,7 @@ final class MacTornUITests: XCTestCase {
     /// focus still require the manual system-level matrix documented in the QA report.
     func testAllModulesAndSettingsExposeStableAXContract() throws {
         let app = launch(fixture: "full", apiKey: "sample-ax-user")
-        _ = window(app)
+        let win = window(app)
 
         let groups: [(name: String, modules: [String])] = [
             ("Now", ["Status", "Travel", "Attacks"]),
@@ -151,20 +151,20 @@ final class MacTornUITests: XCTestCase {
         ]
 
         for group in groups {
-            let groupButton = app.buttons["uitest.group.\(group.name)"]
+            let groupButton = win.buttons["uitest.group.\(group.name)"]
             XCTAssertTrue(groupButton.waitForExistence(timeout: 10))
             XCTAssertEqual(groupButton.label, "\(group.name) group")
             groupButton.click()
             assertBecomesSelected(groupButton)
 
             for module in group.modules {
-                let moduleButton = app.buttons["uitest.tab.\(module)"]
+                let moduleButton = win.buttons["uitest.tab.\(module)"]
                 XCTAssertTrue(moduleButton.waitForExistence(timeout: 10))
                 XCTAssertEqual(moduleButton.label, module)
                 moduleButton.click()
                 assertBecomesSelected(moduleButton)
                 XCTAssertTrue(
-                    app.descendants(matching: .any)["uitest.tabContent.\(module)"]
+                    win.descendants(matching: .any)["uitest.tabContent.\(module)"]
                         .waitForExistence(timeout: 10),
                     "\(module) content should be reachable through its AX identifier"
                 )
@@ -175,21 +175,21 @@ final class MacTornUITests: XCTestCase {
         // On macOS, SwiftUI's accessibilityValue is available to assistive
         // technologies but is omitted from XCUI's snapshot for these `Other`
         // elements; spoken values remain part of the manual VoiceOver matrix.
-        app.buttons["uitest.group.Now"].click()
-        app.buttons["uitest.tab.Status"].click()
-        let refresh = app.buttons["Refresh Torn data"]
+        win.buttons["uitest.group.Now"].click()
+        win.buttons["uitest.tab.Status"].click()
+        let refresh = win.buttons["Refresh Torn data"]
         XCTAssertTrue(refresh.waitForExistence(timeout: 10))
         XCTAssertEqual(refresh.label, "Refresh Torn data")
 
         let expectedProgressLabels = ["Energy", "Nerve", "Happy", "Life"]
-        let statusScroll = app.scrollViews["uitest.tabContent.Status"]
+        let statusScroll = win.scrollViews["uitest.tabContent.Status"]
         XCTAssertTrue(statusScroll.waitForExistence(timeout: 10))
         XCTAssertLessThanOrEqual(
             statusScroll.frame.height,
             481,
             "Status should stay a compact, bounded surface"
         )
-        let nextAction = app.descendants(matching: .any)["uitest.nextAction"]
+        let nextAction = win.descendants(matching: .any)["uitest.nextAction"]
         XCTAssertTrue(nextAction.waitForExistence(timeout: 10))
         XCTAssertLessThanOrEqual(
             nextAction.frame.height,
@@ -205,12 +205,12 @@ final class MacTornUITests: XCTestCase {
             XCTAssertEqual(element.label, label)
         }
 
-        app.buttons["uitest.openSettings"].click()
-        let keyField = app.secureTextFields["uitest.apiKeyField"]
+        win.buttons["uitest.openSettings"].click()
+        let keyField = win.secureTextFields["uitest.apiKeyField"]
         XCTAssertTrue(keyField.waitForExistence(timeout: 10))
         XCTAssertEqual(keyField.label, "Torn API Key")
-        XCTAssertEqual(app.buttons["uitest.saveKey"].label, "Save & Connect")
-        XCTAssertEqual(app.buttons["uitest.testConnection"].label, "Test Connection")
+        XCTAssertEqual(win.buttons["uitest.saveKey"].label, "Save & Connect")
+        XCTAssertEqual(win.buttons["uitest.testConnection"].label, "Test Connection")
 
         let settingsSections: [(id: String, title: String)] = [
             ("account", "Account"),
@@ -221,14 +221,14 @@ final class MacTornUITests: XCTestCase {
             ("diagnostics", "Diagnostics & About"),
         ]
         for section in settingsSections {
-            let button = app.buttons["settings.section.\(section.id)"]
+            let button = win.buttons["settings.section.\(section.id)"]
             XCTAssertTrue(button.waitForExistence(timeout: 10))
             XCTAssertTrue(button.isHittable)
             XCTAssertEqual(button.label, section.title)
             button.click()
             assertBecomesSelected(button)
             XCTAssertTrue(
-                app.descendants(matching: .any)["uitest.settingsContent.\(section.id)"]
+                win.descendants(matching: .any)["uitest.settingsContent.\(section.id)"]
                     .waitForExistence(timeout: 10),
                 "\(section.title) should replace the current Settings section"
             )
@@ -244,30 +244,30 @@ final class MacTornUITests: XCTestCase {
             fixture: "accountSwitch",
             apiKey: "fixture-account-a"
         )
-        _ = window(app)
+        let win = window(app)
 
-        let accountA = app.staticTexts["Fixture Account A"]
+        let accountA = win.staticTexts["Fixture Account A"]
         XCTAssertTrue(accountA.waitForExistence(timeout: 10), "Fixture account A should load")
 
         // Start the deliberately delayed second A request, then switch while it is in flight.
-        app.buttons["Refresh Torn data"].click()
-        app.buttons["uitest.openSettings"].click()
+        win.buttons["Refresh Torn data"].click()
+        win.buttons["uitest.openSettings"].click()
 
-        let keyField = app.secureTextFields["uitest.apiKeyField"]
+        let keyField = win.secureTextFields["uitest.apiKeyField"]
         XCTAssertTrue(keyField.waitForExistence(timeout: 10))
         keyField.click()
         keyField.typeKey("a", modifierFlags: .command)
         keyField.typeText("fixture-account-b")
-        app.buttons["uitest.saveKey"].click()
+        win.buttons["uitest.saveKey"].click()
 
         // During the new account's initial load ContentView disables interaction. Wait
         // for the fixture B response, then return to Status.
-        let back = app.buttons["uitest.openSettings"]
+        let back = win.buttons["uitest.openSettings"]
         expectation(for: NSPredicate(format: "hittable == true"), evaluatedWith: back)
         waitForExpectations(timeout: 10)
         back.click()
 
-        let accountB = app.staticTexts["Fixture Account B"]
+        let accountB = win.staticTexts["Fixture Account B"]
         XCTAssertTrue(accountB.waitForExistence(timeout: 10), "Fixture account B should load")
 
         // The non-cancellable A response arrives after 3 seconds. Sample beyond that
@@ -286,9 +286,9 @@ final class MacTornUITests: XCTestCase {
     /// leave the user on a blank screen.
     func testInvalidKeySurfacesError() throws {
         let app = launch(fixture: "invalidKey", apiKey: "sample-bad-user")
-        _ = window(app)
+        let win = window(app)
 
-        let error = app.descendants(matching: .any)["uitest.error"]
+        let error = win.descendants(matching: .any)["uitest.error"]
         XCTAssertTrue(error.waitForExistence(timeout: 15),
                       "An invalid key should surface a visible error message")
     }
@@ -301,18 +301,18 @@ final class MacTornUITests: XCTestCase {
             fixture: "full",
             apiKey: "sample-connection-user"
         )
-        _ = window(app)
+        let win = window(app)
 
         // Open Settings from the signed-in footer, then run Test Connection.
-        let settings = app.buttons["uitest.openSettings"]
+        let settings = win.buttons["uitest.openSettings"]
         XCTAssertTrue(settings.waitForExistence(timeout: 10), "Settings button should exist")
         settings.click()
 
-        let testButton = app.buttons["uitest.testConnection"]
+        let testButton = win.buttons["uitest.testConnection"]
         XCTAssertTrue(testButton.waitForExistence(timeout: 10), "Test Connection button should exist")
         testButton.click()
 
-        XCTAssertTrue(app.descendants(matching: .any)["uitest.keyValidationSuccess"].waitForExistence(timeout: 15),
+        XCTAssertTrue(win.descendants(matching: .any)["uitest.keyValidationSuccess"].waitForExistence(timeout: 15),
                       "A valid key should report its access level after Test Connection")
     }
 
@@ -320,20 +320,20 @@ final class MacTornUITests: XCTestCase {
     /// result stays visible on the Settings screen instead of flipping to the tab UI.
     func testOnboardingTestConnectionKeepsSettingsVisible() throws {
         let app = launch(fixture: "full", apiKey: nil)
-        _ = window(app)
+        let win = window(app)
 
-        let keyField = app.secureTextFields["uitest.apiKeyField"]
+        let keyField = win.secureTextFields["uitest.apiKeyField"]
         XCTAssertTrue(keyField.waitForExistence(timeout: 10), "Key field should be shown at onboarding")
         keyField.click()
         keyField.typeText("sample-typed-value")
 
-        app.buttons["uitest.testConnection"].click()
+        win.buttons["uitest.testConnection"].click()
 
-        XCTAssertTrue(app.descendants(matching: .any)["uitest.keyValidationSuccess"].waitForExistence(timeout: 15),
+        XCTAssertTrue(win.descendants(matching: .any)["uitest.keyValidationSuccess"].waitForExistence(timeout: 15),
                       "Result should appear after Test Connection")
         XCTAssertTrue(keyField.exists,
                       "Test Connection must not save the key / leave the onboarding screen")
-        XCTAssertFalse(app.buttons["uitest.tab.Status"].exists,
+        XCTAssertFalse(win.buttons["uitest.tab.Status"].exists,
                        "The signed-in tab UI must not appear from a mere Test Connection")
     }
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 # MacTorn Makefile
 # Run tests and build commands for local development
 
-.PHONY: test test-unit test-ui build clean coverage coverage-gate help release release-signed hooks scan
+.PHONY: test test-unit test-ui test-all build analyze clean coverage coverage-gate help \
+	release verify-release release-signed diagnose-xctest hooks scan quick-test watch \
+	open test-summary
+
+RELEASE_DERIVED_DATA ?= DerivedData/Release
+RELEASE_APP := $(RELEASE_DERIVED_DATA)/Build/Products/Release/MacTorn.app
 
 # Default target
 help:
@@ -10,8 +15,11 @@ help:
 	@echo "  make test            - Run all unit tests"
 	@echo "  make test-ui         - Run UI tests"
 	@echo "  make build           - Build the app in Debug mode"
+	@echo "  make analyze         - Run Xcode static analysis"
 	@echo "  make release         - Build the app in Release mode (ad-hoc signed, dev only)"
+	@echo "  make verify-release  - Verify universal architectures and strict ad-hoc signature"
 	@echo "  make release-signed  - Build Release signed with Developer ID (set DEVELOPER_ID)"
+	@echo "  make diagnose-xctest - Collect read-only local XCTest runner diagnostics"
 	@echo "  make clean           - Clean build artifacts"
 	@echo "  make coverage        - Run tests with code coverage"
 	@echo "  make coverage-gate   - Enforce >=80% coverage on critical modules"
@@ -64,7 +72,17 @@ build:
 		CODE_SIGN_IDENTITY="-" \
 		CODE_SIGNING_REQUIRED=NO
 
-# Build Release (Universal Binary for Intel + Apple Silicon, ad-hoc signed)
+# Run Xcode static analysis
+analyze:
+	xcodebuild analyze \
+		-project MacTorn/MacTorn.xcodeproj \
+		-scheme MacTorn \
+		-configuration Debug \
+		-destination 'platform=macOS' \
+		CODE_SIGN_IDENTITY="-" \
+		CODE_SIGNING_REQUIRED=NO
+
+# Build Release (Universal Binary for Intel + Apple Silicon, strict ad-hoc signed)
 # This is fine for local development. For distribution use `release-signed` below.
 release:
 	xcodebuild build \
@@ -72,10 +90,24 @@ release:
 		-scheme MacTorn \
 		-configuration Release \
 		-destination 'generic/platform=macOS' \
+		-derivedDataPath '$(RELEASE_DERIVED_DATA)' \
 		ARCHS="arm64 x86_64" \
 		ONLY_ACTIVE_ARCH=NO \
+		CODE_SIGN_STYLE=Manual \
 		CODE_SIGN_IDENTITY="-" \
-		CODE_SIGNING_REQUIRED=NO
+		CODE_SIGNING_ALLOWED=YES \
+		CODE_SIGNING_REQUIRED=YES
+
+# Verify that the local Release gate produced both architectures and only an ad-hoc signature.
+verify-release:
+	@test -d '$(RELEASE_APP)' || { echo "Release app not found: $(RELEASE_APP). Run 'make release' first."; exit 2; }
+	@archs="$$(lipo -archs '$(RELEASE_APP)/Contents/MacOS/MacTorn')"; \
+		echo "Architectures: $$archs"; \
+		printf '%s\n' "$$archs" | grep -qw arm64; \
+		printf '%s\n' "$$archs" | grep -qw x86_64
+	codesign --verify --deep --strict --verbose=2 '$(RELEASE_APP)'
+	@codesign -dv --verbose=4 '$(RELEASE_APP)' 2>&1 | grep -q '^Signature=adhoc$$'
+	@echo "Release verification passed: universal and strict ad-hoc signed."
 
 # Build Release signed with Developer ID (Universal Binary). Required for distribution
 # so users can verify the publisher. Notarization is a follow-up — without it, Gatekeeper
@@ -178,6 +210,11 @@ hooks:
 scan:
 	@command -v gitleaks >/dev/null 2>&1 || { echo "❌ gitleaks not found. Install with: brew install gitleaks"; exit 1; }
 	gitleaks git --no-banner --redact -v --config .gitleaks.toml
+
+# Collect environment and service state without restarting or killing XCTest services.
+# Pass RESULT_BUNDLE=/path/to/result.xcresult to include its test summary.
+diagnose-xctest:
+	bash scripts/diagnose-xctest.sh '$(RESULT_BUNDLE)'
 
 # Show test summary
 test-summary:

--- a/QA_ACCESSIBILITY_SYSTEM_REPORT.md
+++ b/QA_ACCESSIBILITY_SYSTEM_REPORT.md
@@ -1,0 +1,115 @@
+# MacTorn — Accessibility and System QA Report
+
+Date: 2026-07-30
+Scope: T14-B execution and T15-B preparation without secrets
+
+## Automated coverage
+
+- [x] All seven modules are reachable through stable AX identifiers and expose the
+  expected selected state.
+- [x] Navigation group and module controls expose non-empty, stable labels.
+- [x] Status progress elements expose combined labels and exact values.
+- [x] Settings exposes stable AX identifiers and labels for the key field, Save and
+  Test Connection.
+- [x] The 320 pt fixture window is checked for navigation clipping and overlap with
+  process-local Reduce Transparency, Reduce Motion and Increase Contrast preference
+  arguments. SwiftUI exposes the latter two environment values as read-only, so this is
+  a best-effort smoke and not a substitute for the real system-setting matrix below.
+- [x] Synthetic account A to B is covered without Keychain or network access. The
+  fixture delivers a delayed, cancellation-ignoring A response and verifies that A
+  never flashes after B becomes active.
+- [x] UI tests skip notification permission prompts and update network calls.
+
+Automated checks are hermetic. The strings `fixture-account-a` and
+`fixture-account-b` are test tokens, not Torn credentials.
+
+### Validation status
+
+- Fixture/unit contract: passed, 13 tests, 0 failures.
+- 320 pt accessibility-display navigation smoke: passed.
+- Synthetic account A→B UI regression: passed; B remained visible after the delayed,
+  cancellation-ignoring A response completed.
+- The seven-module AX traversal reaches the progress-value assertions successfully.
+  Its latest rerun exposed only a test viewport issue (the preserved Status scroll
+  offset hid the first progress element); the test now resets the scroll position and
+  needs one final rerun after the current parallel `AppState` extraction is stable.
+
+## Manual T14-B matrix
+
+Use the Debug UI-test fixture or a dedicated local QA build. Do not use production
+credentials.
+
+| Surface | VoiceOver order/audio | Full Keyboard Access | Reduce Motion | Increase Contrast |
+|---|---|---|---|---|
+| Status | [ ] | [ ] | [ ] | [ ] |
+| Travel | [ ] | [ ] | [ ] | [ ] |
+| Attacks | [ ] | [ ] | [ ] | [ ] |
+| Money | [ ] | [ ] | [ ] | [ ] |
+| Faction | [ ] | [ ] | [ ] | [ ] |
+| Watchlist | [ ] | [ ] | [ ] | [ ] |
+| Forums | [ ] | [ ] | [ ] | [ ] |
+| Settings | [ ] | [ ] | [ ] | [ ] |
+
+For every row:
+
+1. VoiceOver: confirm spoken order matches visual/task order, selected navigation is
+   announced, values are not split into noisy fragments, and icon actions have meaningful
+   names. Record audio findings manually; XCTest cannot assess pronunciation or listening
+   effort.
+2. Full Keyboard Access: traverse forward and backward, confirm a visible focus ring,
+   no focus trap, logical group/module order and activation with Space/Return.
+3. Reduce Motion: enable the real macOS setting and confirm no essential state depends
+   on animation and no unexpected motion remains.
+4. Increase Contrast: enable the real macOS setting and confirm selected state, focus,
+   progress tracks, banners and text remain distinguishable.
+
+Acceptance: no open P1/P2 accessibility issue. Any reproducible semantic regression gets
+an AX/XCUITest before closure.
+
+## Manual T15-B system scenarios
+
+These steps require explicit user preparation and are intentionally not automated:
+
+### Two dedicated test accounts
+
+- [ ] User supplies two dedicated non-production Torn test keys through the UI.
+- [ ] Confirm account A identity and a recognizable A-only datum.
+- [ ] Start Refresh, immediately save account B, then return to Status.
+- [ ] Confirm A disappears immediately and never flashes while B loads or after B appears.
+- [ ] Confirm watchlist, forum, faction, money and diagnostics contain no A data.
+- [ ] Remove both test keys from the QA profile after the run.
+
+Never paste keys into this report, terminal output, source, fixtures or screenshots.
+The agent did not read the real Keychain or local configuration.
+
+### Notification permission and alert
+
+- [ ] In a dedicated macOS QA profile, user explicitly approves notification permission.
+- [ ] Trigger a fixture-safe notification path and confirm title/body, timing and click
+  behavior.
+- [ ] Test denied permission and confirm the app remains usable with clear recovery.
+- [ ] Record the macOS version and permission state, without player data.
+
+The UI-test harness intentionally bypasses the system prompt. No notification permission
+was changed during automated work.
+
+### Launch at Login
+
+- [ ] In the dedicated QA profile, enable Launch at Login.
+- [ ] Log out and back in, then confirm MacTorn starts once and remains a menu-bar app.
+- [ ] Disable Launch at Login, repeat logout/login and confirm it does not start.
+
+This changes persistent system state and requires the user's explicit approval. It was not
+performed during automated work.
+
+## Known limits
+
+- VoiceOver audio quality and reading order require an interactive listening session.
+- Full Keyboard Access and real Reduce Motion/Increase Contrast behavior depend on global
+  macOS settings; process-level fixture injection is only a regression smoke test.
+- Notification authorization and Launch at Login require system consent and a dedicated
+  macOS QA profile.
+- Real account switching requires two dedicated test accounts supplied by the user.
+- XCUITest drove only the hermetic app fixture. The `computer-use` safety boundary was
+  applied: no direct interaction with system settings, consent dialogs, VoiceOver audio
+  or real-account credentials was attempted.

--- a/UX_RECOMMENDATIONS.md
+++ b/UX_RECOMMENDATIONS.md
@@ -1,0 +1,222 @@
+# MacTorn — stan UX i dalsze rekomendacje
+
+Data: 2026-07-30
+Zakres: stan po wdrożeniach T01–T17, przegląd heurystyczny, testy modeli i fixture'ów oraz automatyczna inspekcja kontraktów UI/Accessibility.
+
+## Podsumowanie
+
+MacTorn realizuje podstawową obietnicę aplikacji menu-bar: pozwala szybko sprawdzić stan Torn, przejść do właściwego modułu i odzyskać się po błędzie bez otwierania pełnej aplikacji.
+
+Najważniejsze wcześniejsze problemy zostały rozwiązane:
+
+- siedem równorzędnych zakładek zastąpiła nawigacja `Now / Account / Watch`;
+- każdy z siedmiu modułów jest dostępny w maksymalnie dwóch akcjach lub bezpośrednim skrótem klawiaturowym;
+- ręczne fonty 8 pt zastąpiły style semantyczne, nie mniejsze niż `.caption2`;
+- alert ceny waliduje dodatnią liczbę całkowitą, pokazuje inline error i nie zamyka formularza po błędzie;
+- usuwanie pozycji watchlisty i obserwowanych wątków ma sześciosekundowe Undo;
+- moduły korzystają ze wspólnego modelu loading / empty / stale / error i pokazują właściwą akcję recovery;
+- freshness jest liczona per endpoint, a ostatnie poprawne dane pozostają widoczne podczas przejściowego błędu;
+- polling i odświeżanie mają ograniczoną współbieżność zamiast niekontrolowanego burstu zapytań;
+- nawigacja kliknięciem i Commands współdzieli jeden stan;
+- Settings ma sześć stale widocznych kategorii i pokazuje tylko jedną sekcję naraz.
+- Status jest ograniczony do zwartej powierzchni, a Next Action pokazuje wyłącznie najbliższe zdarzenie.
+
+Pozostałe ryzyka dotyczą przede wszystkim walidacji na prawdziwym macOS i prawdziwych kontach, a nie brakujących mechanizmów w kodzie. Nadal potrzebne są ręczne przejścia VoiceOver, rzeczywisty Full Keyboard Access, systemowe Increase Contrast / Reduce Motion / Reduce Transparency, zmiana między dwoma kontami, dostarczenie powiadomień oraz Launch at Login.
+
+Techniczny punkt odniesienia: lokalny automated release candidate jest zielony — 428/428 unit, 8/8 UI, coverage gate, Debug/build-for-testing, post-merge analyze, scan oraz universal strict ad-hoc Release przechodzą. Pierwszy zdalny run nowego workflow CI nie został jeszcze wykonany.
+
+## Ocena heurystyczna
+
+Skala: 1 — słabo, 5 — bardzo dobrze. Ocena uwzględnia wdrożenia T01–T17, ale nie zastępuje otwartych testów manualnych.
+
+| Kryterium | Ocena | Uzasadnienie |
+|---|---:|---|
+| Widoczność stanu systemu | 4,7 | Loading, freshness, stale data, błędy endpointów i diagnostyka mają wspólny język i recovery CTA. |
+| Dopasowanie do modelu użytkownika | 4,6 | Terminologia odpowiada Torn, a Quick Travel rozróżnia Standard oraz Airstrip + pilot. |
+| Kontrola i odwracalność | 4,6 | Watchlist i forum mają Undo; formularze zachowują błędny input; Escape zamyka aktywne warstwy tam, gdzie jest to bezpieczne. |
+| Spójność | 4,5 | Moduły współdzielą komponent stanów, semantyczną typografię i konsekwentne wzorce retry/error. |
+| Zapobieganie błędom | 4,6 | Klucz, forum ID i próg ceny mają walidację; zapis alertu nie przyjmuje wartości pustej, tekstowej, zerowej ani ujemnej. |
+| Rozpoznawanie zamiast pamiętania | 4,6 | Trzy grupy i aktywny picker ograniczają liczbę równoczesnych opcji; Commands pokazuje skróty. |
+| Efektywność dla regularnego gracza | 4,7 | Refresh `⌘R`, Settings `⌘,` i moduły `⌘1…⌘7` obsługują podstawowe zadania bez myszy. |
+| Minimalizm i hierarchia | 4,4 | Nawigacja grupowa oraz sekcje Settings zmniejszyły gęstość w powierzchni 320 pt. |
+| Obsługa błędów | 4,6 | Ostatnie dobre dane nie znikają przy błędzie chwilowym, a użytkownik dostaje adekwatne Retry lub Open Settings. |
+| Dostępność | 4,2 | AX labels, selected traits, semantyczne fonty i widoczny focus są wdrożone; pełny manualny audyt audio i systemowego FKA pozostaje otwarty. |
+
+Średnia heurystyczna: **4,55 / 5**.
+
+## Najważniejsze ścieżki użytkownika
+
+### 1. Szybki check stanu
+
+Cel: w kilka sekund sprawdzić bars, cooldowny, travel/status i kolejną akcję.
+
+Stan: wdrożony. Status jest domyślnym modułem grupy Now. Progress bary są pojedynczymi elementami AX z nazwą, wartością i procentem. Stan modułu odróżnia dane świeże, stare, ładowanie i błąd, zachowując ostatni poprawny snapshot.
+
+### 2. Zmiana lub test klucza
+
+Cel: wkleić klucz, sprawdzić uprawnienia i rozpocząć polling bez wyświetlenia danych poprzedniego konta.
+
+Stan: wdrożony i objęty deterministycznym fixture'em. Whitespace-only nie aktywuje zapisu, spóźniona odpowiedź starej sesji nie nadpisuje nowej, a trwałe odrzucenie usuwa stary snapshot.
+
+Otwarte: ręczny test szybkiej zmiany pomiędzy dwoma rzeczywistymi kontami testowymi.
+
+### 3. Obserwowanie wątku
+
+Cel: wkleić URL lub ID, włączyć monitoring i bezpiecznie zarządzać listą.
+
+Stan: wdrożony. Błędny input pozostaje w polu, format i duplikat mają osobne inline errors, a usunięty wątek można przywrócić przez Undo wraz z pełnym stanem i pozycją.
+
+### 4. Alert ceny
+
+Cel: ustawić dodatnią cenę progową dla itemu.
+
+Stan: wdrożony. Formularz przyjmuje wyłącznie dodatnią liczbę całkowitą, pokazuje konkretny inline error, wyłącza Set dla niepoprawnej wartości i nie zamyka się po błędnym Enter. Usuniętą pozycję można przywrócić przez Undo.
+
+### 5. Quick Travel
+
+Cel: otrzymać uczciwy szacunek lotu i odróżnić estymatę od aktywnego lotu.
+
+Stan: wdrożony.
+
+- Dla planowanego lotu użytkownik jawnie wybiera `Standard` albo `Airstrip + pilot`.
+- Interfejs informuje, że Airstrip + pilot wymaga odpowiedniego upgrade'u i aktywnego pilota.
+- Szacunki uwzględniają oficjalne czasy oraz wariancję ±3%.
+- Aktywny lot jest API-driven: UI pokazuje czas pozostały zwrócony dla bieżącej podróży zamiast zastępować go lokalną estymatą.
+- Ustawienie Private Island steruje wyłącznie skrótem/ikoną powrotu i nie przełącza metody estymacji.
+
+### 6. Nawigacja i Settings bez myszy
+
+Cel: odświeżyć dane, przejść do modułu i zmienić ustawienie klawiaturą.
+
+Stan: wdrożony.
+
+- Refresh: `⌘R`
+- Settings: `⌘,`
+- Status, Travel, Attacks, Money, Faction, Watchlist, Forums: `⌘1…⌘7`
+- Escape zamyka Settings, aktywne pole lub modal tam, gdzie nie narusza onboardingu.
+- Widoczne menu Commands i fokus na elementach nawigacji ułatwiają odkrycie obsługi klawiaturą.
+
+Otwarte: pełne ręczne przejście z włączonym systemowym Full Keyboard Access.
+
+### 7. Diagnoza i recovery
+
+Cel: rozpoznać offline, zły klucz, brak uprawnień, rate limit lub awarię pojedynczego endpointu.
+
+Stan: wdrożony. Wspólny komponent stanu kieruje do Retry lub Settings, per-endpoint freshness rozróżnia brak danych od danych nieświeżych, a Diagnostics pokazuje connectivity, budżet zapytań i zdrowie endpointów bez PII.
+
+## Wdrożenia T02–T17 istotne dla UX
+
+| Obszar | Stan | Kryterium potwierdzające |
+|---|---|---|
+| Walidacja progu cenowego | Wdrożone | Inline error, disabled Set, błędny Enter nie zamyka formularza. |
+| Undo watchlisty i forum | Wdrożone | Przywrócenie pełnego elementu i pierwotnej pozycji w ciągu 6 s. |
+| Nawigacja grupowa | Wdrożone | `Now / Account / Watch`, aktywny podrzędny picker, maks. 2 akcje do modułu. |
+| Typografia semantyczna | Wdrożone | Brak ręcznych 8 pt; produkcyjne widoki używają stylów co najmniej `.caption2`. |
+| Wspólne stany i recovery | Wdrożone | Jednolity loading / empty / stale / error oraz właściwe CTA. |
+| Freshness | Wdrożone | Stan per endpoint i zachowanie ostatnich dobrych danych. |
+| Ograniczona współbieżność | Wdrożone | Kolejka z limitem i obsługą anulowania zamiast burstu requestów. |
+| Keyboard-first | Wdrożone | Commands, `⌘R`, `⌘,`, `⌘1…⌘7`, Escape i widoczny fokus. |
+| Settings IA | Wdrożone | Stały przełącznik sześciu kategorii; jedna sekcja naraz, lokalny scroll tylko po rozwinięciu długiej treści. |
+| Quick Travel | Wdrożone | Jawny Standard/Airstrip + pilot; aktywny lot oparty na API. |
+
+## Status walidacji
+
+### Potwierdzone automatycznie
+
+- 428/428 unit tests, 0 failed, 0 skipped.
+- Coverage gate: PASS.
+- `TornAPIError` 99,07%, `TornEndpoint` 83,56%, `PollingCoordinator` 100%, `NotificationCoordinator` 100%, `NextAction` 96,51%.
+- Debug i build-for-testing: PASS.
+- Post-merge analyze: PASS.
+- Scan: PASS, brak wycieków.
+- 320 pt accessibility-display navigation smoke: PASS.
+- Synthetic account A→B: PASS.
+- Finalny MacTornUITests: 8/8 PASS, 0 failed/skipped/expected.
+- All-modules + Settings AX: PASS, 48.535 s.
+- Stale account switch: PASS, 15.534 s.
+- UI bundle: `/tmp/mactorn-final-ui-suite-20260730-1058-clean.xcresult`.
+- Quick Travel: 24/24 `TravelTests`, w tym komplet Standard/Airstrip oraz API-driven active flight.
+- Universal Release `x86_64 arm64` i strict ad-hoc codesign: PASS.
+
+### Oczekujące
+
+- pierwszy zdalny run workflow CI i jego artefakty;
+- VoiceOver audio i real Full Keyboard Access;
+- systemowe motion/contrast/transparency;
+- dwa rzeczywiste konta, notifications i Launch at Login.
+
+## Aktualna architektura informacji
+
+```text
+Now
+  Status
+  Travel
+  Attacks
+
+Account
+  Money
+  Faction
+
+Watch
+  Watchlist
+  Forums
+```
+
+W powierzchni 320 pt stale widoczne są trzy grupy, a drugi rząd pokazuje wyłącznie moduły aktywnej grupy. Commands zapewnia bezpośredni skok bez przechodzenia przez oba poziomy.
+
+Settings zachowuje liniową kolejność wizualną i Accessibility:
+
+```text
+Account
+Refresh
+Notifications
+Privacy
+Startup
+Diagnostics & About
+```
+
+Stały przełącznik kategorii zastępuje dawną długą stronę i jump menu. Zmiana sekcji podmienia treść w tym samym miejscu, więc użytkownik nie traci orientacji ani nie musi wracać na początek listy.
+
+## Dalsze rekomendacje
+
+| Priorytet | Rekomendacja | Rodzaj | Kryterium zakończenia |
+|---|---|---|---|
+| P1 | Przejść wszystkie moduły i Settings z VoiceOver audio. | Manualny test systemowy | Logiczna kolejność, poprawne nazwy i wartości, brak podwójnie czytanych kontrolek. |
+| P1 | Przejść pełny scenariusz z rzeczywistym Full Keyboard Access. | Manualny test systemowy | Każdy interaktywny element osiągalny, focus zawsze widoczny, brak pułapki. |
+| P1 | Sprawdzić Increase Contrast, Reduce Motion i Reduce Transparency w ustawieniach systemowych. | Manualny test systemowy | Brak utraty stanu selected/focus, czytelne warstwy i brak zbędnego ruchu. |
+| P1 | Zmienić szybko dwa rzeczywiste konta testowe. | Manualny test integracyjny | Brak flasha poprzedniej tożsamości i brak danych starego konta po zmianie. |
+| P2 | Zweryfikować powiadomienia na prawdziwym urządzeniu i koncie. | Manualny test integracyjny | Jedno poprawne powiadomienie, właściwy deep link i brak duplikatów. |
+| P2 | Zweryfikować Launch at Login po restarcie i po odmowie systemowej. | Manualny test systemowy | Poprawny start, czytelny błąd i możliwość odzyskania. |
+| P2 | Sprawdzić większy tekst/zoom we wszystkich sześciu sekcjach Settings i siedmiu modułach. | Manualny test wizualny | Brak obcięć, overlapów i niedostępnych akcji w szerokości 320 pt. |
+| P3 | Przeprowadzić krótkie testy zadaniowe z graczami Torn. | Badanie użyteczności | Quick check, alert ceny, forum watch i recovery wykonane bez podpowiedzi. |
+
+## Checklist UX / Accessibility
+
+### Wdrożone i objęte testami automatycznymi
+
+- [x] Każdy moduł ma nazwę i selected trait w AX.
+- [x] Ikonowe refresh/add/remove/open mają zrozumiałe etykiety.
+- [x] Energy/Nerve/Happy/Life czytają nazwę, wartość i procent.
+- [x] Błędny wątek i próg ceny zachowują wpis oraz pokazują inline error.
+- [x] Set alertu jest wyłączony dla pustej, tekstowej, zerowej i ujemnej wartości.
+- [x] Watchlist i forum mają Undo.
+- [x] Invalid key, offline, stale data i brak danych są rozróżnialne.
+- [x] Recovery prowadzi do Retry lub Settings zależnie od stanu.
+- [x] Freshness i zdrowie są liczone per endpoint.
+- [x] Ograniczona współbieżność respektuje anulowanie.
+- [x] Nawigacja grupowa mieści siedem modułów w trzech grupach.
+- [x] Fonty produkcyjne używają stylów semantycznych co najmniej `.caption2`.
+- [x] Commands mapuje jednoznacznie `⌘R`, `⌘,` oraz `⌘1…⌘7`.
+- [x] Settings ma sześć stale widocznych kategorii i jedną aktywną sekcję.
+- [x] Quick Travel rozdziela Standard, Airstrip + pilot i API-driven active flight.
+- [x] Diagnostics nie ujawnia klucza ani danych gracza.
+
+### Nadal wymagane ręcznie
+
+- [ ] VoiceOver audio: kolejność i brzmienie wszystkich siedmiu modułów oraz Settings.
+- [ ] Rzeczywisty Full Keyboard Access: kolejność tabulacji, focus ring i brak pułapki.
+- [ ] Systemowe Increase Contrast, Reduce Motion i Reduce Transparency.
+- [ ] Większy tekst / zoom bez obcięć w szerokości 320 pt.
+- [ ] Szybka zmiana pomiędzy dwoma rzeczywistymi kontami testowymi.
+- [ ] Dostarczenie, treść, deep link i deduplikacja powiadomień.
+- [ ] Launch at Login po restarcie oraz obsługa odmowy/błędu systemowego.

--- a/scripts/diagnose-xctest.sh
+++ b/scripts/diagnose-xctest.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Read-only XCTest runner diagnostics. This intentionally does not restart, kill, or
+# mutate testmanagerd/Xcode services. Optionally pass an xcresult path to summarize it.
+
+set -u
+set -o pipefail
+
+RESULT_BUNDLE="${1:-}"
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+section "Timestamp"
+date -u '+%Y-%m-%dT%H:%M:%SZ'
+
+section "macOS"
+sw_vers
+
+section "Selected developer directory"
+xcode-select -p
+xcodebuild -version
+
+section "Available macOS test destinations"
+xcodebuild \
+  -project "$PROJECT_ROOT/MacTorn/MacTorn.xcodeproj" \
+  -scheme MacTorn \
+  -showdestinations 2>&1
+
+section "XCTest-related processes"
+# Use executable names rather than full command lines so diagnostics cannot leak
+# arguments supplied to an unrelated local test process.
+ps -axo pid,ppid,etime,state,comm \
+  | awk 'NR == 1 { print; next }
+         {
+           name = $5
+           sub(/^.*\//, "", name)
+           if (name == "xcodebuild" || name == "xctest" || name == "testmanagerd") print
+         }'
+
+section "Writable runner paths"
+for path in "${TMPDIR:-/tmp}" \
+            "$PROJECT_ROOT/DerivedData" \
+            "$PROJECT_ROOT/TestResults"; do
+  parent="$path"
+  if [[ ! -e "$parent" ]]; then
+    parent="$(dirname "$parent")"
+  fi
+  if [[ -w "$parent" ]]; then
+    printf 'writable  %s\n' "$path"
+  else
+    printf 'BLOCKED   %s (nearest existing parent: %s)\n' "$path" "$parent"
+  fi
+done
+
+if [[ -n "$RESULT_BUNDLE" ]]; then
+  section "xcresult summary"
+  if [[ -e "$RESULT_BUNDLE" ]]; then
+    xcrun xcresulttool get test-results summary --path "$RESULT_BUNDLE" 2>&1
+  else
+    printf 'Result bundle not found: %s\n' "$RESULT_BUNDLE"
+  fi
+fi
+
+section "Safety"
+printf '%s\n' "No service was restarted or terminated and no cache was deleted."


### PR DESCRIPTION
## Summary

- compact Status and category-based Settings UI
- current travel times with standard-airport and Private Island airstrip modes
- account-scoped sessions, bounded service fan-out, clearer recovery/freshness states
- AppState decomposition, Sentry 9.23 privacy hardening, expanded QA and audit artifacts
- version bump and changelog for v1.11.0

## Validation

- 428/428 unit tests passed
- critical-module coverage gate passed (83.56%–100%)
- Xcode static analysis passed
- staged secret scan passed
- universal Release build passed (`x86_64` + `arm64`)
- strict ad-hoc signature verification passed
- DMG mounted and verified headlessly

UI automation was intentionally not rerun for the final compact-layout delta because the workstation was in active use; no UI was opened or controlled during this release run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added grouped navigation with keyboard shortcuts and a Commands menu for refresh and quick tab switching.
  * Added compact “Next Action” display (single upcoming item).
  * Added undo for watchlist and forum-thread removals.
  * Added travel estimate method selection (including airstrip).
* **Improvements**
  * Enhanced module status indicators with Retry/Settings recovery, plus privacy-conscious diagnostics.
  * Improved accessibility labels and navigation focus/escape behavior.
  * Strengthened account switching safety and data freshness/error recovery.
* **Documentation**
  * Added release, audit, accessibility QA, UX recommendations, and implementation backlog documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->