### PR TITLE
Improve accessibility of Watchlist and Forum Watch rows

### DIFF
--- a/MacTorn/MacTorn/Helpers/UITestSupport.swift
+++ b/MacTorn/MacTorn/Helpers/UITestSupport.swift
@@ -56,6 +56,9 @@ enum FixtureScenario: String {
     /// Rich, deterministic values for screen-reader contracts: an active flight,
     /// a recent attack, and both faction progress bars.
     case accessibility
+    /// Deterministic Watchlist and Forum Watch rows used to verify compact control
+    /// hit areas and the non-visual state exposed to assistive technologies.
+    case watchAccessibility
 }
 
 enum UITestConfiguration {
@@ -145,6 +148,38 @@ enum UITestConfiguration {
             ]
         }
 
+        if scenario == .watchAccessibility {
+            appState.watchlistItems = [
+                WatchlistItem(
+                    id: 206,
+                    name: "Accessibility Item",
+                    lowestPrice: 4_200,
+                    lowestPriceQuantity: 2,
+                    secondLowestPrice: 4_300,
+                    lastUpdated: Date(),
+                    error: nil
+                )
+            ]
+            appState.watchedThreads = [
+                WatchedThread(
+                    id: 101,
+                    title: "Unavailable forum thread",
+                    notificationsEnabled: true,
+                    lastKnownPostCount: 3,
+                    lastChecked: Date(),
+                    error: "Fixture forum unavailable."
+                ),
+                WatchedThread(
+                    id: 102,
+                    title: "Healthy forum thread",
+                    notificationsEnabled: false,
+                    lastKnownPostCount: 8,
+                    lastChecked: Date(),
+                    error: nil
+                ),
+            ]
+        }
+
         return appState
     }
 }
@@ -216,6 +251,8 @@ final class FixtureNetworkSession: NetworkSession, @unchecked Sendable {
             json = fullUserResponse()
         case (_, true, .accessibility):
             json = fullUserResponse(traveling: true)
+        case (_, true, .watchAccessibility):
+            json = fullUserResponse()
         case (_, true, .accountSwitch):
             switch apiKey(in: url) {
             case accountAKey:

--- a/MacTorn/MacTorn/Views/ForumWatchView.swift
+++ b/MacTorn/MacTorn/Views/ForumWatchView.swift
@@ -265,7 +265,7 @@ struct ForumThreadRow: View {
                 if let error = thread.error {
                     Text(error)
                         .font(.caption2)
-                        .foregroundStyle(.yellow)
+                        .foregroundStyle(.red)
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }

--- a/MacTorn/MacTorn/Views/ForumWatchView.swift
+++ b/MacTorn/MacTorn/Views/ForumWatchView.swift
@@ -241,7 +241,7 @@ struct ForumThreadRow: View {
     let onRemove: () -> Void
 
     var body: some View {
-        HStack(spacing: 6) {
+        HStack(alignment: .top, spacing: 6) {
             // Faction badge
             if thread.isFactionThread {
                 Image(systemName: "person.3.fill")
@@ -250,16 +250,25 @@ struct ForumThreadRow: View {
             }
 
             // Thread title (clickable)
-            Button {
-                onOpen()
-            } label: {
-                Text(thread.title)
-                    .font(.caption)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .foregroundColor(.primary)
+            VStack(alignment: .leading, spacing: 2) {
+                Button {
+                    onOpen()
+                } label: {
+                    Text(thread.title)
+                        .font(.caption)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .foregroundColor(.primary)
+                }
+                .buttonStyle(.plain)
+
+                if let error = thread.error {
+                    Text(error)
+                        .font(.caption2)
+                        .foregroundStyle(.yellow)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
-            .buttonStyle(.plain)
 
             Spacer()
 
@@ -269,6 +278,7 @@ struct ForumThreadRow: View {
                     .font(.caption2)
                     .foregroundColor(.yellow)
                     .help(error)
+                    .accessibilityLabel("Error: \(error)")
             }
 
             // Last checked indicator
@@ -277,6 +287,7 @@ struct ForumThreadRow: View {
                     .font(.caption2)
                     .foregroundColor(.green)
                     .opacity(0.5)
+                    .accessibilityLabel("Last checked successfully")
             }
 
             // Notification toggle
@@ -286,12 +297,14 @@ struct ForumThreadRow: View {
                 Image(systemName: thread.notificationsEnabled ? "bell.fill" : "bell.slash")
                     .font(.caption)
                     .foregroundColor(thread.notificationsEnabled ? .blue : .secondary)
+                    .frame(width: 24, height: 24)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .help(thread.notificationsEnabled ? "Notifications on" : "Notifications off")
             .accessibilityLabel(thread.notificationsEnabled
-                                ? "Disable notifications for \(thread.title)"
-                                : "Enable notifications for \(thread.title)")
+                                ? "Notifications on for \(thread.title). Disable notifications"
+                                : "Notifications off for \(thread.title). Enable notifications")
 
             // Remove button
             Button {
@@ -300,6 +313,8 @@ struct ForumThreadRow: View {
                 Image(systemName: "xmark.circle.fill")
                     .font(.caption)
                     .foregroundColor(.secondary)
+                    .frame(width: 24, height: 24)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Remove \(thread.title) from watched threads")

--- a/MacTorn/MacTorn/Views/WatchlistView.swift
+++ b/MacTorn/MacTorn/Views/WatchlistView.swift
@@ -298,6 +298,8 @@ struct WatchlistPriceRow: View {
                     Image(systemName: item.priceThreshold != nil ? "bell.fill" : "bell")
                         .foregroundColor(item.priceThreshold != nil ? .yellow : .gray)
                         .font(.caption)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(item.priceThreshold != nil
@@ -349,6 +351,8 @@ struct WatchlistPriceRow: View {
                     Image(systemName: "xmark.circle.fill")
                         .foregroundColor(.gray)
                         .font(.caption)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Remove \(item.name) from price watch")

--- a/MacTorn/MacTornTests/ViewModels/UITestHarnessTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/UITestHarnessTests.swift
@@ -68,6 +68,7 @@ final class UITestHarnessTests: XCTestCase {
         XCTAssertEqual(FixtureScenario(rawValue: "empty"), .empty)
         XCTAssertEqual(FixtureScenario(rawValue: "accountSwitch"), .accountSwitch)
         XCTAssertEqual(FixtureScenario(rawValue: "accessibility"), .accessibility)
+        XCTAssertEqual(FixtureScenario(rawValue: "watchAccessibility"), .watchAccessibility)
         XCTAssertNil(FixtureScenario(rawValue: "nonsense"))
     }
 

--- a/MacTorn/MacTornUITests/MacTornUITests.swift
+++ b/MacTorn/MacTornUITests/MacTornUITests.swift
@@ -320,6 +320,56 @@ final class MacTornUITests: XCTestCase {
         XCTAssertEqual(warProgress.label, "Ranked War lead progress")
     }
 
+    /// Compact list controls must remain easy to hit, while forum state that used to
+    /// live only in icons, colour and tooltips stays available without a mouse.
+    func testWatchListsExposeAccessibleControlsAndForumState() throws {
+        let app = launch(fixture: "watchAccessibility", apiKey: "sample-watch-a11y-user")
+        let win = window(app)
+
+        win.buttons["uitest.group.Watch"].click()
+
+        let priceAlert = win.buttons["Set price alert for Accessibility Item"]
+        let removeItem = win.buttons["Remove Accessibility Item from price watch"]
+        for control in [priceAlert, removeItem] {
+            XCTAssertTrue(control.waitForExistence(timeout: 10))
+            XCTAssertTrue(control.isHittable)
+            XCTAssertGreaterThanOrEqual(control.frame.width, 24)
+            XCTAssertGreaterThanOrEqual(control.frame.height, 24)
+        }
+
+        win.buttons["uitest.tab.Forums"].click()
+
+        let errorText = win.staticTexts["Fixture forum unavailable."]
+        XCTAssertTrue(errorText.waitForExistence(timeout: 10),
+                      "Forum errors must be visible without hovering a tooltip")
+        XCTAssertTrue(
+            win.descendants(matching: .any)["Error: Fixture forum unavailable."]
+                .waitForExistence(timeout: 10),
+            "The warning icon must expose the error to VoiceOver"
+        )
+        XCTAssertTrue(
+            win.descendants(matching: .any)["Last checked successfully"]
+                .waitForExistence(timeout: 10),
+            "A successful check must not rely on a green icon alone"
+        )
+
+        let notificationsOn = win.buttons[
+            "Notifications on for Unavailable forum thread. Disable notifications"
+        ]
+        let notificationsOff = win.buttons[
+            "Notifications off for Healthy forum thread. Enable notifications"
+        ]
+        let removeThread = win.buttons[
+            "Remove Unavailable forum thread from watched threads"
+        ]
+        for control in [notificationsOn, notificationsOff, removeThread] {
+            XCTAssertTrue(control.waitForExistence(timeout: 10))
+            XCTAssertTrue(control.isHittable)
+            XCTAssertGreaterThanOrEqual(control.frame.width, 24)
+            XCTAssertGreaterThanOrEqual(control.frame.height, 24)
+        }
+    }
+
     // MARK: - Account isolation (T15 fixture preparation)
 
     /// A delayed, cancellation-ignoring response for synthetic account A must never


### PR DESCRIPTION
### Summary

Improves accessibility of the Watchlist and Forum Watch rows for mouse, keyboard, and VoiceOver users.

### Included issues

- #37 — expands compact icon controls to explicit 24×24 hit targets.
- #38 — exposes forum errors inline and provides descriptive accessibility state.

### Root cause

The icon buttons inherited the small bounds of their caption-sized SF Symbols, making the controls unnecessarily difficult to hit. Forum refresh state was communicated through symbols, color, and hover-only help text, so the error detail and successful state were not reliably available without a mouse.

### Implementation

- Give Watchlist alert/remove and Forum notification/remove buttons explicit 24×24 frames and rectangular hit regions.
- Display forum refresh errors directly below the thread title.
- Add descriptive VoiceOver labels for forum errors, successful checks, and notification state/action.
- Add a deterministic Watch accessibility UI-test fixture.
- Add regression coverage for hit-target geometry, visible error content, and accessibility labels.

### Testing

- `make test`
- `make test-ui` — 12 tests, 0 failures
- Targeted `testWatchListsExposeAccessibleControlsAndForumState`
- `make build`
- `make analyze`
- `make scan`
- `git diff --check main...HEAD`

### Risks

- Forum rows become taller when an error is present so the error remains visible. The compact 320-point window path is covered by UI tests.
- No application behavior or persistence model is changed; changes are limited to presentation, accessibility semantics, and deterministic test support.

### Screenshots or recordings

Not included. The affected controls are compact row affordances; deterministic XCUITest coverage validates the 320-point UI, 24×24 hit regions, visible error text, and accessibility contract.

Closes #37
Closes #38