### PR TITLE
Distinguish the Watchlist tab icon from Stocks

### DIFF
--- a/MacTorn/MacTorn/Views/ContentView.swift
+++ b/MacTorn/MacTorn/Views/ContentView.swift
@@ -46,7 +46,7 @@ enum AppTab: String, CaseIterable {
         case .stocks: return "chart.line.uptrend.xyaxis"
         case .attacks: return "bolt.shield.fill"
         case .faction: return "person.3.fill"
-        case .watchlist: return "chart.line.uptrend.xyaxis"
+        case .watchlist: return "tag.fill"
         case .forums: return "bubble.left.and.bubble.right.fill"
         }
     }

--- a/MacTorn/MacTornTests/Models/WatchlistItemTests.swift
+++ b/MacTorn/MacTornTests/Models/WatchlistItemTests.swift
@@ -3,6 +3,10 @@ import XCTest
 
 final class WatchlistItemTests: XCTestCase {
 
+    func testWatchlistTabUsesTagIcon() {
+        XCTAssertEqual(AppTab.watchlist.icon, "tag.fill")
+    }
+
     // MARK: - priceDifference Tests
 
     func testPriceDifference_normalCase() {


### PR DESCRIPTION
PR description in progress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the watchlist tab icon to a tag symbol for clearer visual identification.

* **Tests**
  * Added coverage to verify the watchlist tab displays the correct icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->