### PR TITLE
fix(#87): stop CooldownEnds.from trapping on API integer overflow

### DIFF
--- a/MacTorn/MacTorn/Models/TornModels.swift
+++ b/MacTorn/MacTorn/Models/TornModels.swift
@@ -146,10 +146,25 @@ struct CooldownEnds: Equatable {
 
     static func from(cooldowns: Cooldowns, anchor: Int) -> CooldownEnds {
         CooldownEnds(
-            drugEndsAt: cooldowns.drug > 0 ? anchor + cooldowns.drug : 0,
-            boosterEndsAt: cooldowns.booster > 0 ? anchor + cooldowns.booster : 0,
-            medicalEndsAt: cooldowns.medical > 0 ? anchor + cooldowns.medical : 0
+            drugEndsAt: endTimestamp(anchor: anchor, duration: cooldowns.drug),
+            boosterEndsAt: endTimestamp(anchor: anchor, duration: cooldowns.booster),
+            medicalEndsAt: endTimestamp(anchor: anchor, duration: cooldowns.medical)
         )
+    }
+
+    /// One cooldown's absolute end-timestamp, or `0` — the struct's existing "not active"
+    /// sentinel — when the cooldown is inactive or the API's numbers cannot produce a
+    /// usable one.
+    ///
+    /// `anchor` and `duration` are both raw `Int`s decoded straight from Torn, so nothing
+    /// bounds their sum. A response carrying a duration near `Int.max` overflowed the
+    /// addition and trapped the process (SIGTRAP, exit 133). Degrading that cooldown to
+    /// "unknown" keeps a display-only menu bar app running, which is strictly better than
+    /// crashing it over a number it only meant to display.
+    private static func endTimestamp(anchor: Int, duration: Int) -> Int {
+        guard duration > 0 else { return 0 }
+        let (endsAt, overflowed) = anchor.addingReportingOverflow(duration)
+        return overflowed ? 0 : endsAt
     }
 
     func endsAt(_ kind: CooldownKind) -> Int {

--- a/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
@@ -501,6 +501,72 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(rankedWarCalls, 1, "the second poll within 60s must not re-fetch ranked wars")
     }
 
+    // MARK: - CooldownEnds.from overflow guard (issue #87)
+
+    /// The ordinary case must be untouched by the guard.
+    func testCooldownEndsFrom_normalResponseIsUnchanged() {
+        let anchor = 1_786_104_547
+        let ends = CooldownEnds.from(
+            cooldowns: Cooldowns(drug: 3600, medical: 0, booster: 120), anchor: anchor)
+
+        XCTAssertEqual(ends.drugEndsAt, anchor + 3600)
+        XCTAssertEqual(ends.boosterEndsAt, anchor + 120)
+        XCTAssertEqual(ends.medicalEndsAt, 0, "an inactive cooldown stays 0")
+    }
+
+    /// `anchor + duration` on raw API integers used to trap the process (SIGTRAP,
+    /// exit 133). An unusable number must degrade that cooldown to "not active"
+    /// rather than crash a display-only menu bar app.
+    func testCooldownEndsFrom_hugeDurationDoesNotTrap() {
+        let ends = CooldownEnds.from(
+            cooldowns: Cooldowns(drug: Int.max, medical: 0, booster: 0),
+            anchor: 1_786_104_547)
+
+        XCTAssertEqual(ends.drugEndsAt, 0, "overflow degrades to the not-active sentinel")
+    }
+
+    /// Every operand comes from the same untrusted payload, so the anchor can be
+    /// hostile too — and all three cooldowns must be guarded, not just the first.
+    func testCooldownEndsFrom_hugeAnchorDoesNotTrap() {
+        let ends = CooldownEnds.from(
+            cooldowns: Cooldowns(drug: 60, medical: 60, booster: 60), anchor: Int.max)
+
+        XCTAssertEqual(ends.drugEndsAt, 0)
+        XCTAssertEqual(ends.boosterEndsAt, 0)
+        XCTAssertEqual(ends.medicalEndsAt, 0)
+    }
+
+    /// Underflow is the same defect with the sign flipped.
+    func testCooldownEndsFrom_negativeAnchorDoesNotTrap() {
+        let ends = CooldownEnds.from(
+            cooldowns: Cooldowns(drug: Int.min, medical: 0, booster: 0), anchor: -1)
+
+        XCTAssertEqual(ends.drugEndsAt, 0, "drug is guarded by duration > 0 before the add")
+    }
+
+    /// One bad cooldown must not take the other two with it — the guard is per field.
+    func testCooldownEndsFrom_overflowIsIsolatedPerCooldown() {
+        let anchor = 1_786_104_547
+        let ends = CooldownEnds.from(
+            cooldowns: Cooldowns(drug: Int.max, medical: 300, booster: 600), anchor: anchor)
+
+        XCTAssertEqual(ends.drugEndsAt, 0, "the bad one degrades")
+        XCTAssertEqual(ends.medicalEndsAt, anchor + 300, "the good ones survive")
+        XCTAssertEqual(ends.boosterEndsAt, anchor + 600)
+    }
+
+    /// A degraded cooldown must read as inactive to every consumer, not as an
+    /// end-timestamp in 1970.
+    func testCooldownEndsFrom_degradedCooldownReadsAsInactive() {
+        let ends = CooldownEnds.from(
+            cooldowns: Cooldowns(drug: Int.max, medical: 0, booster: 0),
+            anchor: 1_786_104_547)
+        let now = Date(timeIntervalSince1970: 1_786_104_547)
+
+        XCTAssertEqual(ends.remainingSeconds(.drug, at: now), 0)
+        XCTAssertNil(ends.soonestActive(at: now), "nothing is counting down")
+    }
+
     // MARK: - CooldownEnds.merged (pure model)
 
     /// Per-poll jitter ≤ tolerance keeps the previously pinned `endsAt`. Without this,


### PR DESCRIPTION
Closes #87.

`CooldownEnds.from` computed `anchor + cooldowns.{kind}` on raw `Int`s decoded straight from the API, with nothing bounding either operand.

## Reproduced first

I copied the current implementation verbatim into a standalone binary rather than reason about it:

```
anchor = 1786104547
a normal response: (1786108147, 0, 0)
about to add drug = Int.max ...
PROBE_EXIT=133
```

Exit 133 is SIGTRAP — the same signature the issue reports for the `#46` sibling. So this is a demonstrated crash, not a theoretical one.

## The fix

Each field goes through `addingReportingOverflow` and degrades to `0` on overflow — the struct's **existing** "not active" sentinel, so no consumer needs to learn a new state:

```swift
private static func endTimestamp(anchor: Int, duration: Int) -> Int {
    guard duration > 0 else { return 0 }
    let (endsAt, overflowed) = anchor.addingReportingOverflow(duration)
    return overflowed ? 0 : endsAt
}
```

I went with the issue's second suggestion (`addingReportingOverflow` + fall back to unknown) rather than the first (clamp to a sane epoch/duration window). Clamping needs two invented thresholds, and a wrong guess there silently truncates a legitimate long cooldown — a real bug traded for a theoretical one. Overflow is a fact about the arithmetic and needs no magic numbers.

Degrading rather than crashing is the right trade for a display-only menu bar app: the cost is one cooldown reading as inactive until the next poll, roughly 30 seconds later.

## Tests

6 added, and `AppStateTests` + `TornResponseTests` run **86 tests, 0 failures**.

Beyond the headline case, they pin three things the obvious single test would miss:

- **the anchor can be hostile too**, not just the duration — every operand arrives in the same untrusted payload
- **overflow is isolated per cooldown** — one bad number must not take the other two down with it
- **a degraded cooldown reads as inactive to consumers** — `remainingSeconds` is `0` and `soonestActive` is `nil`, so it does not surface as an end-timestamp in 1970

### The tests fail without the fix — with a wrinkle worth your attention

Committed first, then restored the raw `anchor + duration` and re-ran. **4 of the 6 crash the test runner** (`Restarting after unexpected exit, crash, or test timeout`), which is the bug behaving exactly as filed.

The two survivors are correct and I would rather explain them than hide them:

- `normalResponseIsUnchanged` — ordinary values, nothing to overflow
- `negativeAnchorDoesNotTrap` — passes `drug: Int.min`, which fails the `duration > 0` guard *before* the addition, so it never reaches the overflow either way

**The part worth flagging:** the mutant run's summary line reads

```
Executed 63 tests, with 0 failures (0 unexpected)
```

A crashed test never reports a failure — it disappears from the count (73 → 63) and the runner restarts. Read the summary alone and the broken build looks clean. Only the non-zero exit (65) and the `Restarting after unexpected exit` lines give it away. Worth knowing for anything that greps xcodebuild output for "0 failures".

## The sweep you asked for

The issue notes this is "worth a sweep for other unbounded `Int` arithmetic on API-supplied values". I did that, and I have **deliberately not fixed the rest in this PR** — each needs a signature or contract change with its own review surface, and bundling them would bury a one-line safety fix. Findings, in the order I would prioritise them:

| site | operands | reachable? |
|---|---|---|
| `ServerClock.serverTimestamp(fetchedAt:plus:)` — `TimeSource.swift:110` | `serverUnix(fetchedAt) + seconds`, where `seconds` is `travel.time_left` or `bar.fulltime` | **Yes** — same shape as this bug, raw API integer added to a local epoch. Two call sites (`AppState+LiveNextAction.swift:134,162`). The natural fix returns `Int?`, which is why it is not here. |
| `Travel.remainingSeconds(from:now:)` — `TornModels.swift:247` | `timestamp - Int(now.timeIntervalSince1970)` where `timestamp` is API-supplied | Yes, on a hostile `timestamp` near `Int.min`. |
| `Travel.flightProgress` — `TornModels.swift:259`, mirrored in `TravelView.swift:17` | `timestamp - departed`, both API-supplied | Yes, and the expression is duplicated in the view — worth unifying whenever it is fixed. |
| `ServerClock.localDate(forServerTimestamp:)` — `TimeSource.swift:117` | `timestamp - offset` | Lower risk: `offset` is already bounded to ±86400 by `init(anchor:localNow:)`. Only `ServerClock(offset:)` used directly could break that. |

Happy to open a follow-up for the first one — it is the closest twin to this bug — or all four together if you would rather have one sweep.

## Note on the other open PR

This branches from `main`, independently of #92 (issue #79). Both touch `TornModels.swift` but in different regions — `CooldownEnds` here, `TornEvent.cleanEvent` there — so they should merge in either order. Say the word if you would rather have them combined.
