### PR TITLE
Stabilize manual refresh and polling loading state

### DIFF
--- a/MacTorn/MacTorn/ViewModels/AppState+PollingUserFetch.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState+PollingUserFetch.swift
@@ -7,19 +7,22 @@ extension AppState {
 
     // MARK: - Polling
 
-    func startPolling(force: Bool = false) {
+    func startPolling() {
         guard !keyHalted else {
             logger.warning("startPolling skipped: polling halted on a permanent key error")
             return
         }
-        if !force,
-           timerCancellable != nil,
-           Date().timeIntervalSince(lastFetchTime) < Double(refreshInterval) / 2 {
+        if timerCancellable != nil,
+           time.now.timeIntervalSince(lastFetchTime) < Double(refreshInterval) / 2 {
             return
         }
         timerCancellable?.cancel()
         fetchData()
         triggerStocksMetadataFetchIfNeeded()
+        installPollingTimer()
+    }
+
+    private func installPollingTimer() {
         timerCancellable = Timer.publish(every: Double(refreshInterval), on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
@@ -40,7 +43,29 @@ extension AppState {
     }
 
     func refreshNow() {
-        startPolling(force: true)
+        guard !keyHalted else {
+            logger.warning("refreshNow skipped: polling halted on a permanent key error")
+            return
+        }
+
+        let identity = accountSession.identity
+        if lastManualRefreshGeneration == identity.generation,
+           let lastManualRefreshAt {
+            let elapsed = time.now.timeIntervalSince(lastManualRefreshAt)
+            if elapsed >= 0, elapsed < Self.manualRefreshMinInterval {
+                return
+            }
+        }
+
+        // `fetchData` performs connectivity/key/budget validation synchronously. Only
+        // accepted requests consume the debounce, so an offline attempt cannot delay
+        // the immediate refresh triggered when connectivity returns.
+        guard fetchData() else { return }
+        lastManualRefreshAt = time.now
+        lastManualRefreshGeneration = identity.generation
+        if timerCancellable == nil {
+            installPollingTimer()
+        }
     }
 
     func isRowSourcePaused(_ endpointID: String) -> Bool {
@@ -179,30 +204,33 @@ extension AppState {
 
     // MARK: - Fetch Data
 
-    func fetchData() {
+    @discardableResult
+    func fetchData() -> Bool {
         guard connectivity.isConnected else {
             if errorMsg != "No internet connection" {
                 errorMsg = "No internet connection"
                 logger.warning("Fetch aborted: No internet connection")
             }
-            return
+            return false
         }
 
         let requestedKey = apiKey
         guard !requestedKey.isEmpty else {
             errorMsg = "API Key required"
             logger.warning("Fetch aborted: API Key required")
-            return
+            return false
         }
 
         guard let url = TornAPI.url(for: requestedKey) else {
             errorMsg = "Invalid URL"
             logger.error("Fetch aborted: Invalid URL")
-            return
+            return false
         }
 
-        guard reserveRequest("user.fast") else { return }
+        guard reserveRequest("user.fast") else { return false }
 
+        pollSequence &+= 1
+        let myPollSequence = pollSequence
         isLoading = true
         errorMsg = nil
         let generation = accountSession.identity.generation
@@ -218,7 +246,8 @@ extension AppState {
                     if elapsed < 0.5 {
                         try? await Task.sleep(nanoseconds: UInt64((0.5 - elapsed) * 1_000_000_000))
                     }
-                    if self.isCurrentAccount(requestedKey, generation: generation) {
+                    if self.isCurrentAccount(requestedKey, generation: generation),
+                       self.pollSequence == myPollSequence {
                         self.isLoading = false
                     }
                 }
@@ -313,6 +342,15 @@ extension AppState {
                     return
                 }
                 let mapped = (error as? URLError).map(TornAPIError.from(urlError:))
+                if mapped?.classification == .offline,
+                   self.lastManualRefreshGeneration == generation,
+                   self.pollSequence == myPollSequence {
+                    // NWPath can briefly remain "online" after transport already failed.
+                    // Re-open the current account's debounce only when this is still the
+                    // latest poll, so stale failures cannot mutate newer refresh state.
+                    self.lastManualRefreshAt = nil
+                    self.lastManualRefreshGeneration = nil
+                }
                 await MainActor.run {
                     guard self.isCurrentAccount(requestedKey, generation: generation) else { return }
                     self.errorMsg = mapped?.userMessage ?? "Network request failed. Please try again."
@@ -327,6 +365,7 @@ extension AppState {
                 )
             }
         }
+        return true
     }
 
     private func parseDataInBackground(data: Data, apiKey: String, generation: UInt) async -> Bool {
@@ -379,7 +418,7 @@ extension AppState {
         stocksData = payload.stocks
 
         lastUpdated = Date()
-        lastFetchTime = Date()
+        lastFetchTime = time.now
         errorMsg = nil
 
         manageLiveTimer()

--- a/MacTorn/MacTorn/ViewModels/AppState.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState.swift
@@ -253,6 +253,16 @@ class AppState {
     @ObservationIgnored var lastForumFetchAt: Date?
     @ObservationIgnored var pendingPriceAlerts: [(name: String, price: Int)] = []
 
+    /// Monotonic identity for accepted user snapshot polls. Deferred cleanup from an
+    /// older, cancelled poll must never mutate the loading state owned by a newer one.
+    @ObservationIgnored var pollSequence: UInt = 0
+
+    /// Manual refresh debounce is account-generation scoped: saving a different API
+    /// key must be able to fetch immediately even if the previous account just did.
+    @ObservationIgnored var lastManualRefreshAt: Date?
+    @ObservationIgnored var lastManualRefreshGeneration: UInt?
+    static let manualRefreshMinInterval: TimeInterval = 3
+
     // Stocks metadata backoff: ladder of seconds applied between retries after failures.
     // Last value is the cap and is used for any further failure beyond the ladder length.
     // Reset to 0 (= no backoff active) on success or when metadata is freshly cached.

--- a/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
@@ -797,6 +797,220 @@ final class AppStateTests: XCTestCase {
         XCTAssertNotNil(appState.data)
     }
 
+    func testRefreshNow_debouncesBurstAndAcceptsBoundaryAtThreeSeconds() {
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        let clock = MutableTimeSource(start)
+        let app = AppState(
+            session: MockNetworkSession(),
+            connectivity: ControllableConnectivity(connected: true),
+            defaults: .createMockDefaults(),
+            time: clock
+        )
+        app.apiKey = "debounce-\(UUID().uuidString)"
+
+        app.refreshNow()
+        XCTAssertEqual(app.pollSequence, 1)
+
+        app.refreshNow()
+        XCTAssertEqual(app.pollSequence, 1, "a held shortcut must not start another poll")
+
+        clock.advance(2.999)
+        app.refreshNow()
+        XCTAssertEqual(app.pollSequence, 1, "the debounce remains closed before 3 seconds")
+
+        clock.set(start.addingTimeInterval(3))
+        app.refreshNow()
+        XCTAssertEqual(app.pollSequence, 2, "the boundary at 3 seconds accepts a new poll")
+        app.stopPolling()
+    }
+
+    func testRefreshNow_newAccountBypassesPreviousAccountsDebounce() {
+        let clock = MutableTimeSource(Date(timeIntervalSince1970: 1_700_000_000))
+        let app = AppState(
+            session: MockNetworkSession(),
+            connectivity: ControllableConnectivity(connected: true),
+            defaults: .createMockDefaults(),
+            time: clock
+        )
+        app.apiKey = "account-a-\(UUID().uuidString)"
+        app.refreshNow()
+        XCTAssertEqual(app.pollSequence, 1)
+
+        app.apiKey = "account-b-\(UUID().uuidString)"
+        app.refreshNow()
+
+        XCTAssertEqual(app.pollSequence, 2,
+                       "saving a different key must refresh immediately at the same clock instant")
+        app.stopPolling()
+    }
+
+    func testOfflineRefreshDoesNotConsumeDebounceBeforeReconnect() {
+        let clock = MutableTimeSource(Date(timeIntervalSince1970: 1_700_000_000))
+        let connectivity = ControllableConnectivity(connected: false)
+        let app = AppState(
+            session: MockNetworkSession(),
+            connectivity: connectivity,
+            defaults: .createMockDefaults(),
+            time: clock
+        )
+        app.apiKey = "offline-\(UUID().uuidString)"
+
+        app.refreshNow()
+        XCTAssertEqual(app.pollSequence, 0, "an offline attempt never starts a poll")
+
+        connectivity.restore()
+        XCTAssertEqual(app.pollSequence, 1,
+                       "the connectivity callback must refresh immediately without waiting 3 seconds")
+        app.stopPolling()
+    }
+
+    func testOfflineTransportFailureReopensDebounceForReconnect() async throws {
+        let clock = MutableTimeSource(Date(timeIntervalSince1970: 1_700_000_000))
+        let connectivity = ControllableConnectivity(connected: true)
+        let service = ControlledHTTPErrorUserSnapshotService()
+        let firstStarted = expectation(description: "manual poll started")
+        let reconnectStarted = expectation(description: "reconnect poll started")
+        service.onLoad = { index in
+            if index == 0 { firstStarted.fulfill() }
+            if index == 1 { reconnectStarted.fulfill() }
+        }
+        let app = AppState(
+            session: MockNetworkSession(),
+            connectivity: connectivity,
+            defaults: .createMockDefaults(),
+            time: clock,
+            userSnapshotService: service
+        )
+        app.apiKey = "transport-offline-\(UUID().uuidString)"
+
+        app.refreshNow()
+        await fulfillment(of: [firstStarted], timeout: 1)
+        service.fail(index: 0, error: URLError(.notConnectedToInternet))
+
+        for _ in 0..<50 where app.errorMsg != TornAPIError.offline.userMessage {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertEqual(app.errorMsg, TornAPIError.offline.userMessage)
+
+        connectivity.goOffline()
+        connectivity.restore()
+        XCTAssertEqual(app.pollSequence, 2,
+                       "a real transport-offline failure must not debounce the reconnect callback")
+        await fulfillment(of: [reconnectStarted], timeout: 1)
+        service.complete(index: 1)
+        app.stopPolling()
+    }
+
+    func testLatestAutomaticOfflineFailureReopensSupersededManualDebounce() async throws {
+        let clock = MutableTimeSource(Date(timeIntervalSince1970: 1_700_000_000))
+        let connectivity = ControllableConnectivity(connected: true)
+        let service = ControlledHTTPErrorUserSnapshotService()
+        let manualStarted = expectation(description: "manual poll started")
+        let automaticStarted = expectation(description: "automatic poll started")
+        let reconnectStarted = expectation(description: "reconnect poll started")
+        service.onLoad = { index in
+            if index == 0 { manualStarted.fulfill() }
+            if index == 1 { automaticStarted.fulfill() }
+            if index == 2 { reconnectStarted.fulfill() }
+        }
+        let app = AppState(
+            session: MockNetworkSession(),
+            connectivity: connectivity,
+            defaults: .createMockDefaults(),
+            time: clock,
+            userSnapshotService: service
+        )
+        app.apiKey = "superseded-offline-\(UUID().uuidString)"
+
+        app.refreshNow()
+        await fulfillment(of: [manualStarted], timeout: 1)
+        app.fetchData()
+        await fulfillment(of: [automaticStarted], timeout: 1)
+        service.fail(index: 1, error: URLError(.notConnectedToInternet))
+
+        for _ in 0..<50 where app.errorMsg != TornAPIError.offline.userMessage {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertEqual(app.errorMsg, TornAPIError.offline.userMessage)
+
+        connectivity.goOffline()
+        connectivity.restore()
+        XCTAssertEqual(app.pollSequence, 3,
+                       "the latest automatic failure must reopen the superseded manual debounce")
+        await fulfillment(of: [reconnectStarted], timeout: 1)
+
+        service.complete(index: 0)
+        service.complete(index: 2)
+        app.stopPolling()
+    }
+
+    func testRefreshNowDoesNotReplaceTheAutomaticPollingTimer() throws {
+        let app = AppState(
+            session: MockNetworkSession(),
+            connectivity: ControllableConnectivity(connected: true),
+            defaults: .createMockDefaults()
+        )
+        app.apiKey = "timer-\(UUID().uuidString)"
+        app.startPolling()
+        let timer = try XCTUnwrap(app.timerCancellable)
+
+        app.refreshNow()
+
+        XCTAssertTrue(app.timerCancellable === timer,
+                      "manual refresh must not cancel and recreate the automatic timer")
+        app.stopPolling()
+    }
+
+    func testRefreshNowRestoresMissingAutomaticTimerAfterKeyIsSaved() {
+        let app = AppState(
+            session: MockNetworkSession(),
+            connectivity: ControllableConnectivity(connected: true),
+            defaults: .createMockDefaults()
+        )
+        app.apiKey = "timer-restore-\(UUID().uuidString)"
+        XCTAssertNil(app.timerCancellable)
+
+        app.refreshNow()
+
+        XCTAssertNotNil(app.timerCancellable,
+                        "saving a key after polling was stopped must resume automatic polling")
+        app.stopPolling()
+    }
+
+    func testCancelledPollCleanupCannotHideNewerPollSpinner() async throws {
+        let service = ControlledHTTPErrorUserSnapshotService()
+        let firstStarted = expectation(description: "first poll started")
+        let secondStarted = expectation(description: "second poll started")
+        service.onLoad = { index in
+            if index == 0 { firstStarted.fulfill() }
+            if index == 1 { secondStarted.fulfill() }
+        }
+        let app = AppState(
+            session: MockNetworkSession(),
+            connectivity: ControllableConnectivity(connected: true),
+            defaults: .createMockDefaults(),
+            userSnapshotService: service
+        )
+        app.apiKey = "spinner-\(UUID().uuidString)"
+
+        app.fetchData()
+        await fulfillment(of: [firstStarted], timeout: 1)
+        app.fetchData()
+        await fulfillment(of: [secondStarted], timeout: 1)
+
+        service.complete(index: 0)
+
+        try await Task.sleep(nanoseconds: 600_000_000)
+        XCTAssertTrue(app.isLoading,
+                      "the first poll's delayed cleanup must not hide the second poll's spinner")
+
+        service.complete(index: 1)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertFalse(app.isLoading, "the current poll must still clear loading on its error path")
+        XCTAssertEqual(app.pollSequence, 2)
+        app.stopPolling()
+    }
+
     // MARK: - Menu Bar Display Tests
 
     /// Helper: build a fixture from `validFullResponse` with a custom travel/status/cooldowns slice.
@@ -1013,6 +1227,60 @@ final class AppStateTests: XCTestCase {
         XCTAssertFalse(relaunched.shouldNotifyOCReady(ready5), "dedup persists across restart")
         let ready6 = OrganizedCrime2(id: 6, name: "New OC", readyAt: now - 10)
         XCTAssertTrue(relaunched.shouldNotifyOCReady(ready6), "a new OC id re-arms")
+    }
+}
+
+/// Holds each request until the test completes it. A cancelled request can therefore
+/// finish after its replacement started, reproducing issue #71 deterministically.
+private final class ControlledHTTPErrorUserSnapshotService: UserSnapshotServicing, @unchecked Sendable {
+    typealias LoadContinuation = CheckedContinuation<UserHTTPResponse, Error>
+
+    private let lock = NSLock()
+    private var loadIndex = 0
+    private var continuations: [Int: LoadContinuation] = [:]
+    var onLoad: (@Sendable (Int) -> Void)?
+
+    func load(_ url: URL) async throws -> UserHTTPResponse {
+        let index = lock.withLock {
+            let index = loadIndex
+            loadIndex += 1
+            return index
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            lock.withLock {
+                continuations[index] = continuation
+            }
+            onLoad?(index)
+        }
+    }
+
+    func complete(index: Int) {
+        let continuation = lock.withLock { continuations.removeValue(forKey: index) }
+        precondition(continuation != nil, "No pending load at index \(index)")
+        continuation?.resume(returning: UserHTTPResponse(data: Data(), statusCode: 503))
+    }
+
+    func fail(index: Int, error: Error) {
+        let continuation = lock.withLock { continuations.removeValue(forKey: index) }
+        precondition(continuation != nil, "No pending load at index \(index)")
+        continuation?.resume(throwing: error)
+    }
+
+    func parseSnapshot(
+        data: Data,
+        requestedSelections: [String],
+        grantedSelections: [String]?
+    ) async -> UserServiceResult<UserSnapshotPayload> {
+        .malformed(responseBytes: data.count)
+    }
+
+    func loadActivity(_ url: URL) async throws -> UserServiceResult<UserActivityPayload> {
+        .malformed(responseBytes: 0)
+    }
+
+    func loadUserV2(_ url: URL) async throws -> UserServiceResult<UserV2Payload> {
+        .malformed(responseBytes: 0)
     }
 }
 

--- a/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
@@ -868,6 +868,7 @@ final class AppStateTests: XCTestCase {
         let clock = MutableTimeSource(Date(timeIntervalSince1970: 1_700_000_000))
         let connectivity = ControllableConnectivity(connected: true)
         let service = ControlledHTTPErrorUserSnapshotService()
+        defer { service.drain() }
         let firstStarted = expectation(description: "manual poll started")
         let reconnectStarted = expectation(description: "reconnect poll started")
         service.onLoad = { index in
@@ -905,6 +906,7 @@ final class AppStateTests: XCTestCase {
         let clock = MutableTimeSource(Date(timeIntervalSince1970: 1_700_000_000))
         let connectivity = ControllableConnectivity(connected: true)
         let service = ControlledHTTPErrorUserSnapshotService()
+        defer { service.drain() }
         let manualStarted = expectation(description: "manual poll started")
         let automaticStarted = expectation(description: "automatic poll started")
         let reconnectStarted = expectation(description: "reconnect poll started")
@@ -979,6 +981,7 @@ final class AppStateTests: XCTestCase {
 
     func testCancelledPollCleanupCannotHideNewerPollSpinner() async throws {
         let service = ControlledHTTPErrorUserSnapshotService()
+        defer { service.drain() }
         let firstStarted = expectation(description: "first poll started")
         let secondStarted = expectation(description: "second poll started")
         service.onLoad = { index in
@@ -1005,7 +1008,9 @@ final class AppStateTests: XCTestCase {
                       "the first poll's delayed cleanup must not hide the second poll's spinner")
 
         service.complete(index: 1)
-        try await Task.sleep(nanoseconds: 100_000_000)
+        for _ in 0..<100 where app.isLoading {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
         XCTAssertFalse(app.isLoading, "the current poll must still clear loading on its error path")
         XCTAssertEqual(app.pollSequence, 2)
         app.stopPolling()
@@ -1257,14 +1262,31 @@ private final class ControlledHTTPErrorUserSnapshotService: UserSnapshotServicin
 
     func complete(index: Int) {
         let continuation = lock.withLock { continuations.removeValue(forKey: index) }
-        precondition(continuation != nil, "No pending load at index \(index)")
-        continuation?.resume(returning: UserHTTPResponse(data: Data(), statusCode: 503))
+        guard let continuation else {
+            XCTFail("No pending load at index \(index)")
+            return
+        }
+        continuation.resume(returning: UserHTTPResponse(data: Data(), statusCode: 503))
     }
 
     func fail(index: Int, error: Error) {
         let continuation = lock.withLock { continuations.removeValue(forKey: index) }
-        precondition(continuation != nil, "No pending load at index \(index)")
-        continuation?.resume(throwing: error)
+        guard let continuation else {
+            XCTFail("No pending load at index \(index)")
+            return
+        }
+        continuation.resume(throwing: error)
+    }
+
+    func drain() {
+        let pending = lock.withLock {
+            let pending = continuations.values
+            continuations.removeAll()
+            return Array(pending)
+        }
+        for continuation in pending {
+            continuation.resume(throwing: CancellationError())
+        }
     }
 
     func parseSnapshot(


### PR DESCRIPTION
### Summary

Stabilizes the user polling lifecycle so repeated manual refreshes cannot create a request burst and stale poll cleanup cannot hide a newer loading state.

### Included issues

- #48 — debounce manual refreshes without resetting the automatic polling timer
- #71 — make loading cleanup owned by the latest accepted poll

### Root cause

`refreshNow()` forced a complete polling restart on every invocation, bypassing throttling and replacing the timer. Separately, every poll task unconditionally cleared `isLoading` in deferred cleanup, so a cancelled older task could clear state owned by its replacement.

### Implementation

- Added a 3-second, account-generation-scoped manual refresh debounce.
- Consume the debounce only after connectivity, API key, URL, and request-budget guards accept a poll.
- Preserve an existing automatic timer and restore it only when missing.
- Re-open the debounce after a latest transport-offline failure so reconnect refreshes immediately.
- Added a monotonic poll sequence and restricted loading cleanup to the latest poll.
- Added deterministic continuation-driven regression coverage for refresh and cancellation races.

### Testing

- `make build` — passed on the final diff
- `make analyze` — passed on the final diff
- `git diff --check` — passed
- `make coverage-gate` — passed during implementation
- `make scan` — passed; no leaks found
- `make release && make verify-release` — passed during implementation
- Local XCTest execution was re-attempted serially and with fresh DerivedData, but the macOS runner stalled before launching any test case; GitHub Actions is the required final runtime gate before merge.

### Risks

Low. The behavior change is isolated to user polling. The debounce is scoped to account generation, rejected requests do not consume it, and only the latest poll may clear loading or reopen reconnect behavior.

### Screenshots or recordings

Not applicable; this is polling lifecycle behavior with no visual layout change.

### Issue closure

Closes #48
Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved polling reliability by preventing stale requests from overriding newer loading states.
  * Prevented overly frequent manual refreshes while allowing refreshes after account changes or offline recovery.
  * Improved timer handling during polling and manual refresh operations.

* **Tests**
  * Added coverage for refresh throttling, account switching, offline recovery, timer behavior, and overlapping requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->