### PR TITLE
fix(#64): stop internal fallbacks leaking into the UI

### DIFF
--- a/MacTorn/MacTorn/Views/StatusView.swift
+++ b/MacTorn/MacTorn/Views/StatusView.swift
@@ -160,7 +160,12 @@ struct StatusView: View {
             HStack {
                 Image(systemName: "airplane")
                     .foregroundColor(.blue)
-                Text(travel.isTraveling ? "Traveling to \(travel.destination ?? "Unknown")" : "In \(travel.destination ?? "Unknown")")
+                // Torn can report an in-progress flight before it sends the destination,
+                // so the traveling row drops the place rather than naming it "Unknown" —
+                // the same rule MenuBarDisplay.accessibilityDescription already follows.
+                Text(travel.isTraveling
+                    ? (travel.destination.map { "Traveling to \($0)" } ?? "Traveling")
+                    : (travel.destination.map { "In \($0)" } ?? "Location unavailable"))
                     .font(.caption.bold())
             }
 

--- a/MacTorn/MacTorn/Views/StocksView.swift
+++ b/MacTorn/MacTorn/Views/StocksView.swift
@@ -53,8 +53,9 @@ struct StocksView: View {
                                         .foregroundColor(.secondary)
                                         .lineLimit(1)
                                 } else {
-                                    Text("Stock #\(stock.stockId)")
+                                    Text("Stock details unavailable")
                                         .font(.caption2)
+                                        .lineLimit(1)
                                 }
 
                                 Spacer(minLength: 4)

--- a/MacTorn/MacTorn/Views/TravelView.swift
+++ b/MacTorn/MacTorn/Views/TravelView.swift
@@ -5,7 +5,9 @@ import AppKit
 struct FlyingStatusView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.reduceTransparency) private var reduceTransparency
-    let destination: String
+    /// Optional because `Travel.isTraveling` only requires a positive `time_left`:
+    /// Torn can report an in-progress flight before the destination is populated.
+    let destination: String?
     let timestamp: Int
     let departed: Int
 
@@ -37,7 +39,7 @@ struct FlyingStatusView: View {
                     .font(.title2)
                     .foregroundColor(.blue)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Flying to \(destination)")
+                    Text(destination.map { "Flying to \($0)" } ?? "Destination unavailable")
                         .font(.headline)
                     Text("In transit...")
                         .font(.caption)
@@ -136,7 +138,7 @@ struct TravelView: View {
             if travel.isTraveling {
                 // Flying state with live countdown - FlyingStatusView observes appState directly
                 FlyingStatusView(
-                    destination: travel.destination ?? "Unknown",
+                    destination: travel.destination,
                     timestamp: travel.timestamp ?? 0,
                     departed: travel.departed ?? 0
                 )
@@ -160,7 +162,7 @@ struct TravelView: View {
                     .font(.title2)
                     .foregroundColor(.orange)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("In \(travel.destination ?? "Unknown")")
+                    Text(travel.destination.map { "In \($0)" } ?? "Location unavailable")
                         .font(.headline)
                     Text("Currently abroad")
                         .font(.caption)


### PR DESCRIPTION
Closes #64

`"Unknown"` and `"Stock #123"` describe *our* missing data, not the player. The user reads them as a bug in the app when they are a normal transient state, which is the point the audit finding makes. This replaces them with text that says the data has not arrived.

The rule is not new to the codebase — `MenuBarDisplay.accessibilityDescription` (`TornModels.swift:1596`) already does exactly this for the menu-bar label, `destination.map { " to \($0)" } ?? ""`, and `testUnknownDestinationStillSpeaksSomethingUseful` pins it with `XCTAssertFalse(spoken.contains("Unknown"))`. VoiceOver users already got the good behaviour; this brings the visible UI in line.

### Which of the five sites are actually reachable

I checked each rather than assuming, because it changes how much of this is a fix and how much is hygiene:

| Site | Guard | Reachable? |
| --- | --- | --- |
| `StatusView:163` traveling half | `isTraveling` = `timeLeft > 0` only | **yes** — Torn sends an in-progress flight before it populates `destination` |
| `TravelView:139` → `FlyingStatusView` | same | **yes** |
| `StocksView:56` | `stocksMetadata[stock.stockId] == nil` | **yes** |
| `StatusView:163` non-traveling half | reached only when `isAbroad` | no — `isAbroad` guards `let dest = destination` |
| `TravelView:163` `abroadStatusView` | `isAbroad` | no — same guard |

So three are live and two are unreachable today. I changed all five anyway, so the string is gone from the files rather than left depending on `isAbroad` keeping that guard, but I'd rather say which is which than let the diff imply five live bugs.

### Choices worth your opinion

1. **`FlyingStatusView.destination` is now `String?`.** The call site was passing `?? "Unknown"` — pushing the optional into the view means the missing case is handled where it's known instead of papered over on the way in. It's the only signature change in the PR.
2. **Two different strings for the same underlying state.** `StatusView` shows just `"Traveling"` — it's a single compact line, so that word is the only state signal it has. `FlyingStatusView` shows `"Destination unavailable"` because it already has `"In transit..."` and a live countdown underneath carrying the state. Deliberate, but if you'd rather they matched, say which one wins.
3. **`"Stock details unavailable"` drops the id.** That's what the issue asks for, but two metadata-less rows then read identically. If you'd rather keep them distinguishable, `"Stock #123 — details unavailable"` or a `"Loading details…"` framing both work; I went with the issue's wording.

### Verified on `53bb1e9`

- `make test` — **563 tests, 0 failures**, `** TEST SUCCEEDED **`.
- `make build` — `** BUILD SUCCEEDED **`.
- Confirmed no test asserted the old strings, so nothing here is a test being edited to match new behaviour.

One thing this PR does *not* do: pin the new strings. These three views carry no `uitestID` and no test touches their text, so the strings stay unpinned. Happy to follow up by extracting the label logic into a pure function next to `accessibilityDescription` with tests in the same style as `testUnknownDestinationStillSpeaksSomethingUseful` — I kept it out of here to keep the diff to the issue.

Separately, and not touched: `ForumWatchService.swift:221` has `title ?? "Unknown"`. Outside the Views the issue lists, and I couldn't tell from reading whether that one reaches the user — flagging it in case it belongs to the same finding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated travel status messaging when destination information is unavailable.
  * Replaced “Unknown” travel labels with clearer “Traveling” or “Location unavailable” text.
  * Added fallback messaging for missing stock metadata: “Stock details unavailable.”
  * Improved flying and abroad status displays when destination details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->