### PR TITLE
fix: persist bounty-notification dedup across restarts

### DIFF
--- a/MacTorn/MacTorn/ViewModels/AppState+PollingUserFetch.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState+PollingUserFetch.swift
@@ -591,23 +591,33 @@ extension AppState {
     }
 
     private func notifyBountiesOnMe() {
-        let currentKeys = Set(bountiesOnMe.map(\.id))
-        for bounty in bountiesOnMe where !notifiedBountyKeys.contains(bounty.id) {
-            let amount = Self.decimalFormatter.string(from: NSNumber(value: bounty.reward)) ?? "\(bounty.reward)"
-            let who: String
-            if bounty.isAnonymous == true {
-                who = " (anonymous)"
-            } else if let name = bounty.listerName {
-                who = " from \(name)"
-            } else {
-                who = ""
-            }
-            NotificationManager.shared.send(
-                title: "⚠️ Bounty on you",
-                body: "$\(amount)\(who)",
-                type: .bountyOnMe
-            )
+        let newBounties = bountiesOnMe.filter {
+            notificationCoordinator.shouldFireOnce("bounty.\($0.id)", epoch: "\($0.id)")
         }
-        notifiedBountyKeys = currentKeys
+        guard !newBounties.isEmpty else { return }
+        let banner = Self.bountyBanner(for: newBounties)
+        NotificationManager.shared.send(title: banner.title, body: banner.body, type: .bountyOnMe)
+    }
+
+    static func bountyBanner(for bounties: [Bounty]) -> (title: String, body: String) {
+        if bounties.count == 1 {
+            return ("⚠️ Bounty on you", bountySummary(bounties[0]))
+        }
+        let preview = bounties.prefix(3).map(Self.bountySummary).joined(separator: ", ")
+        let extra = bounties.count > 3 ? " +\(bounties.count - 3) more" : ""
+        return ("\(bounties.count) bounties on you", "\(preview)\(extra)")
+    }
+
+    static func bountySummary(_ bounty: Bounty) -> String {
+        let amount = decimalFormatter.string(from: NSNumber(value: bounty.reward)) ?? "\(bounty.reward)"
+        let who: String
+        if bounty.isAnonymous == true {
+            who = " (anonymous)"
+        } else if let name = bounty.listerName {
+            who = " from \(name)"
+        } else {
+            who = ""
+        }
+        return "$\(amount)\(who)"
     }
 }

--- a/MacTorn/MacTorn/ViewModels/AppState.swift
+++ b/MacTorn/MacTorn/ViewModels/AppState.swift
@@ -75,7 +75,6 @@ class AppState {
             // also called on a transient permanent-key error, where clearing the latches
             // would re-fire alerts the user has already seen. (Audit finding C-03.)
             notificationCoordinator.reset()
-            notifiedBountyKeys = []
             if newValue.isEmpty {
                 stopPolling()
                 stopForumPolling()
@@ -256,7 +255,6 @@ class AppState {
 
     // MARK: - State Comparison
     @ObservationIgnored var previousTravel: Travel?
-    @ObservationIgnored var notifiedBountyKeys: Set<String> = []
     /// Throttle for the heavy, slow-changing faction v2 overlays (ranked wars + news).
     /// `news` is a row-based cloud category, so this doubles as its rate control:
     /// 5 min → ≤288 calls/day × 25-row limit ≈ 7,200 rows/day, well under the 50k cap.
@@ -405,7 +403,6 @@ class AppState {
         travelSecondsRemaining = 0
         menuBarDisplay = .fallbackIcon
         previousTravel = nil
-        notifiedBountyKeys = []
         lastFactionV2Fetch = nil
         lastActivityFetch = nil
         rowSourcePausedUntil = [:]

--- a/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
+++ b/MacTorn/MacTornTests/ViewModels/AppStateTests.swift
@@ -474,6 +474,70 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(appState.bountiesOnMe.first?.reward, 3_000_000)
     }
 
+    // MARK: - Bounty notification dedup (issue #53)
+
+    /// One new bounty → single banner whose body carries the lister name.
+    func testBountyBanner_singleBounty() {
+        let bounty = Bounty(
+            targetId: 1, targetName: "A", targetLevel: nil,
+            listerId: 7, listerName: "Alice", reward: 1000,
+            reason: nil, quantity: nil, isAnonymous: false, validUntil: nil
+        )
+        let banner = AppState.bountyBanner(for: [bounty])
+        XCTAssertEqual(banner.title, "⚠️ Bounty on you")
+        XCTAssertTrue(banner.body.contains("Alice"))
+        XCTAssertTrue(banner.body.contains("from"))
+    }
+
+    /// An anonymous bounty renders without a lister name.
+    func testBountyBanner_anonymousBounty() {
+        let bounty = Bounty(
+            targetId: 1, targetName: "A", targetLevel: nil,
+            listerId: nil, listerName: nil, reward: 1000,
+            reason: nil, quantity: nil, isAnonymous: true, validUntil: nil
+        )
+        let banner = AppState.bountyBanner(for: [bounty])
+        XCTAssertTrue(banner.body.contains("anonymous"))
+    }
+
+    /// Several new bounties → one summary banner with a preview, modeled on price alerts.
+    func testBountyBanner_batchesMultipleBounties() {
+        func makeBounty(_ id: Int) -> Bounty {
+            Bounty(
+                targetId: id, targetName: nil, targetLevel: nil,
+                listerId: id, listerName: "Lister\(id)", reward: 100,
+                reason: nil, quantity: nil, isAnonymous: false, validUntil: nil
+            )
+        }
+        let two = AppState.bountyBanner(for: [makeBounty(1), makeBounty(2)])
+        XCTAssertEqual(two.title, "2 bounties on you")
+        XCTAssertTrue(two.body.contains("Lister1"))
+        XCTAssertTrue(two.body.contains("Lister2"))
+
+        let four = AppState.bountyBanner(for: [makeBounty(1), makeBounty(2), makeBounty(3), makeBounty(4)])
+        XCTAssertEqual(four.title, "4 bounties on you")
+        XCTAssertTrue(four.body.contains("+1 more"))
+    }
+
+    /// The dedup must survive restart: a fresh coordinator on the same defaults must
+    /// suppress the bounty that was already announced before the restart.
+    func testBountyNotificationDedupPersistsAcrossRestart() async throws {
+        appState.apiKey = "valid_key"
+        try mockSession.setSuccessResponse(
+            json: TornAPIFixtures.userV2Response(bounties: [TornAPIFixtures.bountyOnMe(reward: 3_000_000)])
+        )
+
+        appState.fetchData()
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
+        let bounty = try XCTUnwrap(appState.bountiesOnMe.first)
+        let relaunched = NotificationCoordinator(defaults: testDefaults)
+        XCTAssertFalse(
+            relaunched.shouldFireOnce("bounty.\(bounty.id)", epoch: "\(bounty.id)"),
+            "the bounty epoch must survive restart"
+        )
+    }
+
     /// Ranked wars from the dedicated v2 faction endpoint land in `rankedWars`.
     func testFetchData_populatesRankedWars_fromV2Faction() async throws {
         appState.apiKey = "valid_key"


### PR DESCRIPTION
**fix: persist bounty-notification dedup across restarts**

Closes #53

## What

- Replaced the in-memory `notifiedBountyKeys: Set<String>` with the persistent `NotificationCoordinator` epoch store: `shouldFireOnce("bounty.\(bounty.id)", epoch: "\(bounty.id)")`.
- Removed the in-memory set and both reset sites in `AppState.swift`.
- Multiple new bounties now collapse into one summary banner, modeled on `flushPendingPriceAlerts()`.

## Why

The set lived only in memory, so every app launch re-announced every open bounty — five open bounties meant five banners per launch, forever.

## Behavioral note (please confirm)

Persistent dedup changes one edge case relative to the old in-memory set (see ISA.md ISC-18): if a bounty is cleared and later re-listed with the identical composite id (`targetId-reward-listerId-validUntil`), it will **not** re-announce — an epoch never expires by design. This matches the coordinator's existing semantics (test: "the same bounty three weeks later is still the same bounty"). If re-alert on an identical re-listing is desired instead, a staleness window on the bounty epoch would be the follow-up.

## Note on the issue's unbounded-growth caveat

`notifications.epochs.v1` is already capped: `BoundedRecencyStore` (capacity 256) evicts least-recently-touched entries, and a suppressed check still touches the key, so live bounties never age out (existing eviction/survivor tests cover this).

## Tests

- 4 new: single / anonymous / batched banners + `testBountyNotificationDedupPersistsAcrossRestart` (fails on the old code).
- Full suite: 573 passed, 0 failures. `xcodebuild analyze`: SUCCEEDED.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved bounty notifications with clearer titles, previews, lister details, and additional-bounty counts.
  - Added support for anonymous bounty notifications without revealing lister information.
  - Prevented duplicate notifications for the same bounty, including across app state refreshes.

- **Bug Fixes**
  - Resolved inconsistent bounty notification presentation for single and multiple bounties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->