### PR TITLE
fix(#84): stop an empty activity body from wiping known events

### DIFF
--- a/MacTorn/MacTorn/Helpers/UITestSupport.swift
+++ b/MacTorn/MacTorn/Helpers/UITestSupport.swift
@@ -170,6 +170,13 @@ enum UITestConfiguration {
             // never overwritten by fetchActivityData's `if let events = ...`
             // guard — same non-clobbering trick as above. Used to pin
             // EventsView's combined VoiceOver label (issue #45).
+            //
+            // This only holds because `UserSnapshotService.loadActivity` reports an
+            // *absent* "events" key as nil rather than as an empty array (issue #84).
+            // Before that fix the first poll wiped this seed and StatusView's
+            // `if !appState.activityEvents.isEmpty` dropped EventsView from the tree
+            // entirely. Never rely on this pattern for a field whose parser collapses
+            // "absent" to an empty collection.
             let fixtureEventJSON = Data("""
             {"timestamp": \(now - 90), "event": "You were mugged by <a href=\\"#\\">Fixture Mugger</a> for $500."}
             """.utf8)

--- a/MacTorn/MacTorn/ViewModels/UserSnapshotService.swift
+++ b/MacTorn/MacTorn/ViewModels/UserSnapshotService.swift
@@ -140,14 +140,26 @@ final class UserSnapshotService: UserSnapshotServicing, @unchecked Sendable {
         }
 
         let decoded = try? JSONDecoder().decode(TornResponse.self, from: data)
+        // `TornResponse.recentEvents` / `.unreadMessagesCount` are non-optional and
+        // collapse a *missing* key to `[]` / `0`. `UserActivityPayload` must instead
+        // preserve the absent-vs-zero distinction the way `parseAttacks(_:)` does:
+        // `AppState.fetchActivityData` only overwrites its state when the payload field
+        // is non-nil, so a 200 body that simply omits `events` must report `nil` rather
+        // than silently emptying the user's event list (issue #84).
         return .success(
             UserActivityPayload(
-                events: decoded?.recentEvents,
-                unreadMessages: decoded?.unreadMessagesCount,
+                events: Self.isPresent(json["events"]) ? decoded?.recentEvents : nil,
+                unreadMessages: Self.isPresent(json["messages"]) ? decoded?.unreadMessagesCount : nil,
                 recentAttacks: Self.parseAttacks(json)
             ),
             responseBytes: data.count
         )
+    }
+
+    /// True when a top-level JSON key is present and not `null`.
+    private static func isPresent(_ value: Any?) -> Bool {
+        guard let value else { return false }
+        return !(value is NSNull)
     }
 
     func loadUserV2(_ url: URL) async throws -> UserServiceResult<UserV2Payload> {

--- a/MacTorn/MacTornTests/ViewModels/UITestHarnessTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/UITestHarnessTests.swift
@@ -55,6 +55,89 @@ final class UITestHarnessTests: XCTestCase {
         XCTAssertEqual(json?.isEmpty, true, "Activity call must not get the fast-user fixture")
     }
 
+    // MARK: - Issue #84 probes: the `.accessibility` activity seed must survive a poll
+    //
+    // `UITestConfiguration.makeAppState()` seeds exactly one activity event for the
+    // `.accessibility` scenario and claims it is "never overwritten by fetchActivityData's
+    // `if let events = ...` guard" because the activity endpoint serves `[:]`. These pin
+    // every link in that chain so the XCUITest failure (`uitest.event.9002` never found)
+    // can be localised without launching the app.
+
+    /// Link 1: the fixture really does serve `{}` on the activity call for `.accessibility`.
+    func testAccessibilityScenarioServesEmptyObjectOnActivityCall() throws {
+        let url = TornAPI.activityURL(for: fakeKey)
+        let data = FixtureNetworkSession.body(for: url, scenario: .accessibility)
+
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertTrue(json.isEmpty,
+                      "The accessibility scenario must not route the activity call to a rich fixture")
+    }
+
+    /// Link 2: an empty activity body must decode to *absent* events, not to an empty
+    /// array. `UserActivityPayload.events` is optional precisely so `AppState` can tell
+    /// "the endpoint said nothing" from "the endpoint said zero events" — and only the
+    /// former leaves a seeded list alone.
+    func testEmptyActivityBodyReportsAbsentEventsRatherThanZeroEvents() async throws {
+        let session = FixtureNetworkSession(scenario: .accessibility)
+        let service = UserSnapshotService(session: session)
+        let url = try XCTUnwrap(TornAPI.activityURL(for: fakeKey))
+
+        let result = try await service.loadActivity(url)
+        guard case .success(let payload, _) = result else {
+            return XCTFail("Activity call should succeed on an empty body, got \(result)")
+        }
+
+        XCTAssertNil(payload.events,
+                     "An activity response with no \"events\" key must report nil, not [] — " +
+                     "[] passes the `if let events` guard and wipes seeded/known events")
+    }
+
+    /// Link 3: `identified(by:)` must win over the timestamp-derived fallback, so the row's
+    /// accessibility identifier really is `uitest.event.9002`.
+    func testSeededAccessibilityEventKeepsItsAPIIdentity() throws {
+        let json = Data("""
+        {"timestamp": 1735689600, "event": "You were mugged by <a href=\\"#\\">Fixture Mugger</a> for $500."}
+        """.utf8)
+        let event = try JSONDecoder().decode(TornEvent.self, from: json).identified(by: "9002")
+
+        XCTAssertEqual(event.id, "9002")
+        XCTAssertEqual("uitest.event.\(event.id)", "uitest.event.9002")
+        XCTAssertEqual(event.cleanEvent, "You were mugged by Fixture Mugger for $500.")
+    }
+
+    /// Link 4, end to end: seed the event exactly as the harness does, run one real poll
+    /// through the fixture session, and require the row to still be there afterwards.
+    /// If this goes red, no amount of scrolling in XCUITest can find `uitest.event.9002`.
+    @MainActor
+    func testAccessibilityPollDoesNotClearSeededActivityEvents() async throws {
+        let appState = AppState(session: FixtureNetworkSession(scenario: .accessibility),
+                                connectivity: ControllableConnectivity(),
+                                defaults: .createMockDefaults())
+        appState.apiKey = "sample-ax-financial-user"   // resets account-scoped state
+
+        let seeded = try JSONDecoder().decode(
+            TornEvent.self,
+            from: Data("""
+            {"timestamp": \(Int(Date().timeIntervalSince1970) - 90), "event": "You were mugged for $500."}
+            """.utf8)
+        ).identified(by: "9002")
+        appState.activityEvents = [seeded]
+
+        XCTAssertTrue(appState.fetchData(), "The fixture poll should start")
+
+        let deadline = Date().addingTimeInterval(10)
+        while Date() < deadline,
+              appState.endpointHealth.latest(for: "user.activity") == nil {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        XCTAssertNotNil(appState.endpointHealth.latest(for: "user.activity"),
+                        "The activity call must have run for this probe to mean anything")
+
+        XCTAssertEqual(appState.activityEvents.map(\.id), ["9002"],
+                       "The accessibility fixture's seeded event must survive the activity poll — " +
+                       "StatusView hides EventsView entirely when activityEvents is empty")
+    }
+
     func testNilURLDoesNotCrashAndServesEmpty() {
         let data = FixtureNetworkSession.body(for: nil, scenario: .full)
         XCTAssertFalse(data.isEmpty, "A nil URL should still yield a valid (empty-object) body")

--- a/MacTorn/MacTornTests/ViewModels/UserSnapshotServiceTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/UserSnapshotServiceTests.swift
@@ -77,6 +77,50 @@ final class UserSnapshotServiceTests: XCTestCase {
         XCTAssertEqual(bytes, data.count)
     }
 
+    /// Issue #84: a 200 body that simply omits the row-based selections must report
+    /// *absent* (nil) for every field, so `AppState.fetchActivityData`'s `if let`
+    /// guards leave the last known events/messages/attacks alone. Reporting `[]`/`0`
+    /// here silently wipes the user's event list on any partial response.
+    func testActivityBodyWithoutRowSelectionsReportsEveryFieldAsAbsent() async throws {
+        let mock = MockNetworkSession()
+        mock.mockData = try TornAPIFixtures.toData([:])
+        let service = UserSnapshotService(session: mock)
+
+        let result = try await service.loadActivity(
+            URL(string: "https://api.torn.com/user")!
+        )
+
+        guard case .success(let payload, _) = result else {
+            return XCTFail("Expected activity payload")
+        }
+        XCTAssertNil(payload.events, "A missing \"events\" key must not decode to []")
+        XCTAssertNil(payload.unreadMessages, "A missing \"messages\" key must not decode to 0")
+        XCTAssertNil(payload.recentAttacks, "A missing \"attacks\" key must not decode to []")
+    }
+
+    /// The mirror image of the test above: when the keys *are* present but empty, the
+    /// endpoint really is saying "zero rows", and that must overwrite stale state.
+    func testActivityBodyWithEmptyRowSelectionsReportsZeroRatherThanAbsent() async throws {
+        let mock = MockNetworkSession()
+        mock.mockData = try TornAPIFixtures.toData([
+            "events": [String: Any](),
+            "messages": [String: Any](),
+            "attacks": [String: Any]()
+        ])
+        let service = UserSnapshotService(session: mock)
+
+        let result = try await service.loadActivity(
+            URL(string: "https://api.torn.com/user")!
+        )
+
+        guard case .success(let payload, _) = result else {
+            return XCTFail("Expected activity payload")
+        }
+        XCTAssertEqual(payload.events?.isEmpty, true)
+        XCTAssertEqual(payload.unreadMessages, 0)
+        XCTAssertEqual(payload.recentAttacks?.isEmpty, true)
+    }
+
     func testLoadsUserV2SectionsIndependently() async throws {
         let mock = MockNetworkSession()
         let data = try TornAPIFixtures.toData(


### PR DESCRIPTION
Fixes #84.

## Root cause

`UserSnapshotService.loadActivity` mapped `events: decoded?.recentEvents`, and
`TornResponse.recentEvents` is a **non-optional** `[TornEvent]` that yields `[]` when the
`events` key is absent. Decoding `{}` therefore succeeded with `events == []`, not `nil`,
which passed `fetchActivityData`'s `if let events = payload.events` guard and assigned
`activityEvents = []`.

The accessibility fixture seeds one event on `AppState` and relies on the activity endpoint
returning `{}` so nothing clobbers it. That assumption held for attacks — `parseAttacks`
returns `nil` for an absent key — but not for events. So the seeded event was wiped on the
first poll, `StatusView`'s `if !appState.activityEvents.isEmpty` dropped `EventsView`
entirely, and `uitest.event.9002` could never exist. Every earlier assertion in the failing
test passed, which is exactly the pattern that made this hard to see.

## Fix

`loadActivity` now gates `events` and `unreadMessages` on raw-JSON key presence, mirroring
`parseAttacks`' absent-vs-zero contract.

**This is a real production bug, not only a test-harness one:** before this change, a 200
response that omitted `events` silently emptied the user's event list.

## Proof

Four headless probes in `UITestHarnessTests`, two of which were deliberately red before the
fix and are green after:

- `testEmptyActivityBodyReportsAbsentEventsRatherThanZeroEvents` — the defect at the service boundary
- `testAccessibilityPollDoesNotClearSeededActivityEvents` — the end-to-end wipe
- `testAccessibilityScenarioServesEmptyObjectOnActivityCall` — was already green, confirming the fixture body itself is correct
- `testSeededAccessibilityEventKeepsItsAPIIdentity` — was already green, confirming the id/identifier chain

Local: `make build` and `make test` green, 495 passing, 0 failing.
The `Fixture UI Tests` job on this PR is the acceptance signal — it was not run locally.

## Residual risk

`EventsView` sits below the fold of the bounded 320x480 test surface, so `a7034fb`'s
`scrollToElement` helper has still never been executed against this row. If the UI job is
still red, that helper is the next place to look, not the data path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved activity data when event or message fields are missing or null.
  * Distinguished between omitted activity fields and explicitly empty collections.
  * Prevented accessibility activity updates from clearing seeded events.

* **Tests**
  * Added regression coverage for activity decoding, event retention, and accessibility polling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->