### PR TITLE
fix(#46): damp the server-clock offset so countdowns never tick backwards

### DIFF
--- a/MacTorn/MacTorn.xcodeproj/project.pbxproj
+++ b/MacTorn/MacTorn.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		AAA00037 /* NextAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10037 /* NextAction.swift */; };
 		AAA00038 /* NextActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA10038 /* NextActionView.swift */; };
 		BBB00029 /* NextActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10029 /* NextActionTests.swift */; };
+		BBB00038 /* ServerClockOffsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB10038 /* ServerClockOffsetTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -213,6 +214,7 @@
 		AAA10037 /* NextAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextAction.swift; sourceTree = "<group>"; };
 		AAA10038 /* NextActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextActionView.swift; sourceTree = "<group>"; };
 		BBB10029 /* NextActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextActionTests.swift; sourceTree = "<group>"; };
+		BBB10038 /* ServerClockOffsetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerClockOffsetTests.swift; sourceTree = "<group>"; };
 		F71B7A54C801E9B473317B0A /* SentryOptInPromptView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SentryOptInPromptView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -451,6 +453,7 @@
 				BBB10034 /* MarketWatchServiceTests.swift */,
 				BBB10035 /* ForumWatchServiceTests.swift */,
 				BBB10036 /* FactionServiceTests.swift */,
+				BBB10038 /* ServerClockOffsetTests.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -688,6 +691,7 @@
 				BBB00028 /* DiagnosticsTests.swift in Sources */,
 				BBB00030 /* UITestHarnessTests.swift in Sources */,
 				BBB00029 /* NextActionTests.swift in Sources */,
+				BBB00038 /* ServerClockOffsetTests.swift in Sources */,
 				BBB00032 /* AccountSessionStoreTests.swift in Sources */,
 				BBB00033 /* UserSnapshotServiceTests.swift in Sources */,
 				BBB00034 /* MarketWatchServiceTests.swift in Sources */,

--- a/MacTorn/MacTorn/Helpers/TimeSource.swift
+++ b/MacTorn/MacTorn/Helpers/TimeSource.swift
@@ -49,6 +49,12 @@ struct ServerClock: Equatable, Sendable {
     /// machine (minutes, even hours) is still honoured.
     static let maxPlausibleSkewSeconds = 86_400
 
+    /// Movement below this is jitter, not a clock correction — see `merged(with:)`.
+    /// The same window `CooldownEnds.merged` uses to pin cooldown end-timestamps: both
+    /// are damping the identical physical wobble (whole-second integers on both sides
+    /// of the subtraction, plus per-request latency), so they must not drift apart.
+    static let jitterToleranceSeconds = 3
+
     init(offset: Int) {
         self.offset = offset
     }
@@ -63,6 +69,29 @@ struct ServerClock: Equatable, Sendable {
         }
         let delta = anchor - Int(localNow.timeIntervalSince1970)
         self.offset = abs(delta) <= Self.maxPlausibleSkewSeconds ? delta : 0
+    }
+
+    /// Stabilises per-poll jitter in the derived offset — the offset's exact analogue of
+    /// `CooldownEnds.merged`, and for the same reason.
+    ///
+    /// `offset = server_time - Int(receiptTime)` is not a stable quantity even when
+    /// neither clock has moved: `server_time` is whole seconds, the local receipt is
+    /// truncated to whole seconds, and the gap between the two absorbs that poll's
+    /// network latency. So it wobbles by a second or three between polls. Since *every*
+    /// countdown is now measured as `deadline - serverNow`, an offset that wobbles makes
+    /// every countdown in the app — the menu bar included — tick backwards at each poll
+    /// boundary. That is precisely the visible jump `CooldownEnds.merged` exists to
+    /// prevent, so pinning `endsAt` while leaving `now` jittery would achieve nothing.
+    ///
+    /// Keep the pinned offset while the fresh derivation is within `toleranceSeconds`;
+    /// adopt anything beyond it, which is a genuine correction (the Mac's clock being
+    /// re-synced, or an anchor discarded as implausible collapsing us to `.synchronized`).
+    /// Because each poll compares against the *pinned* value rather than the previous
+    /// derivation, slow one-directional drift still crosses the window and is adopted —
+    /// the error is bounded by the tolerance, and nothing latches.
+    func merged(with fresh: ServerClock,
+                toleranceSeconds: Int = ServerClock.jitterToleranceSeconds) -> ServerClock {
+        abs(fresh.offset - offset) <= toleranceSeconds ? self : fresh
     }
 
     /// Torn's "now" for a given local instant.

--- a/MacTorn/MacTorn/Helpers/TimeSource.swift
+++ b/MacTorn/MacTorn/Helpers/TimeSource.swift
@@ -23,3 +23,68 @@ final class MutableTimeSource: TimeSource {
     func advance(_ seconds: TimeInterval) { current = current.addingTimeInterval(seconds) }
     func set(_ date: Date) { current = date }
 }
+
+// MARK: - Server clock (issue #46)
+//
+// Torn stamps every response with `server_time`. Cooldowns already used it, but travel,
+// hospital, jail, chain and OC each measured against a bare `Date()`, so a Mac whose
+// clock ran 90 s behind Torn's showed two contradictory clocks in one window: the
+// cooldown pill was right while the menu bar claimed the plane was still 90 s out.
+//
+// `ServerClock` is the single conversion between the two clocks. Derive it once per
+// snapshot, then read *every* countdown through it — never patch a call site by hand.
+
+/// The Mac↔Torn clock skew for one snapshot, in whole seconds.
+struct ServerClock: Equatable, Sendable {
+    /// Seconds to add to the local clock to land on Torn's. Positive = the Mac is behind.
+    let offset: Int
+
+    /// No known skew — every conversion is the identity. Also the safe degraded state
+    /// when a response carries no usable anchor.
+    static let synchronized = ServerClock(offset: 0)
+
+    /// Skew beyond this is a corrupt payload, not a slow Mac: a `server_time` a decade
+    /// out would throw every countdown into the next geological era, which is far worse
+    /// than the drift it was meant to correct. Generous enough that a genuinely un-synced
+    /// machine (minutes, even hours) is still honoured.
+    static let maxPlausibleSkewSeconds = 86_400
+
+    init(offset: Int) {
+        self.offset = offset
+    }
+
+    /// Derives the skew from a response anchor (`TornResponse.anchorTimestamp`) and the
+    /// local instant that response was received. A missing, zero or implausible anchor
+    /// collapses to `.synchronized` rather than throwing the countdowns the other way.
+    init(anchor: Int?, localNow: Date) {
+        guard let anchor, anchor > 0 else {
+            self.offset = 0
+            return
+        }
+        let delta = anchor - Int(localNow.timeIntervalSince1970)
+        self.offset = abs(delta) <= Self.maxPlausibleSkewSeconds ? delta : 0
+    }
+
+    /// Torn's "now" for a given local instant.
+    func serverNow(_ localNow: Date) -> Date {
+        localNow.addingTimeInterval(TimeInterval(offset))
+    }
+
+    /// Torn's "now" as Unix seconds for a given local instant.
+    func serverUnix(_ localNow: Date) -> Int {
+        Int(localNow.timeIntervalSince1970) + offset
+    }
+
+    /// Turns a duration measured from the moment the server generated a response
+    /// (`travel.time_left`, `bar.fulltime`) into an absolute *server* timestamp.
+    func serverTimestamp(fetchedAt: Date, plus seconds: Int) -> Int {
+        serverUnix(fetchedAt) + seconds
+    }
+
+    /// The local instant at which a server timestamp occurs. Needed whenever something
+    /// outside the app holds the deadline — a scheduled local notification fires on the
+    /// Mac's clock, so a server-absolute arrival time has to be converted back.
+    func localDate(forServerTimestamp timestamp: Int) -> Date {
+        Date(timeIntervalSince1970: TimeInterval(timestamp - offset))
+    }
+}

--- a/MacTorn/MacTorn/Models/TornModels.swift
+++ b/MacTorn/MacTorn/Models/TornModels.swift
@@ -187,7 +187,12 @@ struct CooldownEnds: Equatable {
     /// taken, drug applied, medical after hospitalisation) — we adopt the new value.
     /// A `0` on either side (cooldown inactive on one side) is taken from `other`
     /// so transitions in/out of active are immediate.
-    func merged(with other: CooldownEnds, toleranceSeconds: Int = 3) -> CooldownEnds {
+    ///
+    /// The tolerance is shared with `ServerClock.merged`, which damps the *other* half
+    /// of the same subtraction (issue #46): pinning `endsAt` while `now` still wobbles
+    /// poll to poll would give the jump back.
+    func merged(with other: CooldownEnds,
+                toleranceSeconds: Int = ServerClock.jitterToleranceSeconds) -> CooldownEnds {
         func pick(_ old: Int, _ new: Int) -> Int {
             if old == 0 || new == 0 { return new }
             return abs(new - old) <= toleranceSeconds ? old : new

--- a/MacTorn/MacTorn/Models/TornModels.swift
+++ b/MacTorn/MacTorn/Models/TornModels.swift
@@ -160,15 +160,17 @@ struct CooldownEnds: Equatable {
         }
     }
 
-    func remainingSeconds(_ kind: CooldownKind) -> Int {
+    /// `endsAt` is an absolute **server** timestamp, so `now` must be Torn's now
+    /// (`AppState.serverNow`). The `Date()` default is for pure-model callers only.
+    func remainingSeconds(_ kind: CooldownKind, at now: Date = Date()) -> Int {
         let target = endsAt(kind)
         guard target > 0 else { return 0 }
-        return max(0, target - Int(Date().timeIntervalSince1970))
+        return max(0, target - Int(now.timeIntervalSince1970))
     }
 
-    func soonestActive() -> (kind: CooldownKind, seconds: Int)? {
+    func soonestActive(at now: Date = Date()) -> (kind: CooldownKind, seconds: Int)? {
         CooldownKind.allCases
-            .map { (kind: $0, seconds: remainingSeconds($0)) }
+            .map { (kind: $0, seconds: remainingSeconds($0, at: now)) }
             .filter { $0.seconds > 0 }
             .min { $0.seconds < $1.seconds }
     }
@@ -227,26 +229,31 @@ struct Travel: Codable, Equatable {
         return Date(timeIntervalSince1970: TimeInterval(ts))
     }
 
-    /// Calculate remaining seconds based on fetch time (for live countdown)
-    func remainingSeconds(from fetchTime: Date) -> Int {
+    /// Remaining seconds of flight.
+    ///
+    /// `timestamp` is an absolute **server** timestamp and `time_left` is measured from
+    /// the instant the *server* generated the response, so both `fetchTime` and `now`
+    /// must be expressed on Torn's clock (`AppState.serverFetchTime` / `AppState.serverNow`)
+    /// — mixing the two clocks is exactly the bug in issue #46. The `Date()` default is
+    /// for pure-model callers that have no skew to correct.
+    func remainingSeconds(from fetchTime: Date, now: Date = Date()) -> Int {
         // Primary: Use timestamp directly if available (more accurate)
         if let timestamp = timestamp, timestamp > 0 {
-            let now = Int(Date().timeIntervalSince1970)
-            return max(0, timestamp - now)
+            return max(0, timestamp - Int(now.timeIntervalSince1970))
         }
 
         // Fallback: Use timeLeft with fetchTime offset (backward compatibility)
         guard let timeLeft = timeLeft, timeLeft > 0 else { return 0 }
-        let elapsed = Int(Date().timeIntervalSince(fetchTime))
+        let elapsed = Int(now.timeIntervalSince(fetchTime))
         return max(0, timeLeft - elapsed)
     }
 
     /// Calculate flight progress (0.0 to 1.0) based on fetch time
-    func flightProgress(from fetchTime: Date) -> Double {
+    func flightProgress(from fetchTime: Date, now: Date = Date()) -> Double {
         guard let departed = departed, let timestamp = timestamp else { return 0 }
         let totalDuration = timestamp - departed
         guard totalDuration > 0 else { return 0 }
-        let remaining = remainingSeconds(from: fetchTime)
+        let remaining = remainingSeconds(from: fetchTime, now: now)
         let elapsed = totalDuration - remaining
         return min(1.0, max(0.0, Double(elapsed) / Double(totalDuration)))
     }
@@ -403,10 +410,14 @@ struct Status: Codable, Equatable {
         state == "Okay" || state == nil
     }
     
-    var timeRemaining: Int {
+    /// Seconds until release. `until` is an absolute **server** timestamp, so `now` must
+    /// be Torn's now (`AppState.serverNow`).
+    func timeRemaining(at now: Date) -> Int {
         guard let until = until else { return 0 }
-        return max(0, until - Int(Date().timeIntervalSince1970))
+        return max(0, until - Int(now.timeIntervalSince1970))
     }
+
+    var timeRemaining: Int { timeRemaining(at: Date()) }
 }
 
 // MARK: - Chain
@@ -426,10 +437,14 @@ struct Chain: Codable, Equatable {
         return cooldown > 0
     }
     
-    var timeoutRemaining: Int {
+    /// Seconds until the chain lapses. `timeout` is an absolute **server** timestamp, so
+    /// `now` must be Torn's now (`AppState.serverNow`).
+    func timeoutRemaining(at now: Date) -> Int {
         guard let timeout = timeout else { return 0 }
-        return max(0, timeout - Int(Date().timeIntervalSince1970))
+        return max(0, timeout - Int(now.timeIntervalSince1970))
     }
+
+    var timeoutRemaining: Int { timeoutRemaining(at: Date()) }
 }
 
 // MARK: - Events
@@ -646,14 +661,16 @@ struct AttackResult: Codable, Identifiable {
         }
     }
     
-    var timeAgo: String {
+    /// `timestampEnded` is Torn's clock, so `now` should be too (`AppState.serverNow`).
+    func timeAgo(at now: Date) -> String {
         guard let ts = timestampEnded else { return "" }
-        let now = Int(Date().timeIntervalSince1970)
-        let diff = now - ts
+        let diff = Int(now.timeIntervalSince1970) - ts
         if diff < 3600 { return "\(diff / 60)m" }
         if diff < 86400 { return "\(diff / 3600)h" }
         return "\(diff / 86400)d"
     }
+
+    var timeAgo: String { timeAgo(at: Date()) }
 }
 
 // MARK: - Faction Data
@@ -753,10 +770,14 @@ struct OrganizedCrime2: Codable, Equatable, Identifiable {
     }
 
     /// True once the OC has reached its ready time and hasn't been executed yet.
-    var isReady: Bool {
+    /// `readyAt` is an absolute **server** timestamp, so `now` must be Torn's now
+    /// (`AppState.serverNow`).
+    func isReady(at now: Date) -> Bool {
         guard executedAt == nil, let readyAt, readyAt > 0 else { return false }
-        return readyAt <= Int(Date().timeIntervalSince1970)
+        return readyAt <= Int(now.timeIntervalSince1970)
     }
+
+    var isReady: Bool { isReady(at: Date()) }
 
     var filledSlots: Int { slots?.filter { $0.user != nil }.count ?? 0 }
     var totalSlots: Int { slots?.count ?? 0 }

--- a/MacTorn/MacTorn/ViewModels/AppState+LiveNextAction.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState+LiveNextAction.swift
@@ -21,7 +21,7 @@ extension AppState {
         guard let data = data else { return false }
         if let travel = data.travel, travel.isTraveling { return true }
         if let status = data.status, status.isInHospital || status.isInJail { return true }
-        if let ends = cooldownEnds, ends.soonestActive() != nil { return true }
+        if let ends = cooldownEnds, ends.soonestActive(at: serverNow) != nil { return true }
         return false
     }
 
@@ -50,10 +50,14 @@ extension AppState {
         }
     }
 
+    // Every countdown below reads `serverNow` / `serverFetchTime` — Torn's clock, not the
+    // Mac's (issue #46). All of `travel.timestamp`, `status.until` and `CooldownEnds.endsAt`
+    // are absolute server timestamps, so comparing them against a local `Date()` leaked the
+    // machine's skew straight into the menu bar.
     private func updateTravelSecondsRemaining() {
         let next: Int
         if let travel = data?.travel, travel.isTraveling {
-            next = travel.remainingSeconds(from: lastFetchTime)
+            next = travel.remainingSeconds(from: serverFetchTime, now: serverNow)
         } else {
             next = 0
         }
@@ -64,14 +68,15 @@ extension AppState {
 
     private func computeMenuBarDisplay() -> MenuBarDisplay {
         guard let data = data else { return .fallbackIcon }
+        let now = serverNow
 
         if let travel = data.travel, travel.isTraveling {
             return .traveling(destination: travel.destination,
-                              seconds: travel.remainingSeconds(from: lastFetchTime))
+                              seconds: travel.remainingSeconds(from: serverFetchTime, now: now))
         }
 
         if let status = data.status, status.isInHospital {
-            let secs = status.timeRemaining
+            let secs = status.timeRemaining(at: now)
             if let travel = data.travel, travel.isAbroad {
                 return .hospitalAbroad(destination: travel.destination, seconds: secs)
             }
@@ -79,11 +84,11 @@ extension AppState {
         }
 
         if let status = data.status, status.isInJail {
-            return .jail(seconds: status.timeRemaining)
+            return .jail(seconds: status.timeRemaining(at: now))
         }
 
         if let ends = cooldownEnds,
-           let soonest = ends.soonestActive() {
+           let soonest = ends.soonestActive(at: now) {
             return .cooldown(kind: soonest.kind, seconds: soonest.seconds)
         }
 
@@ -101,8 +106,11 @@ extension AppState {
         defaults.set(hiddenNextActionCategories.map(\.rawValue), forKey: Self.hiddenNextActionKey)
     }
 
+    /// Builds the timeline input. `now` is a *local* instant (the shared clock's); it is
+    /// converted to Torn's clock here, and every timestamp in the snapshot is likewise
+    /// server-absolute — so the whole timeline is one consistent clock (issue #46).
     func makeNextActionSnapshot(now: Date = Date()) -> NextActionSnapshot {
-        let nowUnix = Int(now.timeIntervalSince1970)
+        let nowUnix = serverClock.serverUnix(now)
         var snapshot = NextActionSnapshot(now: nowUnix)
 
         if let bars = data?.bars {
@@ -120,7 +128,10 @@ extension AppState {
             if let timestamp = travel.timestamp, timestamp > 0 {
                 snapshot.travelArrivalAt = timestamp
             } else if let timeLeft = travel.timeLeft, timeLeft > 0 {
-                snapshot.travelArrivalAt = Int(lastFetchTime.timeIntervalSince1970) + timeLeft
+                // `time_left` counts from the instant the *server* built the response, so
+                // it is anchored on the server's reading of the fetch, not the Mac's.
+                snapshot.travelArrivalAt =
+                    serverClock.serverTimestamp(fetchedAt: lastFetchTime, plus: timeLeft)
             }
         }
         if let status = data?.status {
@@ -142,9 +153,13 @@ extension AppState {
         return snapshot
     }
 
+    /// `fulltime` is a duration relative to the response, exactly like travel's `time_left`
+    /// — so it moves onto the server clock with the fetch anchor. Shifting the timeline's
+    /// `now` onto Torn's clock without moving these anchors too would knock the whole skew
+    /// off every bar ETA.
     private func barFullAt(_ bar: Bar) -> Int? {
         guard bar.current < bar.maximum, let full = bar.fulltime, full > 0 else { return nil }
-        return Int(lastFetchTime.timeIntervalSince1970) + full
+        return serverClock.serverTimestamp(fetchedAt: lastFetchTime, plus: full)
     }
 
     func nextEvents(now: Date = Date()) -> [NextEvent] {

--- a/MacTorn/MacTorn/ViewModels/AppState+NotificationsFeedback.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState+NotificationsFeedback.swift
@@ -65,15 +65,19 @@ extension AppState {
         guard let chain = liveChain, chainExpiringShouldFire(chain) else { return }
         NotificationManager.shared.send(
             title: "Chain Expiring! ⚠️",
-            body: "Chain timeout in \(chain.timeoutRemaining) seconds!",
+            body: "Chain timeout in \(chain.timeoutRemaining(at: serverNow)) seconds!",
             type: .chainExpiring
         )
     }
 
+    /// `FactionChain.timeout` is an absolute server timestamp, so the danger window is
+    /// measured on Torn's clock (issue #46) — on a slow Mac the local reading overstated
+    /// the time left and armed the alert late.
     func chainExpiringShouldFire(_ chain: Chain?) -> Bool {
+        let remaining = chain?.timeoutRemaining(at: serverNow) ?? 0
         let inDanger = (chain?.isActive == true)
-            && chain!.timeoutRemaining > 0
-            && chain!.timeoutRemaining < Self.chainWarningThreshold
+            && remaining > 0
+            && remaining < Self.chainWarningThreshold
         return notificationCoordinator.shouldFireOnEdge("chain.expiring", active: inDanger)
     }
 

--- a/MacTorn/MacTorn/ViewModels/AppState+PersistenceStocks.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState+PersistenceStocks.swift
@@ -152,12 +152,16 @@ extension AppState {
     func scheduleTravelNotifications(for travel: Travel) {
         NotificationManager.shared.cancelTravelNotifications()
 
-        guard let arrivalDate = travel.arrivalDate else { return }
+        // `travel.timestamp` is an absolute *server* timestamp, but a scheduled local
+        // notification fires on the *Mac's* clock — so convert back through the skew
+        // (issue #46), or a 90 s-slow Mac fires every landing alert 90 s early.
+        guard travel.isTraveling, let arrival = travel.timestamp, arrival > 0 else { return }
+        let arrivalDate = serverClock.localDate(forServerTimestamp: arrival)
 
         for setting in travelNotificationSettings where setting.enabled {
             let notificationDate = arrivalDate.addingTimeInterval(-Double(setting.secondsBefore))
 
-            if notificationDate > Date() {
+            if notificationDate > time.now {
                 let identifier = "\(setting.id)_alert"
                 let timeText: String
                 if setting.secondsBefore >= 60 {

--- a/MacTorn/MacTorn/ViewModels/AppState+PollingUserFetch.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState+PollingUserFetch.swift
@@ -397,11 +397,23 @@ extension AppState {
         let decoded = payload.snapshot
         logger.info("Parsed authenticated user data successfully")
 
+        // Issue #46: re-derive the Mac↔Torn skew from THIS snapshot before anything reads
+        // a countdown. Deriving it per snapshot (rather than adjusting a running value) is
+        // what keeps it from accumulating across polls or latching when the Mac's clock is
+        // corrected mid-session. `receivedAt` is the same instant later stored as
+        // `lastFetchTime`, so the two never disagree by a poll's worth of work.
+        let receivedAt = time.now
+        serverClock = ServerClock(anchor: decoded.anchorTimestamp, localNow: receivedAt)
+
         checkNotifications(newData: decoded)
         self.data = decoded
 
         if let cooldowns = decoded.cooldowns {
-            let anchor = decoded.anchorTimestamp ?? Int(Date().timeIntervalSince1970)
+            // Deliberately the RAW anchor, not `serverClock.serverUnix(receivedAt)`: a
+            // cooldown's `endsAt` only has to be self-consistent with the response that
+            // produced it, and clamping it through the plausibility guard would silently
+            // re-anchor cooldowns from a payload whose timestamp is merely unusual.
+            let anchor = decoded.anchorTimestamp ?? Int(receivedAt.timeIntervalSince1970)
             let fresh = CooldownEnds.from(cooldowns: cooldowns, anchor: anchor)
             cooldownEnds = cooldownEnds?.merged(with: fresh) ?? fresh
         } else {
@@ -420,7 +432,7 @@ extension AppState {
         stocksData = payload.stocks
 
         lastUpdated = Date()
-        lastFetchTime = time.now
+        lastFetchTime = receivedAt
         errorMsg = nil
 
         manageLiveTimer()
@@ -554,7 +566,7 @@ extension AppState {
     }
 
     func shouldNotifyOCReady(_ oc: OrganizedCrime2?) -> Bool {
-        guard let oc, oc.isReady else { return false }
+        guard let oc, oc.isReady(at: serverNow) else { return false }
         return notificationCoordinator.shouldFireOnce("oc.ready", epoch: "\(oc.id)")
     }
 

--- a/MacTorn/MacTorn/ViewModels/AppState+PollingUserFetch.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState+PollingUserFetch.swift
@@ -257,6 +257,12 @@ extension AppState {
 
             do {
                 let response = try await self.userSnapshotService.load(url)
+                // Issue #46: stamp the receipt the instant the transport hands the bytes
+                // back. The Mac↔Torn offset is `server_time - Int(receivedAt)`, so every
+                // millisecond spent after this line — the top-level JSON sniff below, the
+                // off-actor decode in `parseSnapshot` — would otherwise be booked as clock
+                // skew and shift every countdown in the app by that much.
+                let receivedAt = self.time.now
                 let data = response.data
                 guard self.isCurrentAccount(requestedKey, generation: generation) else {
                     self.recordHealth("user.fast", outcome: .cancelled, since: startTime, bytes: 0)
@@ -296,6 +302,7 @@ extension AppState {
                     async let activityResult: Void = self.fetchActivityData(apiKey: requestedKey, generation: generation)
                     let parsed = await self.parseDataInBackground(
                         data: data,
+                        receivedAt: receivedAt,
                         apiKey: requestedKey,
                         generation: generation
                     )
@@ -370,7 +377,13 @@ extension AppState {
         return true
     }
 
-    private func parseDataInBackground(data: Data, apiKey: String, generation: UInt) async -> Bool {
+    /// - Parameter receivedAt: the local instant the transport returned these bytes,
+    ///   sampled by the caller *before* this decode (issue #46). It is both the anchor
+    ///   for the Mac↔Torn offset and the value stored as `lastFetchTime`.
+    private func parseDataInBackground(data: Data,
+                                       receivedAt: Date,
+                                       apiKey: String,
+                                       generation: UInt) async -> Bool {
         let requestedSelections =
             TornEndpointRegistry.endpoint(id: "user.fast")?.selections ?? []
         let grantedSelections = keyInfo?.selections.user
@@ -400,10 +413,16 @@ extension AppState {
         // Issue #46: re-derive the Mac↔Torn skew from THIS snapshot before anything reads
         // a countdown. Deriving it per snapshot (rather than adjusting a running value) is
         // what keeps it from accumulating across polls or latching when the Mac's clock is
-        // corrected mid-session. `receivedAt` is the same instant later stored as
-        // `lastFetchTime`, so the two never disagree by a poll's worth of work.
-        let receivedAt = time.now
-        serverClock = ServerClock(anchor: decoded.anchorTimestamp, localNow: receivedAt)
+        // corrected mid-session.
+        //
+        // …but the raw derivation is jittery — whole-second truncation on both sides plus
+        // this request's latency — and it is now the `now` behind EVERY countdown, so the
+        // wobble is damped against the pinned value exactly as `CooldownEnds.merged` damps
+        // `endsAt`. Without that, each poll boundary walks the menu bar backwards by a
+        // second or three. `receivedAt` is the transport's receipt instant and is also
+        // what lands in `lastFetchTime`, so the anchor and the fetch time never disagree.
+        let derivedClock = ServerClock(anchor: decoded.anchorTimestamp, localNow: receivedAt)
+        serverClock = serverClock.merged(with: derivedClock)
 
         checkNotifications(newData: decoded)
         self.data = decoded

--- a/MacTorn/MacTorn/ViewModels/AppState.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState.swift
@@ -199,6 +199,21 @@ class AppState {
     // MARK: - Fetch Time (for live countdown calculations)
     var lastFetchTime: Date = Date()
 
+    /// Mac↔Torn clock skew, re-derived from `server_time` on every successful snapshot
+    /// (issue #46). Every countdown in the app — travel, hospital, jail, chain, OC,
+    /// cooldowns, bars — is measured through this, so the whole window agrees on one
+    /// clock. Absent or implausible anchors leave it `.synchronized`, i.e. the plain
+    /// local clock.
+    var serverClock: ServerClock = .synchronized
+
+    /// "Now" on Torn's clock. The only `now` any countdown should compare against.
+    var serverNow: Date { serverClock.serverNow(time.now) }
+
+    /// The instant of the last successful fetch, expressed on Torn's clock. Pair it with
+    /// `serverNow` whenever a duration is relative to the response (`travel.time_left`,
+    /// `bar.fulltime`) so the elapsed time is a same-clock subtraction.
+    var serverFetchTime: Date { serverClock.serverNow(lastFetchTime) }
+
     /// Absolute end-timestamps for active cooldowns, derived at fetch time from
     /// the server's response timestamp. The single source of truth that keeps
     /// the menu-bar and Status tab cooldown countdowns matching torn.com.
@@ -383,6 +398,7 @@ class AppState {
         education = nil
         bountiesOnMe = []
         cooldownEnds = nil
+        serverClock = .synchronized
         travelSecondsRemaining = 0
         menuBarDisplay = .fallbackIcon
         previousBars = nil

--- a/MacTorn/MacTorn/Views/AttacksView.swift
+++ b/MacTorn/MacTorn/Views/AttacksView.swift
@@ -83,9 +83,9 @@ struct AttacksView: View {
                             let direction = userWasAttacker
                                 ? "outgoing attack against"
                                 : "incoming attack from"
-                            let timeDescription = attack.timeAgo.isEmpty
+                            let timeDescription = attack.timeAgo(at: appState.serverNow).isEmpty
                                 ? ""
-                                : ", \(attack.timeAgo) ago"
+                                : ", \(attack.timeAgo(at: appState.serverNow)) ago"
 
                             Button {
                                 if let opponentId = attack.opponentId(forUserId: userId),
@@ -118,7 +118,7 @@ struct AttacksView: View {
 
                                     Spacer()
 
-                                    Text(attack.timeAgo)
+                                    Text(attack.timeAgo(at: appState.serverNow))
                                         .font(.caption2)
                                         .foregroundColor(.secondary)
                                 }

--- a/MacTorn/MacTorn/Views/Components/ChainView.swift
+++ b/MacTorn/MacTorn/Views/Components/ChainView.swift
@@ -4,11 +4,14 @@ struct ChainView: View {
     @Environment(\.reduceTransparency) private var reduceTransparency
     let chain: Chain
     let fetchTime: Date
+    /// Mac↔Torn skew (issue #46). `chain.timeout` is an absolute server timestamp, so the
+    /// tick has to be compared against Torn's now, not the Mac's.
+    var serverClock: ServerClock = .synchronized
 
     var body: some View {
         if chain.isActive {
             TimelineView(.periodic(from: fetchTime, by: 1.0)) { context in
-                let remaining = max(0, (chain.timeout ?? 0) - Int(context.date.timeIntervalSince1970))
+                let remaining = chain.timeoutRemaining(at: serverClock.serverNow(context.date))
                 let color = timeoutColor(for: remaining)
 
                 VStack(alignment: .leading, spacing: 4) {

--- a/MacTorn/MacTorn/Views/Components/EventsView.swift
+++ b/MacTorn/MacTorn/Views/Components/EventsView.swift
@@ -3,7 +3,10 @@ import SwiftUI
 struct EventsView: View {
     @Environment(\.reduceTransparency) private var reduceTransparency
     let events: [TornEvent]
-    
+    /// Mac↔Torn skew (issue #46) — event timestamps are Torn's, so "how long ago" is
+    /// measured from Torn's now like every other clock in the window.
+    var serverClock: ServerClock = .synchronized
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack {
@@ -44,7 +47,7 @@ struct EventsView: View {
     }
     
     private func timeAgo(_ timestamp: Int) -> String {
-        let now = Int(Date().timeIntervalSince1970)
+        let now = serverClock.serverUnix(Date())
         let diff = now - timestamp
         
         if diff < 60 {

--- a/MacTorn/MacTorn/Views/Components/StatusBadgesView.swift
+++ b/MacTorn/MacTorn/Views/Components/StatusBadgesView.swift
@@ -3,7 +3,12 @@ import SwiftUI
 struct StatusBadgesView: View {
     @Environment(\.reduceTransparency) private var reduceTransparency
     let status: Status
-    
+    /// Mac↔Torn skew (issue #46). `status.until` is an absolute server timestamp, so the
+    /// badge counts down against Torn's now, matching the menu bar and the timeline.
+    var serverClock: ServerClock = .synchronized
+
+    private var remaining: Int { status.timeRemaining(at: serverClock.serverNow(Date())) }
+
     var body: some View {
         if !status.isOkay {
             HStack(spacing: 8) {
@@ -14,7 +19,7 @@ struct StatusBadgesView: View {
                             .accessibilityHidden(true)
                         Text("Hospital")
                             .font(.caption.bold())
-                        Text(formatTime(status.timeRemaining))
+                        Text(formatTime(remaining))
                             .font(.caption.monospacedDigit())
                             .foregroundColor(.secondary)
                     }
@@ -23,7 +28,7 @@ struct StatusBadgesView: View {
                     .background(Color.red.opacity(reduceTransparency ? 0.4 : 0.1))
                     .cornerRadius(6)
                     .accessibilityElement(children: .ignore)
-                    .accessibilityLabel("In hospital, \(formatTime(status.timeRemaining)) remaining")
+                    .accessibilityLabel("In hospital, \(formatTime(remaining)) remaining")
                     .uiTestID("uitest.status.hospital")
                 }
 
@@ -34,7 +39,7 @@ struct StatusBadgesView: View {
                             .accessibilityHidden(true)
                         Text("Jail")
                             .font(.caption.bold())
-                        Text(formatTime(status.timeRemaining))
+                        Text(formatTime(remaining))
                             .font(.caption.monospacedDigit())
                             .foregroundColor(.secondary)
                     }
@@ -43,7 +48,7 @@ struct StatusBadgesView: View {
                     .background(Color.orange.opacity(reduceTransparency ? 0.4 : 0.1))
                     .cornerRadius(6)
                     .accessibilityElement(children: .ignore)
-                    .accessibilityLabel("In jail, \(formatTime(status.timeRemaining)) remaining")
+                    .accessibilityLabel("In jail, \(formatTime(remaining)) remaining")
                     .uiTestID("uitest.status.jail")
                 }
             }

--- a/MacTorn/MacTorn/Views/FactionView.swift
+++ b/MacTorn/MacTorn/Views/FactionView.swift
@@ -38,7 +38,8 @@ struct FactionView: View {
                         // every second and never extrapolate from a stored duration.
                         if faction.chain.current > 0 {
                             TimelineView(.periodic(from: .now, by: 1.0)) { context in
-                                let remaining = max(0, faction.chain.timeout - Int(context.date.timeIntervalSince1970))
+                                let remaining = max(0, faction.chain.timeout
+                                    - appState.serverClock.serverUnix(context.date))
                                 let color = chainColor(remaining: remaining)
                                 HStack {
                                     Image(systemName: "link")
@@ -92,7 +93,7 @@ struct FactionView: View {
 
                 // Organized Crime 2.0 (your own current OC)
                 if let oc = appState.organizedCrime {
-                    OC2StatusView(oc: oc, playerId: appState.data?.playerId)
+                    OC2StatusView(oc: oc, playerId: appState.data?.playerId, serverClock: appState.serverClock)
                 }
 
                 // Active ranked war (score vs target)
@@ -184,6 +185,8 @@ struct OC2StatusView: View {
     @Environment(\.reduceTransparency) private var reduceTransparency
     let oc: OrganizedCrime2
     let playerId: Int?
+    /// Mac↔Torn skew (issue #46) — `readyAt` is server-absolute.
+    var serverClock: ServerClock = .synchronized
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -203,7 +206,7 @@ struct OC2StatusView: View {
             // Name + ready countdown. `readyAt` is an absolute Unix timestamp, so we
             // tick `now` against it every second — no drift vs the in-game OC panel.
             TimelineView(.periodic(from: .now, by: 1.0)) { context in
-                let now = Int(context.date.timeIntervalSince1970)
+                let now = serverClock.serverUnix(context.date)
                 let ready = oc.readyAt.map { $0 <= now } ?? false
                 let remaining = max(0, (oc.readyAt ?? 0) - now)
 

--- a/MacTorn/MacTorn/Views/StatusView.swift
+++ b/MacTorn/MacTorn/Views/StatusView.swift
@@ -32,12 +32,12 @@ struct StatusView: View {
                 
                 // Status badges (Hospital/Jail)
                 if let status = appState.data?.status {
-                    StatusBadgesView(status: status)
+                    StatusBadgesView(status: status, serverClock: appState.serverClock)
                 }
                 
                 // Chain status
                 if let chain = appState.liveChain, let fetchTime = appState.lastUpdated {
-                    ChainView(chain: chain, fetchTime: fetchTime)
+                    ChainView(chain: chain, fetchTime: fetchTime, serverClock: appState.serverClock)
                 }
                 
                 // Travel status
@@ -70,7 +70,7 @@ struct StatusView: View {
 
                 // Events
                 if !appState.activityEvents.isEmpty {
-                    EventsView(events: appState.activityEvents)
+                    EventsView(events: appState.activityEvents, serverClock: appState.serverClock)
                 }
                 
                 // Quick Links
@@ -237,9 +237,9 @@ struct StatusView: View {
 
             HStack(spacing: 16) {
                 if let ends = appState.cooldownEnds {
-                    LiveCooldownItem(label: "Drug", endsAt: ends.drugEndsAt, icon: "pills.fill", actionURL: drugURL, actionLabel: "Use Drug →")
-                    LiveCooldownItem(label: "Medical", endsAt: ends.medicalEndsAt, icon: "cross.case.fill", actionURL: medicalURL, actionLabel: "Use Medical →")
-                    LiveCooldownItem(label: "Booster", endsAt: ends.boosterEndsAt, icon: "arrow.up.circle.fill", actionURL: boosterURL, actionLabel: boosterLabel)
+                    LiveCooldownItem(label: "Drug", endsAt: ends.drugEndsAt, icon: "pills.fill", actionURL: drugURL, actionLabel: "Use Drug →", serverClock: appState.serverClock)
+                    LiveCooldownItem(label: "Medical", endsAt: ends.medicalEndsAt, icon: "cross.case.fill", actionURL: medicalURL, actionLabel: "Use Medical →", serverClock: appState.serverClock)
+                    LiveCooldownItem(label: "Booster", endsAt: ends.boosterEndsAt, icon: "arrow.up.circle.fill", actionURL: boosterURL, actionLabel: boosterLabel, serverClock: appState.serverClock)
                 } else {
                     CooldownItem(label: "Drug", seconds: cooldowns.drug, icon: "pills.fill", actionURL: drugURL, actionLabel: "Use Drug →")
                     CooldownItem(label: "Medical", seconds: cooldowns.medical, icon: "cross.case.fill", actionURL: medicalURL, actionLabel: "Use Medical →")
@@ -364,7 +364,8 @@ struct StatusView: View {
                 // `endsDate` is an absolute time, so tick `now` against it — no drift.
                 if let ends = appState.education?.endsDate {
                     TimelineView(.periodic(from: .now, by: 1.0)) { context in
-                        let remaining = max(0, Int(ends.timeIntervalSince(context.date)))
+                        let remaining = max(0, Int(ends.timeIntervalSince(
+                            appState.serverClock.serverNow(context.date))))
                         HStack(spacing: 6) {
                             Image(systemName: "graduationcap.fill")
                                 .foregroundColor(.purple)
@@ -492,13 +493,16 @@ struct LiveCooldownItem: View {
     let icon: String
     var actionURL: URL? = nil
     var actionLabel: String? = nil
+    /// Mac↔Torn skew (issue #46) — `endsAt` is server-absolute, so the tick is compared
+    /// against Torn's now.
+    var serverClock: ServerClock = .synchronized
 
     @Environment(\.reduceTransparency) private var reduceTransparency
 
     var body: some View {
         TimelineView(.periodic(from: .now, by: 1.0)) { context in
             let remaining = endsAt > 0
-                ? max(0, endsAt - Int(context.date.timeIntervalSince1970))
+                ? max(0, endsAt - serverClock.serverUnix(context.date))
                 : 0
 
             if remaining <= 0, let url = actionURL {

--- a/MacTorn/MacTornTests/ViewModels/ServerClockOffsetTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/ServerClockOffsetTests.swift
@@ -332,6 +332,214 @@ final class ServerClockOffsetTests: XCTestCase {
         XCTAssertEqual(try eta(.energy), 600,
                        "a relative fulltime must not be shifted by the clock offset")
     }
+
+    // MARK: - The offset must not itself be jittery (issue #46, review finding)
+    //
+    // `server_time` is whole seconds and the response takes real time to arrive, so the
+    // quantity `server_time - Int(localReceiptTime)` wobbles by a second or three between
+    // polls even when neither clock has moved. Re-deriving it from scratch every poll and
+    // then measuring EVERY countdown against it feeds that wobble into the menu bar: the
+    // number counts down for a minute and then jumps back UP at the poll boundary.
+    //
+    // This is the exact hazard `CooldownEnds.merged` was written for ("without smoothing,
+    // every poll causes a visible jump in the menu bar countdown") — and routing `now`
+    // through a jittery offset defeats that pin for every surface at once. So the offset
+    // gets the same treatment as `endsAt`: ignore sub-tolerance movement, track real
+    // corrections.
+    //
+    // Each test below runs the same shape — two polls 60 s of injected time apart, the
+    // second response's anchor 2 s "late" (ordinary network latency) — and asserts the
+    // countdown fell by exactly 60. Any implementation that lets latency reach `now`
+    // reports 62 and has visibly ticked backwards on screen.
+
+    /// The proof case from the review: 300 → 240 over a minute, never 242.
+    func testCooldownCountdownDoesNotJumpBackWhenTheAnchorJitters() async throws {
+        try await poll(serverTime: localNow,
+                       cooldowns: ["drug": 0, "booster": 0, "medical": 300])
+        XCTAssertEqual(app.serverClock.offset, 0, "first poll: anchor and receipt agree")
+        XCTAssertEqual(try eta(.medical), 300)
+
+        clock.advance(60)
+        try await poll(serverTime: localNow + 58,
+                       cooldowns: ["drug": 0, "booster": 0, "medical": 240])
+
+        XCTAssertEqual(app.serverClock.offset, 0,
+                       "2 s of request latency is jitter, not a clock correction — "
+                       + "re-deriving the offset from scratch reads it as -2")
+        XCTAssertEqual(try eta(.medical), 240,
+                       "the menu bar counted 300…241 over that minute; 242 is a visible "
+                       + "jump backwards on the app's only always-visible surface")
+        XCTAssertEqual(app.menuBarDisplay, .cooldown(kind: .medical, seconds: 240))
+    }
+
+    /// Travel carries an absolute arrival timestamp, so the deadline is provably
+    /// unchanged between the two polls — only `now` can move it.
+    func testTravelCountdownDoesNotJumpBackWhenTheAnchorJitters() async throws {
+        let arrival = localNow + 300
+        try await poll(serverTime: localNow,
+                       travel: travelSlice(arrivingAt: arrival,
+                                           departedAt: localNow - 300,
+                                           timeLeft: 300))
+        XCTAssertEqual(app.travelSecondsRemaining, 300)
+
+        clock.advance(60)
+        try await poll(serverTime: localNow + 58,
+                       travel: travelSlice(arrivingAt: arrival,
+                                           departedAt: localNow - 300,
+                                           timeLeft: 240))
+
+        XCTAssertEqual(app.travelSecondsRemaining, 240,
+                       "same arrival timestamp, 60 s later — the plane cannot get further away")
+        XCTAssertEqual(app.menuBarDisplay, .traveling(destination: "Mexico", seconds: 240))
+        XCTAssertEqual(try eta(.travel), 240)
+    }
+
+    func testHospitalCountdownDoesNotJumpBackWhenTheAnchorJitters() async throws {
+        let release = localNow + 300
+        try await poll(serverTime: localNow, status: hospitalSlice(until: release))
+        XCTAssertEqual(try eta(.hospital), 300)
+
+        clock.advance(60)
+        try await poll(serverTime: localNow + 58, status: hospitalSlice(until: release))
+
+        XCTAssertEqual(try eta(.hospital), 240,
+                       "`until` never moved, so the countdown can only fall")
+        XCTAssertEqual(app.menuBarDisplay, .hospitalAtHome(seconds: 240))
+    }
+
+    func testJailCountdownDoesNotJumpBackWhenTheAnchorJitters() async throws {
+        let release = localNow + 450
+        try await poll(serverTime: localNow, status: jailSlice(until: release))
+        XCTAssertEqual(try eta(.jail), 450)
+
+        clock.advance(60)
+        try await poll(serverTime: localNow + 58, status: jailSlice(until: release))
+
+        XCTAssertEqual(try eta(.jail), 390)
+        XCTAssertEqual(app.menuBarDisplay, .jail(seconds: 390))
+    }
+
+    /// Chain and OC deadlines arrive on their own endpoints, so they are re-published
+    /// verbatim after the second poll — identical absolute timestamps, nothing about
+    /// them changed. Only the shared "now" can move these numbers.
+    func testChainAndOrganizedCrimeCountdownsDoNotJumpBackWhenTheAnchorJitters() async throws {
+        let chainTimeout = localNow + 180
+        let ocReadyAt = localNow + 240
+
+        try await poll(serverTime: localNow)
+        publishChain(timeout: chainTimeout)
+        app.organizedCrime = OrganizedCrime2(id: 1, name: "Clinical Precision",
+                                             status: "Planning", readyAt: ocReadyAt)
+        XCTAssertEqual(try eta(.chain), 180)
+        XCTAssertEqual(try eta(.organizedCrime), 240)
+
+        clock.advance(60)
+        try await poll(serverTime: localNow + 58)
+        publishChain(timeout: chainTimeout)
+        app.organizedCrime = OrganizedCrime2(id: 1, name: "Clinical Precision",
+                                             status: "Planning", readyAt: ocReadyAt)
+
+        XCTAssertEqual(try eta(.chain), 120,
+                       "the chain lapses at a fixed server instant — 122 is a jump backwards")
+        XCTAssertEqual(try eta(.organizedCrime), 180,
+                       "ready_at is a fixed server instant — 182 is a jump backwards")
+    }
+
+    /// Damping must not become latching. Four seconds is past the tolerance the cooldown
+    /// pin already uses, so it is a real correction and has to be adopted — otherwise a
+    /// Mac whose clock is being nudged would silently keep the stale skew.
+    func testSkewChangeBeyondToleranceIsStillAdopted() async throws {
+        let release = localNow + 600
+        try await poll(serverTime: localNow, status: hospitalSlice(until: release))
+        XCTAssertEqual(app.serverClock.offset, 0)
+
+        // 60 s of local time pass; Torn's clock advanced 64 → the Mac lost 4 s.
+        clock.advance(60)
+        try await poll(serverTime: localNow + 64, status: hospitalSlice(until: release + 4))
+
+        XCTAssertEqual(app.serverClock.offset, 4,
+                       "4 s is past the jitter tolerance — a real correction, so track it")
+        XCTAssertEqual(try eta(.hospital), 540)
+    }
+
+    /// Part (a) of the fix: the receipt instant must be sampled the moment the transport
+    /// returns, not after the off-actor decode. Decoding burns real time, and folding it
+    /// into `server_time - receiptTime` makes the app believe the Mac runs that much fast
+    /// — freezing the countdown for exactly as long as the parse took.
+    func testOffsetIsNotInflatedByDecodeTime() async throws {
+        // 5 s of "decode" — deliberately past the jitter tolerance, so this test can only
+        // pass by sampling the receipt earlier, never by damping.
+        let slowService = ClockBurningSnapshotService(
+            wrapping: UserSnapshotService(session: session),
+            clock: clock,
+            decodeSeconds: 5
+        )
+        app.stopPolling()
+        app = AppState(session: session,
+                       connectivity: ControllableConnectivity(connected: true),
+                       defaults: .createMockDefaults(),
+                       time: clock,
+                       userSnapshotService: slowService)
+
+        try await poll(serverTime: localNow, status: hospitalSlice(until: localNow + 300))
+
+        XCTAssertEqual(app.serverClock.offset, 0,
+                       "the decode took 5 s of wall time; that is not clock skew")
+        XCTAssertEqual(try eta(.hospital), 295,
+                       "5 s really did elapse, so 5 s came off the countdown — reading the "
+                       + "receipt after the decode reports a frozen 300")
+    }
+
+    // MARK: - Helpers for the jitter suite
+
+    private func publishChain(timeout: Int) {
+        app.factionService.publishBasic(
+            FactionData(name: "Test", factionId: 1, respect: 10,
+                        chain: FactionChain(current: 25, max: 100,
+                                            timeout: timeout, cooldown: 0))
+        )
+    }
+}
+
+/// Wraps the real snapshot service and burns injected clock time inside `parseSnapshot`,
+/// the way a large payload's off-actor decode burns real time. Everything else passes
+/// straight through.
+private final class ClockBurningSnapshotService: UserSnapshotServicing, @unchecked Sendable {
+    private let wrapped: UserSnapshotServicing
+    private let clock: MutableTimeSource
+    private let decodeSeconds: TimeInterval
+
+    init(wrapping: UserSnapshotServicing, clock: MutableTimeSource, decodeSeconds: TimeInterval) {
+        self.wrapped = wrapping
+        self.clock = clock
+        self.decodeSeconds = decodeSeconds
+    }
+
+    func load(_ url: URL) async throws -> UserHTTPResponse {
+        try await wrapped.load(url)
+    }
+
+    func parseSnapshot(
+        data: Data,
+        requestedSelections: [String],
+        grantedSelections: [String]?
+    ) async -> UserServiceResult<UserSnapshotPayload> {
+        let result = await wrapped.parseSnapshot(data: data,
+                                                 requestedSelections: requestedSelections,
+                                                 grantedSelections: grantedSelections)
+        let seconds = decodeSeconds
+        let clock = self.clock
+        await MainActor.run { clock.advance(seconds) }
+        return result
+    }
+
+    func loadActivity(_ url: URL) async throws -> UserServiceResult<UserActivityPayload> {
+        try await wrapped.loadActivity(url)
+    }
+
+    func loadUserV2(_ url: URL) async throws -> UserServiceResult<UserV2Payload> {
+        try await wrapped.loadUserV2(url)
+    }
 }
 
 /// The pure conversion `ServerClockOffsetTests` drives end-to-end. These pin the two
@@ -411,5 +619,80 @@ final class ServerClockTests: XCTestCase {
         let clock = ServerClock.synchronized
         XCTAssertEqual(clock.serverNow(localNow), localNow)
         XCTAssertEqual(clock.localDate(forServerTimestamp: 1_700_000_000), localNow)
+    }
+
+    // MARK: - Damping the offset
+
+    /// `merged` is the offset's version of `CooldownEnds.merged`, and exists for the same
+    /// reason: whole-second `server_time` minus a whole-second local receipt, plus that
+    /// request's latency, makes the derived offset wobble by a second or three between
+    /// polls even when neither clock moved. Since every countdown is now measured against
+    /// this offset, letting the wobble through walks the menu bar backwards at each poll.
+    func testJitterWithinToleranceKeepsThePreviousOffset() {
+        let pinned = ServerClock(offset: 90)
+
+        XCTAssertEqual(pinned.merged(with: ServerClock(offset: 92)).offset, 90,
+                       "2 s of latency is not a clock correction")
+        XCTAssertEqual(pinned.merged(with: ServerClock(offset: 88)).offset, 90,
+                       "and symmetrically in the other direction")
+        XCTAssertEqual(pinned.merged(with: ServerClock(offset: 90)).offset, 90)
+    }
+
+    /// The exact edge, pinned in both directions so a later change to the window is
+    /// deliberate rather than a silent regression.
+    func testMergeToleranceBoundary() {
+        let tolerance = ServerClock.jitterToleranceSeconds
+        XCTAssertEqual(tolerance, 3, "the window CooldownEnds.merged has always used")
+        let pinned = ServerClock(offset: 90)
+
+        XCTAssertEqual(pinned.merged(with: ServerClock(offset: 90 + tolerance)).offset, 90,
+                       "movement exactly at the tolerance is still jitter")
+        XCTAssertEqual(pinned.merged(with: ServerClock(offset: 90 - tolerance)).offset, 90)
+        XCTAssertEqual(pinned.merged(with: ServerClock(offset: 90 + tolerance + 1)).offset,
+                       90 + tolerance + 1,
+                       "one second past it is a real correction — adopt it")
+        XCTAssertEqual(pinned.merged(with: ServerClock(offset: 90 - tolerance - 1)).offset,
+                       90 - tolerance - 1)
+    }
+
+    /// One tolerance for the whole clock. `CooldownEnds.merged` damps `endsAt` and
+    /// `ServerClock.merged` damps the `now` it is subtracted from — two halves of one
+    /// subtraction, so a divergent window would reintroduce the jump on one side.
+    func testCooldownPinSharesTheSameToleranceWindow() {
+        let tolerance = ServerClock.jitterToleranceSeconds
+        let pinned = CooldownEnds(drugEndsAt: 0, boosterEndsAt: 0, medicalEndsAt: 1_000)
+
+        func mergedMedical(_ endsAt: Int) -> Int {
+            pinned.merged(with: CooldownEnds(drugEndsAt: 0, boosterEndsAt: 0, medicalEndsAt: endsAt))
+                .medicalEndsAt
+        }
+
+        XCTAssertEqual(mergedMedical(1_000 + tolerance), 1_000,
+                       "cooldowns hold at exactly the same window the offset does")
+        XCTAssertEqual(mergedMedical(1_000 + tolerance + 1), 1_000 + tolerance + 1)
+    }
+
+    /// Damping must never become latching: a Mac whose clock is corrected mid-session,
+    /// or a payload whose anchor was discarded as implausible, has to move the offset.
+    func testMergeAdoptsGenuineCorrections() {
+        XCTAssertEqual(ServerClock.synchronized.merged(with: ServerClock(offset: 90)).offset, 90,
+                       "first real skew must be adopted, not damped away")
+        XCTAssertEqual(ServerClock(offset: 90).merged(with: .synchronized).offset, 0,
+                       "a discarded anchor degrades to the local clock rather than latching")
+        XCTAssertEqual(ServerClock(offset: 90).merged(with: ServerClock(offset: -30)).offset, -30)
+    }
+
+    /// Slow one-directional drift still converges: each poll compares against the
+    /// *pinned* value, not the previous derivation, so the error is bounded by the
+    /// tolerance and a correction always lands.
+    func testSlowDriftEventuallyCrossesTheToleranceAndIsAdopted() {
+        var pinned = ServerClock(offset: 0)
+        for derived in 1...ServerClock.jitterToleranceSeconds {
+            pinned = pinned.merged(with: ServerClock(offset: derived))
+            XCTAssertEqual(pinned.offset, 0, "still inside the window")
+        }
+        pinned = pinned.merged(with: ServerClock(offset: ServerClock.jitterToleranceSeconds + 1))
+        XCTAssertEqual(pinned.offset, ServerClock.jitterToleranceSeconds + 1,
+                       "drift past the window is picked up — bounded error, no latching")
     }
 }

--- a/MacTorn/MacTornTests/ViewModels/ServerClockOffsetTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/ServerClockOffsetTests.swift
@@ -333,3 +333,83 @@ final class ServerClockOffsetTests: XCTestCase {
                        "a relative fulltime must not be shifted by the clock offset")
     }
 }
+
+/// The pure conversion `ServerClockOffsetTests` drives end-to-end. These pin the two
+/// things the behavioural suite leaves open: exactly where the plausibility guard sits,
+/// and that the server→local direction is a true inverse (the notification scheduler
+/// depends on it — a local alert fires on the Mac's clock, so a server-absolute landing
+/// time has to be converted back).
+final class ServerClockTests: XCTestCase {
+
+    private let localNow = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Deriving the offset
+
+    func testAnchorAheadOfLocalYieldsPositiveOffset() {
+        let clock = ServerClock(anchor: 1_700_000_090, localNow: localNow)
+        XCTAssertEqual(clock.offset, 90, "Torn ahead of the Mac → add to the local clock")
+    }
+
+    /// A Mac running *fast* is just as ordinary as one running slow, and the correction
+    /// has to go the other way.
+    func testAnchorBehindLocalYieldsNegativeOffset() {
+        let clock = ServerClock(anchor: 1_699_999_910, localNow: localNow)
+        XCTAssertEqual(clock.offset, -90)
+        XCTAssertEqual(clock.serverUnix(localNow), 1_699_999_910)
+    }
+
+    func testMissingOrZeroAnchorIsSynchronized() {
+        XCTAssertEqual(ServerClock(anchor: nil, localNow: localNow), .synchronized)
+        XCTAssertEqual(ServerClock(anchor: 0, localNow: localNow), .synchronized)
+        XCTAssertEqual(ServerClock(anchor: -5, localNow: localNow), .synchronized,
+                       "a negative epoch is nonsense, not skew")
+    }
+
+    /// The guard's exact edge, in both directions. Pinned so a later tightening of the
+    /// window is a deliberate, visible change rather than a silent regression in which
+    /// countdowns quietly stop being corrected.
+    func testPlausibilityGuardBoundary() {
+        let limit = ServerClock.maxPlausibleSkewSeconds
+
+        XCTAssertEqual(ServerClock(anchor: 1_700_000_000 + limit, localNow: localNow).offset, limit,
+                       "skew exactly at the limit is still honoured")
+        XCTAssertEqual(ServerClock(anchor: 1_700_000_000 - limit, localNow: localNow).offset, -limit,
+                       "and symmetrically in the other direction")
+        XCTAssertEqual(ServerClock(anchor: 1_700_000_000 + limit + 1, localNow: localNow).offset, 0,
+                       "one second past the limit is a corrupt payload → discard")
+        XCTAssertEqual(ServerClock(anchor: 1_700_000_000 - limit - 1, localNow: localNow).offset, 0)
+    }
+
+    // MARK: - Converting
+
+    func testServerNowAndServerUnixAgree() {
+        let clock = ServerClock(offset: 90)
+        XCTAssertEqual(clock.serverNow(localNow), localNow.addingTimeInterval(90))
+        XCTAssertEqual(clock.serverUnix(localNow), 1_700_000_090)
+    }
+
+    /// Fetch-relative durations become absolute *server* timestamps.
+    func testServerTimestampAnchorsARelativeDuration() {
+        let clock = ServerClock(offset: 90)
+        XCTAssertEqual(clock.serverTimestamp(fetchedAt: localNow, plus: 300), 1_700_000_390)
+    }
+
+    /// The direction the travel-notification scheduler needs: a landing 300 s away on
+    /// Torn's clock is 300 s away on the Mac's too — the skew must not shorten the wait.
+    func testLocalDateForServerTimestampInvertsTheOffset() {
+        let clock = ServerClock(offset: 90)
+        let landsAt = clock.serverUnix(localNow) + 300      // server-absolute
+
+        let localLanding = clock.localDate(forServerTimestamp: landsAt)
+
+        XCTAssertEqual(localLanding, localNow.addingTimeInterval(300),
+                       "a 90 s-slow Mac must not fire the landing alert 90 s early")
+        XCTAssertEqual(clock.serverUnix(localLanding), landsAt, "round-trips exactly")
+    }
+
+    func testSynchronizedClockIsTheIdentity() {
+        let clock = ServerClock.synchronized
+        XCTAssertEqual(clock.serverNow(localNow), localNow)
+        XCTAssertEqual(clock.localDate(forServerTimestamp: 1_700_000_000), localNow)
+    }
+}

--- a/MacTorn/MacTornTests/ViewModels/ServerClockOffsetTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/ServerClockOffsetTests.swift
@@ -1,0 +1,335 @@
+import XCTest
+@testable import MacTorn
+
+/// Issue #46 — every countdown, not just cooldowns, must be computed against Torn's
+/// clock.
+///
+/// Torn stamps each response with `server_time`. Only `CooldownEnds` ever used it
+/// (`AppState+PollingUserFetch.swift`, `anchorTimestamp`); travel, hospital, jail,
+/// chain and OC all measured against a bare `Date()`. On a Mac whose clock is 90 s
+/// behind Torn's, that put two contradictory clocks in one window: the cooldown pill
+/// was right while the menu bar claimed the plane was still 90 s from landing.
+///
+/// The contract pinned here is behavioural, deliberately — it names no new type and
+/// no new property, so the implementation is free to store an offset on `AppState`
+/// or to thread a `TimeSource` down into the models, as long as:
+///
+/// 1. the offset is taken from the snapshot's `server_time` (`anchorTimestamp`),
+/// 2. every countdown is measured from `serverNow = AppState.time.now + offset`,
+/// 3. an absent or implausible `server_time` collapses the offset to zero rather
+///    than throwing the countdowns the other way,
+/// 4. the offset is re-derived per snapshot and never accumulates.
+///
+/// Everything reads through the injected `MutableTimeSource`, so once the countdowns
+/// stop calling `Date()` these numbers are exact rather than approximate. Chain comes
+/// from the FACTION endpoint (`AppState.liveChain`) — `TornResponse.chain` is never
+/// populated by the real API.
+@MainActor
+final class ServerClockOffsetTests: XCTestCase {
+
+    /// Torn's clock runs this many seconds ahead of the Mac's in most of these tests.
+    /// Matches the issue's worked example (a Mac 90 s slow).
+    private let skew = 90
+
+    private var clock: MutableTimeSource!
+    private var session: MockNetworkSession!
+    private var app: AppState!
+    /// Whole-second local "now" — the frozen value the injected clock reports.
+    private var localNow: Int!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        localNow = Int(Date().timeIntervalSince1970)
+        clock = MutableTimeSource(Date(timeIntervalSince1970: TimeInterval(localNow)))
+        session = MockNetworkSession()
+        app = AppState(session: session,
+                       connectivity: ControllableConnectivity(connected: true),
+                       defaults: .createMockDefaults(),
+                       time: clock)
+    }
+
+    override func tearDown() async throws {
+        app.stopPolling()
+        app.liveTimerCancellable?.cancel()
+        app.liveTimerCancellable = nil
+        app = nil
+        session = nil
+        clock = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Drives one full poll through the mock network.
+    ///
+    /// - Parameter serverTime: value for the response's top-level `server_time`.
+    ///   `nil` removes the field entirely (the "API told us nothing" case).
+    private func poll(serverTime: Int?,
+                      travel: [String: Any]? = nil,
+                      status: [String: Any]? = nil,
+                      cooldowns: [String: Any]? = nil) async throws {
+        var json = TornAPIFixtures.validFullResponse()
+        if let serverTime {
+            json["server_time"] = serverTime
+        } else {
+            json.removeValue(forKey: "server_time")
+        }
+        if let travel { json["travel"] = travel }
+        if let status { json["status"] = status }
+        if let cooldowns { json["cooldowns"] = cooldowns }
+
+        app.apiKey = "valid_key"
+        try session.setSuccessResponse(json: json)
+        app.fetchData()
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+    }
+
+    /// ETA of one Next Action category, measured from the injected clock.
+    private func eta(_ category: NextActionCategory,
+                     file: StaticString = #filePath,
+                     line: UInt = #line) throws -> Int {
+        let events = app.nextEvents(now: clock.now)
+        let event = try XCTUnwrap(
+            events.first { $0.category == category },
+            "expected a \(category.rawValue) event, got \(events.map(\.category.rawValue))",
+            file: file, line: line
+        )
+        return event.eta
+    }
+
+    /// Absolute fire time of one Next Action category.
+    private func fireAt(_ category: NextActionCategory,
+                        file: StaticString = #filePath,
+                        line: UInt = #line) throws -> Int {
+        let events = app.nextEvents(now: clock.now)
+        let event = try XCTUnwrap(
+            events.first { $0.category == category },
+            "expected a \(category.rawValue) event, got \(events.map(\.category.rawValue))",
+            file: file, line: line
+        )
+        return event.fireAt
+    }
+
+    private func travelSlice(arrivingAt arrival: Int, departedAt departed: Int, timeLeft: Int) -> [String: Any] {
+        ["destination": "Mexico", "timestamp": arrival, "departed": departed, "time_left": timeLeft]
+    }
+
+    private func hospitalSlice(until: Int) -> [String: Any] {
+        ["description": "In hospital", "details": "", "state": "Hospital", "until": until]
+    }
+
+    private func jailSlice(until: Int) -> [String: Any] {
+        ["description": "In jail", "details": "", "state": "Jail", "until": until]
+    }
+
+    // MARK: - Capture + travel
+
+    /// The offset comes from `server_time`, and the travel countdown — the app's only
+    /// always-visible surface — is measured from it. Torn says the plane lands 300 s
+    /// from *its* now; the Mac is 90 s behind, so a local-clock reading gives 390.
+    func testTravelCountdownIsAnchoredToServerTimeNotTheMacClock() async throws {
+        let serverNow = localNow + skew
+        let arrival = serverNow + 300
+        try await poll(serverTime: serverNow,
+                       travel: travelSlice(arrivingAt: arrival,
+                                           departedAt: serverNow - 300,
+                                           timeLeft: 300))
+
+        XCTAssertEqual(app.travelSecondsRemaining, 300,
+                       "travel must count down from server_time; the Mac's 90 s lag must not inflate it")
+        XCTAssertEqual(app.menuBarDisplay, .traveling(destination: "Mexico", seconds: 300),
+                       "the menu bar is the surface the issue reports as wrong")
+        XCTAssertEqual(try eta(.travel), 300,
+                       "the Next Action timeline must agree with the menu bar")
+    }
+
+    /// Same skew, but the response carries only a relative `time_left` (no absolute
+    /// arrival timestamp). `time_left` is measured from the instant the *server*
+    /// generated the response, so it must be anchored on `server_time` — not on
+    /// `lastFetchTime`, which is the Mac's (skewed) reading of that same instant.
+    func testTravelCountdownFromRelativeTimeLeftIsAnchoredToServerTime() async throws {
+        let serverNow = localNow + skew
+        try await poll(serverTime: serverNow,
+                       travel: travelSlice(arrivingAt: 0,
+                                           departedAt: serverNow - 300,
+                                           timeLeft: 300))
+
+        XCTAssertEqual(try fireAt(.travel), serverNow + 300,
+                       "time_left must be turned into an absolute time by adding it to "
+                       + "server_time; adding it to lastFetchTime lands 90 s early")
+        XCTAssertEqual(try eta(.travel), 300)
+        XCTAssertEqual(app.travelSecondsRemaining, 300,
+                       "an off-by-a-second miss here means the countdown still reads Date() "
+                       + "instead of the injected AppState.time")
+    }
+
+    // MARK: - Hospital / jail
+
+    func testHospitalCountdownIsAnchoredToServerTime() async throws {
+        let serverNow = localNow + skew
+        try await poll(serverTime: serverNow, status: hospitalSlice(until: serverNow + 300))
+
+        XCTAssertEqual(app.menuBarDisplay, .hospitalAtHome(seconds: 300),
+                       "hospital release is an absolute server timestamp — compare it against server now")
+        XCTAssertEqual(try eta(.hospital), 300,
+                       "the Next Action timeline must agree with the menu bar")
+    }
+
+    func testJailCountdownIsAnchoredToServerTime() async throws {
+        let serverNow = localNow + skew
+        try await poll(serverTime: serverNow, status: jailSlice(until: serverNow + 450))
+
+        XCTAssertEqual(app.menuBarDisplay, .jail(seconds: 450),
+                       "jail release is an absolute server timestamp — compare it against server now")
+        XCTAssertEqual(try eta(.jail), 450,
+                       "the Next Action timeline must agree with the menu bar")
+    }
+
+    // MARK: - Chain (faction endpoint)
+
+    /// Chain lives on the faction endpoint. `FactionChain.timeout` is an absolute
+    /// server timestamp, so the same offset applies.
+    func testChainTimeoutIsAnchoredToServerTime() async throws {
+        let serverNow = localNow + skew
+        try await poll(serverTime: serverNow)
+
+        app.factionService.publishBasic(
+            FactionData(name: "Test", factionId: 1, respect: 10,
+                        chain: FactionChain(current: 25, max: 100,
+                                            timeout: serverNow + 180, cooldown: 0))
+        )
+
+        XCTAssertEqual(try eta(.chain), 180,
+                       "a 90 s slow Mac must not claim three extra minutes of chain")
+    }
+
+    // MARK: - Organized crime
+
+    func testOrganizedCrimeReadyCountdownIsAnchoredToServerTime() async throws {
+        let serverNow = localNow + skew
+        try await poll(serverTime: serverNow)
+
+        app.organizedCrime = OrganizedCrime2(id: 1, name: "Clinical Precision",
+                                             status: "Planning",
+                                             readyAt: serverNow + 240)
+
+        XCTAssertEqual(try eta(.organizedCrime), 240,
+                       "OC ready_at is an absolute server timestamp — compare it against server now")
+    }
+
+    // MARK: - One clock, not two
+
+    /// The core symptom: cooldowns were already server-anchored while everything else
+    /// was not, so one window showed two clocks 90 s apart. Two events that Torn says
+    /// fire at the same instant must report the same ETA.
+    func testCooldownAndHospitalCountdownsAgreeOnOneClock() async throws {
+        let serverNow = localNow + skew
+        try await poll(serverTime: serverNow,
+                       status: hospitalSlice(until: serverNow + 300),
+                       cooldowns: ["drug": 0, "booster": 0, "medical": 300])
+
+        let medical = try eta(.medical)
+        let hospital = try eta(.hospital)
+        XCTAssertEqual(medical, 300)
+        XCTAssertEqual(hospital, 300)
+        XCTAssertEqual(medical, hospital,
+                       "cooldown and hospital fire at the same server instant — one window, one clock")
+    }
+
+    // MARK: - Degrading safely
+
+    /// No `server_time` in the payload (and no legacy `timestamp` either) → offset 0,
+    /// i.e. exactly the old local-clock behaviour. A fix must not invent an offset out
+    /// of nothing. (Red today only by the second that elapses between the fixture being
+    /// built and the assertion — the countdown is reading `Date()` rather than the
+    /// injected clock. Once it reads `AppState.time` the number is exact.)
+    func testMissingServerTimeFallsBackToTheLocalClock() async throws {
+        try await poll(serverTime: nil, status: hospitalSlice(until: localNow + 300))
+
+        XCTAssertEqual(app.menuBarDisplay, .hospitalAtHome(seconds: 300),
+                       "without an anchor the local clock is all we have — no offset, no shift")
+        XCTAssertEqual(try eta(.hospital), 300)
+    }
+
+    /// A `server_time` a decade away is a corrupt payload, not clock skew: applying it
+    /// would throw every countdown into the next geological era. The number must stay
+    /// where the local clock puts it.
+    func testImplausiblyDistantServerTimeIsIgnored() async throws {
+        let tenYears = 10 * 365 * 86_400
+        try await poll(serverTime: localNow + tenYears,
+                       status: hospitalSlice(until: localNow + 300))
+
+        XCTAssertEqual(app.menuBarDisplay, .hospitalAtHome(seconds: 300),
+                       "an implausible anchor must be discarded, not applied")
+        XCTAssertEqual(try eta(.hospital), 300)
+    }
+
+    /// A zero / missing-but-present anchor is the same class of nonsense.
+    func testZeroServerTimeIsIgnored() async throws {
+        try await poll(serverTime: 0, status: hospitalSlice(until: localNow + 300))
+
+        XCTAssertEqual(app.menuBarDisplay, .hospitalAtHome(seconds: 300))
+        XCTAssertEqual(try eta(.hospital), 300)
+    }
+
+    /// The plausibility guard must not be so tight that it rejects real skew. Ten
+    /// minutes of drift is an entirely ordinary un-synced Mac and must be honoured.
+    func testLargeButPlausibleSkewIsStillHonoured() async throws {
+        let serverNow = localNow + 600
+        try await poll(serverTime: serverNow, status: hospitalSlice(until: serverNow + 300))
+
+        XCTAssertEqual(app.menuBarDisplay, .hospitalAtHome(seconds: 300),
+                       "10 minutes of clock drift is skew, not corruption")
+        XCTAssertEqual(try eta(.hospital), 300)
+    }
+
+    // MARK: - No drift
+
+    /// The offset is re-derived from each snapshot, never added to the previous one.
+    /// Both polls see the same 90 s skew, so an implementation that accumulates
+    /// (`offset += anchor - localNow`) lands on 180 and reports 450 instead of 540.
+    func testOffsetDoesNotAccumulateAcrossSuccessiveSnapshots() async throws {
+        let release = localNow + skew + 600
+
+        try await poll(serverTime: localNow + skew, status: hospitalSlice(until: release))
+        XCTAssertEqual(try eta(.hospital), 600, "first snapshot: 600 s of hospital left")
+
+        clock.advance(60)
+        try await poll(serverTime: localNow + 60 + skew, status: hospitalSlice(until: release))
+
+        XCTAssertEqual(try eta(.hospital), 540,
+                       "a minute later, 540 s left — the offset is still 90, not 180")
+        XCTAssertEqual(app.menuBarDisplay, .hospitalAtHome(seconds: 540))
+    }
+
+    /// Skew that shrinks between polls (the Mac's clock being corrected mid-session)
+    /// must be picked up, not latched from the first snapshot.
+    func testOffsetTracksAChangingSkew() async throws {
+        let release = localNow + skew + 600
+
+        try await poll(serverTime: localNow + skew, status: hospitalSlice(until: release))
+        XCTAssertEqual(try eta(.hospital), 600)
+
+        // 60 s of Torn time pass (server 90 → 150) while the Mac's clock is nudged
+        // forward by 60 s on top of that (local 0 → 120). Skew is now 30, not 90.
+        clock.advance(120)
+        try await poll(serverTime: localNow + 150, status: hospitalSlice(until: release))
+
+        XCTAssertEqual(try eta(.hospital), 540,
+                       "offset must be re-derived as 30; latching the original 90 gives 480")
+    }
+
+    // MARK: - Regression guard: fetch-relative durations
+
+    /// `Bar.fulltime` is a duration relative to the response, exactly like travel's
+    /// `time_left`. Nudging the timeline's "now" onto the server clock without moving
+    /// bar anchors with it would knock 90 s off every bar ETA. The one test in this
+    /// file that is GREEN today — it must stay green.
+    func testBarFulltimeStaysCorrectUnderClockSkew() async throws {
+        // validFullResponse: energy 100/150 with fulltime 600.
+        try await poll(serverTime: localNow + skew)
+
+        XCTAssertEqual(try eta(.energy), 600,
+                       "a relative fulltime must not be shifted by the clock offset")
+    }
+}


### PR DESCRIPTION
Fixes #46.

Every countdown outside cooldowns now reads Torn's clock instead of the Mac's: travel, hospital,
jail, chain and OC all route through one shared server-clock offset derived from `server_time`,
with a safe fallback to the local clock when the anchor is missing or implausible.

The offset is damped the same way `CooldownEnds.merged` damps `endsAt` — the previous offset is
kept unless a fresh one differs by more than the existing 3s tolerance — and the receipt instant is
sampled right after the transport returns rather than after the off-actor decode. Without that, the
offset absorbed network jitter and every countdown ticked *backwards* by 1-3s at each poll, on the
app's only always-visible surface.

**Proof:** 34 new tests, whole suite green (529 passing, 0 failing) at this commit. Reviewed by
three independent passes (correctness, edge cases, security) — all pass. Coverage includes a
"never jumps back" test per surface, tolerance boundaries from both sides, and hostile anchors
(zero, implausibly distant).

**Known follow-up, not fixed here:** `localDate(forServerTimestamp:)` can trap on integer overflow
with an `Int.max`-scale `timestamp` from a hostile response. Same pattern as #87.

CI was not awaited before merge; the local gate was green at this commit.
