### PR TITLE
Make status indicators descriptive for VoiceOver

### DIFF
--- a/MacTorn/MacTorn/Helpers/UITestSupport.swift
+++ b/MacTorn/MacTorn/Helpers/UITestSupport.swift
@@ -53,6 +53,9 @@ enum FixtureScenario: String {
     /// for account A is deliberately delayed and ignores task cancellation so XCUITest
     /// can prove that a stale A response never flashes after switching to B.
     case accountSwitch
+    /// Rich, deterministic values for screen-reader contracts: an active flight,
+    /// a recent attack, and both faction progress bars.
+    case accessibility
 }
 
 enum UITestConfiguration {
@@ -109,10 +112,40 @@ enum UITestConfiguration {
         let session = FixtureNetworkSession(scenario: scenario)
         let connectivity = UITestConnectivity(connected: startsOnline)
 
-        return AppState(session: session,
-                        connectivity: connectivity,
-                        defaults: defaults,
-                        time: SystemTimeSource())
+        let appState = AppState(session: session,
+                                connectivity: connectivity,
+                                defaults: defaults,
+                                time: SystemTimeSource())
+
+        if scenario == .accessibility {
+            let now = Int(Date().timeIntervalSince1970)
+            appState.recentAttacks = [
+                AttackResult(
+                    code: "fixture-attack",
+                    timestampStarted: now - 150,
+                    timestampEnded: now - 120,
+                    attackerId: 123_456,
+                    attackerName: "TestPlayer",
+                    defenderId: 654_321,
+                    defenderName: "Fixture Opponent",
+                    result: "Mugged",
+                    respect: 2.5
+                ),
+                AttackResult(
+                    code: "fixture-incoming-attack",
+                    timestampStarted: now - 240,
+                    timestampEnded: now - 210,
+                    attackerId: 777_777,
+                    attackerName: "Fixture Aggressor",
+                    defenderId: 123_456,
+                    defenderName: "TestPlayer",
+                    result: "Hospitalized",
+                    respect: 1.25
+                )
+            ]
+        }
+
+        return appState
     }
 }
 
@@ -168,6 +201,11 @@ final class FixtureNetworkSession: NetworkSession, @unchecked Sendable {
         let isFastUser = isFastUserURL(url)
         let isKeyInfo = s.contains("/key/info")
 
+        if scenario == .accessibility,
+           let fixture = accessibilityResponse(for: url) {
+            return (try? JSONSerialization.data(withJSONObject: fixture)) ?? Data("{}".utf8)
+        }
+
         let json: [String: Any]
         switch (isKeyInfo, isFastUser, scenario) {
         case (true, _, .invalidKey):
@@ -176,6 +214,8 @@ final class FixtureNetworkSession: NetworkSession, @unchecked Sendable {
             json = keyInfoResponse()
         case (_, true, .full):
             json = fullUserResponse()
+        case (_, true, .accessibility):
+            json = fullUserResponse(traveling: true)
         case (_, true, .accountSwitch):
             switch apiKey(in: url) {
             case accountAKey:
@@ -191,6 +231,65 @@ final class FixtureNetworkSession: NetworkSession, @unchecked Sendable {
             json = [:]
         }
         return (try? JSONSerialization.data(withJSONObject: json)) ?? Data("{}".utf8)
+    }
+
+    private static func accessibilityResponse(for url: URL?) -> [String: Any]? {
+        let path = url?.path ?? ""
+        let now = Int(Date().timeIntervalSince1970)
+
+        if path == "/v2/user" {
+            return [
+                "organizedCrime": [
+                    "id": 101,
+                    "name": "Fixture Crime",
+                    "difficulty": 4,
+                    "status": "Planning",
+                    "created_at": now - 600,
+                    "ready_at": now + 3_600,
+                    "expired_at": now + 86_400,
+                    "executed_at": NSNull(),
+                    "slots": [
+                        [
+                            "position": "Muscle",
+                            "checkpoint_pass_rate": 80,
+                            "user": ["id": 123_456, "progress": 62, "joined_at": now - 600],
+                        ]
+                    ],
+                ],
+                "refills": ["energy": true, "nerve": true, "token": true, "special_count": 0],
+                "education": ["complete": [], "current": NSNull()],
+                "bounties": [],
+            ]
+        }
+
+        if path.contains("/v2/faction/rankedwars") {
+            return [
+                "rankedwars": [
+                    [
+                        "id": 202,
+                        "start": now - 7_200,
+                        "end": 0,
+                        "target": 1_000,
+                        "winner": NSNull(),
+                        "factions": [
+                            ["id": 6_789, "name": "Fixture Faction", "score": 1_250, "chain": 10],
+                            ["id": 9_876, "name": "Fixture Rivals", "score": 750, "chain": 5],
+                        ],
+                    ]
+                ]
+            ]
+        }
+
+        if path == "/faction/" || path == "/faction" {
+            return [
+                "name": "Fixture Faction",
+                "ID": 6_789,
+                "respect": 1_000,
+                "chain": ["current": 0, "max": 0, "timeout": 0, "cooldown": 0],
+            ]
+        }
+
+        return nil
     }
 
     private static func isFastUserURL(_ url: URL?) -> Bool {
@@ -240,16 +339,21 @@ final class FixtureNetworkSession: NetworkSession, @unchecked Sendable {
     /// suite's `TornAPIFixtures.validFullResponse()` (kept in sync by construction —
     /// same keys), with `server_time = now` so live countdowns anchor to the run.
     static func fullUserResponse(name: String = "TestPlayer",
-                                 playerID: Int = 123456) -> [String: Any] { [
+                                 playerID: Int = 123456,
+                                 traveling: Bool = false) -> [String: Any] {
+        let now = Int(Date().timeIntervalSince1970)
+        return [
         "name": name,
         "player_id": playerID,
-        "server_time": Int(Date().timeIntervalSince1970),
+        "server_time": now,
         "energy": ["current": 100, "maximum": 150, "increment": 5, "interval": 300, "ticktime": 60, "fulltime": 600],
         "nerve": ["current": 50, "maximum": 60, "increment": 1, "interval": 300, "ticktime": 120, "fulltime": 1800],
         "life": ["current": 7500, "maximum": 7500, "increment": 100, "interval": 300, "ticktime": 0, "fulltime": 0],
         "happy": ["current": 5000, "maximum": 10000, "increment": 50, "interval": 300, "ticktime": 100, "fulltime": 30000],
         "cooldowns": ["drug": 0, "medical": 0, "booster": 0],
-        "travel": ["destination": "Torn", "timestamp": 0, "departed": 0, "time_left": 0],
+        "travel": traveling
+            ? ["destination": "Japan", "timestamp": now + 300, "departed": now - 300, "time_left": 300]
+            : ["destination": "Torn", "timestamp": 0, "departed": 0, "time_left": 0],
         "status": ["description": "Okay", "details": "", "state": "Okay", "until": 0],
         // NOTE: no "chain" key here on purpose. Torn's v1 `user` endpoint does not
         // return one, and this fixture used to invent it — which is exactly what hid
@@ -270,7 +374,8 @@ final class FixtureNetworkSession: NetworkSession, @unchecked Sendable {
                 )
             }
         ),
-    ] }
+        ]
+    }
 }
 
 // MARK: - UI-test root view

--- a/MacTorn/MacTorn/Views/AttacksView.swift
+++ b/MacTorn/MacTorn/Views/AttacksView.swift
@@ -71,6 +71,17 @@ struct AttacksView: View {
                     if let attacks = appState.recentAttacks, !attacks.isEmpty,
                        let userId = appState.data?.playerId {
                         ForEach(attacks.prefix(5)) { attack in
+                            let result = attack.result.flatMap { $0.isEmpty ? nil : $0 }
+                                ?? "Result unavailable"
+                            let userWasAttacker = attack.wasAttacker(userId: userId)
+                            let opponentName = attack.opponentName(forUserId: userId)
+                            let direction = userWasAttacker
+                                ? "outgoing attack against"
+                                : "incoming attack from"
+                            let timeDescription = attack.timeAgo.isEmpty
+                                ? ""
+                                : ", \(attack.timeAgo) ago"
+
                             Button {
                                 if let opponentId = attack.opponentId(forUserId: userId),
                                    let url = URL(string: "https://www.torn.com/profiles.php?XID=\(opponentId)") {
@@ -81,15 +92,24 @@ struct AttacksView: View {
                                     Image(systemName: attack.resultIcon(forUserId: userId))
                                         .foregroundColor(attack.resultColor(forUserId: userId))
                                         .frame(width: 14)
+                                        .accessibilityHidden(true)
 
-                                    Image(systemName: attack.wasAttacker(userId: userId) ? "arrow.right" : "arrow.left")
+                                    Image(systemName: userWasAttacker ? "arrow.right" : "arrow.left")
                                         .font(.caption2)
-                                        .foregroundColor(attack.wasAttacker(userId: userId) ? .blue : .orange)
+                                        .foregroundColor(userWasAttacker ? .blue : .orange)
                                         .frame(width: 12)
+                                        .accessibilityHidden(true)
 
-                                    Text(attack.opponentName(forUserId: userId))
-                                        .font(.caption)
-                                        .lineLimit(1)
+                                    VStack(alignment: .leading, spacing: 0) {
+                                        Text(opponentName)
+                                            .font(.caption)
+                                            .lineLimit(1)
+
+                                        Text(result)
+                                            .font(.caption2.weight(.medium))
+                                            .foregroundColor(.secondary)
+                                            .lineLimit(1)
+                                    }
 
                                     Spacer()
 
@@ -100,6 +120,9 @@ struct AttacksView: View {
                                 .contentShape(Rectangle())
                             }
                             .buttonStyle(.plain)
+                            .accessibilityElement(children: .ignore)
+                            .accessibilityLabel("\(result), \(direction) \(opponentName)\(timeDescription)")
+                            .uiTestID("uitest.attack.\(attack.id)")
                         }
                     } else {
                         Text("No recent attacks")

--- a/MacTorn/MacTorn/Views/DiagnosticsView.swift
+++ b/MacTorn/MacTorn/Views/DiagnosticsView.swift
@@ -164,18 +164,22 @@ struct ModuleStateView: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            if state.kind == .loading {
-                ProgressView()
-                    .controlSize(.small)
-            } else {
-                Image(systemName: icon)
-                    .foregroundStyle(color)
-                    .accessibilityHidden(true)
-            }
+            HStack(spacing: 6) {
+                if state.kind == .loading {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Image(systemName: icon)
+                        .foregroundStyle(color)
+                        .accessibilityHidden(true)
+                }
 
-            Text(label)
-                .font(.caption2)
-                .foregroundStyle(state.kind == .fresh ? Color.secondary : color)
+                Text(label)
+                    .font(.caption2)
+                    .foregroundStyle(state.kind == .fresh ? Color.secondary : color)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(label)
 
             Spacer(minLength: 4)
 
@@ -184,10 +188,12 @@ struct ModuleStateView: View {
                 Button("Retry", action: onRetry)
                     .buttonStyle(.plain)
                     .font(.caption2.weight(.semibold))
+                    .uiTestID("uitest.moduleState.recovery")
             case .settings:
                 Button("Settings") { openSettings() }
                     .buttonStyle(.plain)
                     .font(.caption2.weight(.semibold))
+                    .uiTestID("uitest.moduleState.recovery")
             case .none:
                 EmptyView()
             }
@@ -196,8 +202,7 @@ struct ModuleStateView: View {
         .padding(.vertical, 5)
         .background(color.opacity(state.kind == .fresh ? 0.06 : 0.12))
         .clipShape(RoundedRectangle(cornerRadius: 6))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(label)
+        .accessibilityElement(children: .contain)
     }
 
     private var label: String {

--- a/MacTorn/MacTorn/Views/FactionView.swift
+++ b/MacTorn/MacTorn/Views/FactionView.swift
@@ -244,18 +244,22 @@ struct OC2StatusView: View {
 
             // Your own progress in your slot, if you hold one
             if let pid = playerId, let progress = oc.myProgress(playerId: pid) {
+                let clampedProgress = min(max(progress, 0), 100)
                 VStack(alignment: .leading, spacing: 2) {
                     HStack {
                         Text("Your progress")
                             .font(.caption2)
                             .foregroundColor(.secondary)
                         Spacer()
-                        Text("\(Int(progress))%")
+                        Text("\(Int(clampedProgress))%")
                             .font(.caption2.monospacedDigit())
                             .foregroundColor(.secondary)
                     }
-                    ProgressView(value: min(max(progress, 0), 100), total: 100)
+                    ProgressView(value: clampedProgress, total: 100)
                         .tint(.orange)
+                        .accessibilityLabel("Organized Crime progress")
+                        .accessibilityValue("\(Int(clampedProgress)) percent")
+                        .uiTestID("uitest.faction.ocProgress")
                 }
             }
         }
@@ -299,6 +303,8 @@ struct RankedWarView: View {
 
             if let mine, let opp {
                 let lead = mine.score - opp.score
+                let progressValue = min(max(lead, 0), war.target)
+                let progressTotal = max(war.target, 1)
                 HStack {
                     Text(mine.name)
                         .font(.caption.bold())
@@ -314,9 +320,12 @@ struct RankedWarView: View {
                         .lineLimit(1)
                 }
                 // War is won when a faction's *lead* reaches `target`.
-                ProgressView(value: Double(min(max(lead, 0), war.target)),
-                             total: Double(max(war.target, 1)))
+                ProgressView(value: Double(progressValue),
+                             total: Double(progressTotal))
                     .tint(lead >= 0 ? .green : .red)
+                    .accessibilityLabel("Ranked War lead progress")
+                    .accessibilityValue("\(formatNumber(progressValue)) of \(formatNumber(progressTotal))")
+                    .uiTestID("uitest.faction.warProgress")
                 Text(lead >= 0 ? "Leading by \(formatNumber(lead))" : "Behind by \(formatNumber(-lead))")
                     .font(.caption2)
                     .foregroundColor(lead >= 0 ? .green : .red)

--- a/MacTorn/MacTorn/Views/SettingsView.swift
+++ b/MacTorn/MacTorn/Views/SettingsView.swift
@@ -260,9 +260,11 @@ struct SettingsView: View {
                     appState.refreshNow()
                 }
                 .buttonStyle(.borderedProminent)
-                // Also gated on `isLoading`: without it, three quick clicks fired three
-                // refreshes in an app that otherwise budgets every single API request.
-                .disabled(trimmedInputKey.isEmpty || appState.isLoading)
+                // Block repeated refreshes for the current key, but still allow an
+                // account switch while its old request is in flight. Updating the key
+                // advances the account generation and cancels those stale tasks.
+                .disabled(trimmedInputKey.isEmpty
+                          || (appState.isLoading && trimmedInputKey == appState.apiKey))
                 .uiTestID("uitest.saveKey")
 
                 Button {

--- a/MacTorn/MacTorn/Views/TravelView.swift
+++ b/MacTorn/MacTorn/Views/TravelView.swift
@@ -70,6 +70,10 @@ struct FlyingStatusView: View {
                     }
                 }
                 .frame(height: 8)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Flight progress")
+                .accessibilityValue("\(Int(progress * 100)) percent")
+                .uiTestID("uitest.travel.progress")
             }
         }
         .padding()

--- a/MacTorn/MacTornTests/ViewModels/UITestHarnessTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/UITestHarnessTests.swift
@@ -67,6 +67,7 @@ final class UITestHarnessTests: XCTestCase {
         XCTAssertEqual(FixtureScenario(rawValue: "invalidKey"), .invalidKey)
         XCTAssertEqual(FixtureScenario(rawValue: "empty"), .empty)
         XCTAssertEqual(FixtureScenario(rawValue: "accountSwitch"), .accountSwitch)
+        XCTAssertEqual(FixtureScenario(rawValue: "accessibility"), .accessibility)
         XCTAssertNil(FixtureScenario(rawValue: "nonsense"))
     }
 

--- a/MacTorn/MacTornUITests/MacTornUITests.swift
+++ b/MacTorn/MacTornUITests/MacTornUITests.swift
@@ -284,6 +284,42 @@ final class MacTornUITests: XCTestCase {
         }
     }
 
+    /// VoiceOver must receive the context hidden by icons, color, and unlabeled
+    /// progress bars. The fixture makes every affected surface deterministic.
+    func testStatusSurfacesExposeDescriptiveVoiceOverSemantics() throws {
+        let app = launch(fixture: "accessibility", apiKey: "sample-ax-semantics-user")
+        let win = window(app)
+
+        win.buttons["uitest.tab.Travel"].click()
+        let flightProgress = win.descendants(matching: .any)["uitest.travel.progress"]
+        XCTAssertTrue(flightProgress.waitForExistence(timeout: 10))
+        XCTAssertEqual(flightProgress.label, "Flight progress")
+        // macOS XCUITest exposes an empty `value` for these custom SwiftUI
+        // accessibility elements. Their VoiceOver values need a manual pass.
+
+        win.buttons["uitest.tab.Attacks"].click()
+        let attack = win.descendants(matching: .any)["uitest.attack.fixture-attack"]
+        XCTAssertTrue(attack.waitForExistence(timeout: 10))
+        XCTAssertTrue(attack.label.contains("Mugged"))
+        XCTAssertTrue(attack.label.contains("outgoing attack against Fixture Opponent"))
+
+        let incomingAttack = win.descendants(matching: .any)["uitest.attack.fixture-incoming-attack"]
+        XCTAssertTrue(incomingAttack.waitForExistence(timeout: 10))
+        XCTAssertTrue(incomingAttack.label.contains("Hospitalized"))
+        XCTAssertTrue(incomingAttack.label.contains("incoming attack from Fixture Aggressor"))
+
+        win.buttons["uitest.group.Account"].click()
+        win.buttons["uitest.tab.Faction"].click()
+
+        let ocProgress = win.descendants(matching: .any)["uitest.faction.ocProgress"]
+        XCTAssertTrue(ocProgress.waitForExistence(timeout: 10))
+        XCTAssertEqual(ocProgress.label, "Organized Crime progress")
+
+        let warProgress = win.descendants(matching: .any)["uitest.faction.warProgress"]
+        XCTAssertTrue(warProgress.waitForExistence(timeout: 10))
+        XCTAssertEqual(warProgress.label, "Ranked War lead progress")
+    }
+
     // MARK: - Account isolation (T15 fixture preparation)
 
     /// A delayed, cancellation-ignoring response for synthetic account A must never
@@ -340,6 +376,25 @@ final class MacTornUITests: XCTestCase {
         let error = win.descendants(matching: .any)["uitest.error"]
         XCTAssertTrue(error.waitForExistence(timeout: 15),
                       "An invalid key should surface a visible error message")
+
+        let recovery = win.descendants(matching: .any)["uitest.moduleState.recovery"]
+        XCTAssertTrue(recovery.waitForExistence(timeout: 10),
+                      "Module recovery action must remain a separate accessibility element")
+        XCTAssertEqual(recovery.label, "Settings")
+    }
+
+    func testOfflineModuleExposesRetryAsSeparateAccessibilityElement() throws {
+        let app = launch(
+            fixture: "empty",
+            apiKey: "sample-offline-user",
+            online: false
+        )
+        let win = window(app)
+
+        let recovery = win.descendants(matching: .any)["uitest.moduleState.recovery"]
+        XCTAssertTrue(recovery.waitForExistence(timeout: 10),
+                      "Retry must not be swallowed by the module status label")
+        XCTAssertEqual(recovery.label, "Retry")
     }
 
     // MARK: - Key validation (Etap C)


### PR DESCRIPTION
## Summary

Makes status-heavy surfaces understandable without relying on icons, color, or custom drawing. Attack rows now expose the result and direction in text and VoiceOver, faction and travel progress expose descriptive semantics, and module recovery actions remain independently focusable. While validating the full fixture suite, the PR also repairs the existing account-switch regression that prevented saving a new key during an in-flight refresh.

## Included issues

- #34 — adds explicit attack result text plus an accessible result, direction, opponent, and relative time description.
- #35 — labels Organized Crime and Ranked War progress and exposes their current values.
- #36 — stops module status grouping from swallowing the Retry or Settings action.
- #70 — exposes the custom flight progress bar and its percentage to VoiceOver.

## Root cause

Several status surfaces encoded meaning only through SF Symbols, color, or a custom-drawn bar. The shared module state additionally combined its children into one accessibility element, which hid the recovery button as a distinct control. Separately, the Settings save action was disabled by any active refresh, so a user could not switch accounts while the old account request was in flight even though account generation and cancellation already support that flow.

## Implementation

- Shows attack results as a compact second line and gives each attack button a complete, direction-aware accessibility label.
- Adds label/value semantics to OC, Ranked War, and flight progress indicators while clamping values to valid ranges.
- Splits module status content from Retry/Settings and contains both as separate accessibility children.
- Adds a deterministic accessibility fixture covering active travel, outgoing and incoming attacks, OC progress, Ranked War progress, and module recovery actions.
- Keeps duplicate refreshes for the current API key disabled while allowing a different key to be saved; the existing generation/cancellation guards reject stale responses.

## Testing

- `make test` — passed (full unit suite).
- `make build` — passed.
- `make analyze` — passed after the final account-switch change.
- `make release verify-release` — passed; universal arm64/x86_64 app and strict ad-hoc signature verified.
- Targeted XCUITest for all four status surfaces — passed.
- Retry and Settings accessibility XCUITests — passed.
- Account switch with an old non-cancellable request in flight — passed after repairing the save-button gating.
- Final CI fixture UI suite — passed all 11 tests.
- Final CI — all 6 checks passed: unit + coverage, fixture UI, analyze + universal Release, gitleaks, Claude review, and CodeRabbit.

## Risks

- The change affects VoiceOver grouping and focus order in four compact views; the deterministic AX tests protect element presence and labels.
- macOS XCUITest reports an empty `value` for custom SwiftUI accessibility elements, so the spoken progress values still warrant a manual VoiceOver pass.
- A different API key can now be saved during an active refresh. The existing account generation, task cancellation, request budget, and stale-response guards remain in force; repeated refreshes for the same key stay disabled.
- No persistence schema, network API, security, or migration behavior changes.

## Screenshots or recordings

Not attached: the primary change is Accessibility API metadata, which a still image cannot represent. The one visible adjustment is the attack result rendered as a compact second line; the deterministic UI fixture covers the narrow app layout.

## Issue closure

Related to #45

Closes #34
Closes #35
Closes #36
Closes #70
